### PR TITLE
Add result deduplication and confidence-weighted knowledge boost

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -57,6 +57,15 @@ def atomic_json_write(data: dict | list, path: Path, indent: int = 2) -> None:
         raise
 
 
+# Near-duplicate Jaccard threshold for result deduplication
+_DEDUP_JACCARD_THRESHOLD = 0.6
+
+
+def _dedup_limit(max_chunks: int) -> int:
+    """Extra candidates to pass through formatting to compensate for dedup."""
+    return max_chunks + max(5, max_chunks // 3)
+
+
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
@@ -1279,8 +1288,11 @@ class TranscriptIndex:
         # logits which can be negative and break ratio-based filtering.
         top = self._rerank_candidates(query, top)
 
+        # Pass extra candidates to _format_results to compensate for
+        # near-duplicate filtering — the token budget is the real limiter.
+        dedup_headroom = _dedup_limit(max_chunks)
         return self._format_results(
-            top[:max_chunks], max_tokens,
+            top[:dedup_headroom], max_tokens,
             knowledge_results=knowledge_results,
             query=query,
         )
@@ -1453,7 +1465,8 @@ class TranscriptIndex:
         # Cross-encoder reranking (Phase 2): after threshold (see fts_global)
         top = self._rerank_candidates(query, top)
 
-        return self._format_results(top[:max_chunks], max_tokens, query=query)
+        dedup_headroom = _dedup_limit(max_chunks)
+        return self._format_results(top[:dedup_headroom], max_tokens, query=query)
 
     def _progressive_lookup(
         self,
@@ -1741,7 +1754,14 @@ class TranscriptIndex:
                 token_overlap = len(query_tokens & node_tokens) >= min_matches
                 strong_emb = rowid in emb_rowids
                 if token_overlap or strong_emb:
-                    node["score"] = score_map.get(rowid, 0.0) * knowledge_boost
+                    conf = node.get("confidence", 0.5)
+                    if not isinstance(conf, (int, float)):
+                        conf = 0.5
+                    # Confidence-weighted boost: well-corroborated facts
+                    # (conf=0.9 → 2.8x) rank above single-session
+                    # observations (conf=0.45 → 1.9x).
+                    effective_boost = 1.0 + conf * knowledge_boost
+                    node["score"] = score_map.get(rowid, 0.0) * effective_boost
                     results.append(node)
                     seen_ids.add(node_id)
 
@@ -1953,13 +1973,26 @@ class TranscriptIndex:
         # Sort by score descending (highest relevance first)
         emit_items.sort(key=lambda x: x[0], reverse=True)
 
+        # Deduplication: skip chunks that are near-duplicates of already-
+        # emitted items (Jaccard similarity > 0.6 on token sets). This frees
+        # token budget for diverse results, especially on multi-hop queries.
+        from synapt.recall.clustering import _jaccard
+
+        emitted_token_sets: list[set[str]] = []
+
         emitted_access: list[dict] = []
         for score, block, item_type, item_id in emit_items:
+            block_tokens_set = set(_tokenize(block))
+            if block_tokens_set and emitted_token_sets:
+                if any(_jaccard(block_tokens_set, prev) > _DEDUP_JACCARD_THRESHOLD
+                       for prev in emitted_token_sets):
+                    continue  # Skip near-duplicate
             block_tokens = len(block) // 4
             if token_count + block_tokens > max_tokens and len(lines) > 1:
                 break
             lines.append(block)
             token_count += block_tokens
+            emitted_token_sets.append(block_tokens_set)
             access_entry: dict = {
                 "item_type": item_type,
                 "item_id": item_id,
@@ -2168,8 +2201,8 @@ class TranscriptIndex:
         parts = [header]
         prev = self._get_preceding_turn(chunk)
         if prev and prev.user_text:
-            ctx = prev.user_text[:120]
-            if len(prev.user_text) > 120:
+            ctx = prev.user_text[:200]
+            if len(prev.user_text) > 200:
                 ctx += "..."
             parts.append(f"  (context: User previously asked: {ctx})")
         if chunk.user_text:

--- a/tests/recall/test_core.py
+++ b/tests/recall/test_core.py
@@ -1682,7 +1682,7 @@ def test_format_results_shows_more_user_text():
 
 
 def test_format_results_shows_wider_context_preview():
-    """Context preview shows up to 120 chars, not 80."""
+    """Context preview shows up to 200 chars, not 80."""
     from synapt.recall.core import TranscriptIndex
 
     prev_question = "A" * 100 + " CONTEXT END"
@@ -1739,3 +1739,51 @@ def test_format_results_journal_chunk_uses_readable_date():
     assert "T09:05:30" not in result
     assert "2026-03-04 09:05" in result
     assert "journal" in result
+
+
+def test_format_results_deduplicates_near_identical_chunks():
+    """Near-duplicate chunks are filtered out to save token budget."""
+    from synapt.recall.core import TranscriptIndex
+
+    # Three chunks with nearly identical content — only the first should appear
+    chunks = [
+        TranscriptChunk(
+            id=f"abc:t{i}", session_id="abcdef12-0000-0000-0000-000000000000",
+            timestamp=f"2026-03-05T14:0{i}:00Z", turn_index=i,
+            user_text="How do I deploy the app?",
+            assistant_text=f"To deploy, run deploy.sh then verify. Variant {i}.",
+        )
+        for i in range(3)
+    ]
+    index = TranscriptIndex(chunks)
+    result = index.lookup("deploy app", max_chunks=10, max_tokens=5000)
+
+    # Only 1 of the 3 near-duplicates should appear
+    deploy_count = result.count("To deploy, run deploy.sh")
+    assert deploy_count == 1, f"Expected 1 unique chunk, got {deploy_count}"
+
+
+def test_format_results_keeps_diverse_chunks():
+    """Chunks with different content are all kept despite sharing a query match."""
+    from synapt.recall.core import TranscriptIndex
+
+    chunks = [
+        TranscriptChunk(
+            id="abc:t0", session_id="abcdef12-0000-0000-0000-000000000000",
+            timestamp="2026-03-05T14:00:00Z", turn_index=0,
+            user_text="How do I deploy?",
+            assistant_text="Run deploy.sh with the production flag.",
+        ),
+        TranscriptChunk(
+            id="abc:t1", session_id="abcdef12-0000-0000-0000-000000000000",
+            timestamp="2026-03-05T14:05:00Z", turn_index=1,
+            user_text="What about rollback?",
+            assistant_text="Use rollback.sh to revert to the previous version.",
+        ),
+    ]
+    index = TranscriptIndex(chunks)
+    result = index.lookup("deploy rollback", max_chunks=10, max_tokens=5000)
+
+    # Both diverse chunks should appear
+    assert "deploy.sh" in result
+    assert "rollback.sh" in result


### PR DESCRIPTION
## Summary
- Near-duplicate filtering (Jaccard > 0.6) prevents redundant chunks from wasting token budget — helps multi-hop queries that need evidence across sessions
- Confidence-weighted knowledge boost ranks well-corroborated facts (2.8x) above single-session observations (1.9x) instead of uniform 2.0x
- Dedup headroom passes extra candidates to compensate for filtered items
- Context preview expanded 120→200 chars for better conversation flow

## Test plan
- [x] 2 new tests: `test_format_results_deduplicates_near_identical_chunks`, `test_format_results_keeps_diverse_chunks`
- [x] All 1085 existing tests pass
- [x] /simplify review: reused `clustering._jaccard` and `bm25._tokenize`, extracted constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)