### PR TITLE
Filter non-project paths from journal file lists

### DIFF
--- a/src/synapt/recall/journal.py
+++ b/src/synapt/recall/journal.py
@@ -15,6 +15,46 @@ from pathlib import Path
 
 from synapt.recall.core import project_worktree_dir, project_index_dir, project_transcript_dir
 
+# Paths that are always noise in journal file lists
+_NOISE_PATH_SEGMENTS = ("/.claude/", "/private/tmp/")
+
+
+def _filter_project_files(
+    files: list[str] | set[str],
+    project_root: str = "",
+) -> list[str]:
+    """Filter file paths to only include project-relevant files.
+
+    Removes:
+    - ~/.claude/ internals (plans, tool results, hooks, settings)
+    - /private/tmp/ and /private/var/ temp files
+    - Absolute paths outside the project root (other projects)
+
+    Relative paths are kept as-is (already project-scoped).
+    Absolute paths under project_root are converted to relative.
+    """
+    if not project_root:
+        project_root = str(Path.cwd())
+    # Normalize: ensure trailing slash for prefix matching
+    prefix = project_root.rstrip("/") + "/"
+
+    result: list[str] = []
+    for fp in files:
+        if not fp or not fp.strip():
+            continue
+        # Skip known noise paths
+        if any(seg in fp for seg in _NOISE_PATH_SEGMENTS):
+            continue
+        # Relative paths are already project-scoped
+        if not fp.startswith("/"):
+            result.append(fp)
+            continue
+        # Absolute paths: keep only if under project root
+        if fp.startswith(prefix):
+            result.append(fp[len(prefix):])
+        # else: absolute path outside project — skip
+    return sorted(set(result))
+
 
 def _journal_path(project_dir: Path | None = None) -> Path:
     """Return path to journal.jsonl for this worktree.
@@ -376,10 +416,9 @@ def auto_extract_entry(
                         if not isinstance(block, dict):
                             continue
                         fp = block.get("input", {}).get("file_path", "") if isinstance(block.get("input"), dict) else ""
-                        if fp and "/.claude/" not in fp and not fp.startswith("/private/tmp"):
-                            clean = fp.replace(cwd + "/", "").replace(cwd, "")
-                            files_set.add(clean)
-        files_modified = sorted(files_set)
+                        if fp:
+                            files_set.add(fp)
+        files_modified = _filter_project_files(files_set, project_root=cwd)
 
     return JournalEntry(
         timestamp=now.isoformat(),
@@ -454,11 +493,11 @@ def synthesize_journal_stubs(
                 focus = msg[:200]
                 break
 
-        # Collect all files touched
+        # Collect all files touched, filtering noise paths
         files_set: set[str] = set()
         for c in transcript_chunks:
             files_set.update(c.files_touched)
-        files_modified = sorted(files_set)
+        files_modified = _filter_project_files(files_set)
 
         # Use earliest timestamp
         timestamp = min(

--- a/tests/recall/test_auto_journal.py
+++ b/tests/recall/test_auto_journal.py
@@ -5,7 +5,9 @@ import json
 from unittest.mock import patch, MagicMock
 
 from synapt.recall.core import TranscriptChunk, TranscriptIndex, parse_journal_entries
-from synapt.recall.journal import JournalEntry, append_entry, synthesize_journal_stubs
+from synapt.recall.journal import (
+    JournalEntry, append_entry, synthesize_journal_stubs, _filter_project_files,
+)
 from synapt.recall.enrich import _parse_llm_response, iter_enrichable_entries
 
 
@@ -198,6 +200,76 @@ class TestSynthesizeJournalStubs:
         count = synthesize_journal_stubs(sessions, journal_path)
 
         assert count == 0
+
+
+# ===========================================================================
+# _filter_project_files
+# ===========================================================================
+
+
+class TestFilterProjectFiles:
+
+    def test_keeps_relative_paths(self):
+        files = ["src/main.py", "tests/test_foo.py"]
+        assert _filter_project_files(files) == ["src/main.py", "tests/test_foo.py"]
+
+    def test_filters_claude_internals(self):
+        files = [
+            "src/main.py",
+            "/Users/me/.claude/plans/plan.md",
+            "/Users/me/.claude/projects/foo/tool-results/abc.txt",
+            "/Users/me/.claude/hooks/pre-commit.sh",
+            "/Users/me/.claude/settings.json",
+        ]
+        assert _filter_project_files(files) == ["src/main.py"]
+
+    def test_filters_tmp_paths(self):
+        files = ["src/main.py", "/private/tmp/something.txt"]
+        assert _filter_project_files(files) == ["src/main.py"]
+
+    def test_converts_absolute_project_paths_to_relative(self):
+        files = ["/home/user/project/src/main.py", "/home/user/project/tests/test.py"]
+        result = _filter_project_files(files, project_root="/home/user/project")
+        assert result == ["src/main.py", "tests/test.py"]
+
+    def test_filters_other_project_paths(self):
+        files = [
+            "/home/user/project/src/main.py",
+            "/home/user/other-project/src/lib.py",
+        ]
+        result = _filter_project_files(files, project_root="/home/user/project")
+        assert result == ["src/main.py"]
+
+    def test_deduplicates(self):
+        files = ["a.py", "b.py", "a.py"]
+        assert _filter_project_files(files) == ["a.py", "b.py"]
+
+    def test_empty_and_blank_strings(self):
+        files = ["", "  ", "a.py"]
+        assert _filter_project_files(files) == ["a.py"]
+
+    def test_accepts_set_input(self):
+        files = {"b.py", "a.py"}
+        assert _filter_project_files(files) == ["a.py", "b.py"]
+
+
+class TestSynthesizeFiltersNoisePaths:
+
+    def test_synthesize_filters_claude_paths(self, tmp_path):
+        sessions = {SESSION_A: [
+            _make_chunk(SESSION_A, 0, "Hello", files_touched=[
+                "src/main.py",
+                "/Users/me/.claude/plans/plan.md",
+                "/private/tmp/result.txt",
+            ]),
+        ]}
+        journal_path = tmp_path / "journal.jsonl"
+
+        synthesize_journal_stubs(sessions, journal_path)
+
+        with open(journal_path) as f:
+            entry = json.loads(f.readline())
+        assert entry["files_modified"] == ["src/main.py"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Add `_filter_project_files()` utility that strips `~/.claude/` internals, `/private/tmp/` temp files, and paths outside the project root from journal file lists
- Applied in `auto_extract_entry()` and `synthesize_journal_stubs()` so journal entries only contain relevant project files
- Converts absolute project paths to relative for cleaner output

## Test plan
- [x] 8 unit tests for `_filter_project_files()` covering: relative paths, claude internals, tmp paths, absolute-to-relative conversion, other-project filtering, dedup, empty/blank strings, set input
- [x] 1 integration test verifying `synthesize_journal_stubs` applies filtering
- [x] Full recall test suite passes (1050 passed, 16 skipped)

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)