### PR TITLE
Generalize enrichment prompt for non-code sessions

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -95,17 +95,17 @@ def _build_transcript_summary(session_id: str, project_dir: Path) -> str:
 
 
 ENRICHMENT_PROMPT = """\
-You are summarizing a Claude Code programming session transcript. Extract structured information about what happened.
+You are summarizing a session transcript. Extract structured information about what happened.
 
 Given the following transcript, produce a JSON object with these fields:
-- "focus": A one-sentence description of the session's main goal (max 200 chars)
-- "done": A list of 1-5 concrete accomplishments (each max 100 chars)
-- "decisions": A list of 0-3 key technical decisions made (each max 100 chars)
-- "next_steps": A list of 0-3 items to follow up on (each max 100 chars)
+- "focus": A one-sentence description of the session's main topic or goal (max 200 chars)
+- "done": A list of 1-5 concrete things accomplished, discussed, or learned (each max 100 chars)
+- "decisions": A list of 0-3 key decisions made or preferences stated (each max 100 chars)
+- "next_steps": A list of 0-3 items to follow up on or remember (each max 100 chars)
 
 Rules:
-- Be specific and concrete, not vague
-- Focus on what changed, not what was discussed
+- Be specific and concrete — include names, dates, places, and key details
+- Capture important facts, preferences, and relationship details mentioned
 - If the session was short or trivial, use fewer items
 - Output ONLY valid JSON, no markdown fences, no explanation
 


### PR DESCRIPTION
## Summary
- Updated enrichment prompt to work with any type of conversation, not just coding sessions
- "done" now captures things discussed/learned (not just code changes)
- "decisions" now includes preferences stated
- Rules emphasize capturing names, dates, places, and relationship details

## Context
The enrichment output feeds the consolidation pipeline. When enrichment misses important conversational facts (names, preferences, relationships), the consolidation pipeline can't produce useful knowledge nodes. This is particularly impactful for the LOCOMO benchmark where single-hop and multi-hop recall depend on knowledge nodes.

## Test plan
- [x] All 1071 recall tests pass
- [ ] Verify enrichment quality on sample LOCOMO transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)