### PR TITLE
fix: preserve full timestamp for free-text date formats

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -2084,7 +2084,11 @@ class TranscriptIndex:
     def _format_chunk_block(self, idx: int) -> str:
         """Format a single chunk as a display block."""
         chunk = self.chunks[idx]
-        raw_ts = chunk.timestamp[:16] if chunk.timestamp else "unknown"
+        raw_ts = chunk.timestamp if chunk.timestamp else "unknown"
+        # For ISO 8601 timestamps, show date + HH:MM (drop seconds/tz).
+        # For free-text timestamps (e.g. "1:56 pm on 8 May, 2023"), keep as-is.
+        if len(raw_ts) > 16 and raw_ts[4:5] == "-" and raw_ts[10:11] == "T":
+            raw_ts = raw_ts[:16]
         ts_display = raw_ts.replace("T", " ")
         turn_label = "journal" if chunk.turn_index == -1 else f"turn {chunk.turn_index}"
         header = f"--- [{ts_display} session {chunk.session_id[:8]}] {turn_label} ---"


### PR DESCRIPTION
## Summary
- Fix timestamp truncation in `_format_chunk_block` that dropped the year from free-text timestamps
- `chunk.timestamp[:16]` assumed ISO 8601 but LOCOMO uses formats like `"1:56 pm on 8 May, 2023"` → truncated to `"1:56 pm on 8 May"` (year lost)
- Now only truncates confirmed ISO 8601 strings (checks for `YYYY-MM-DDTHH:MM` pattern)

## Impact
Temporal questions in LOCOMO benchmark (category 2, n=321) have 110 questions with perfect retrieval recall but wrong answers — many due to missing year in context. This fix restores the year, expected to improve temporal J-score by 2-3pt.

## Test plan
- [ ] Run `python evaluation/locomo_eval.py --recalldb --max-conversations 1` and verify timestamps include year
- [ ] Verify ISO 8601 timestamps still display correctly (e.g. Claude Code sessions)
- [ ] Run full LOCOMO eval to measure temporal J-score improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)