### PR TITLE
Fix consolidation model and add markdown response parser

### DIFF
--- a/src/synapt/recall/_llm_util.py
+++ b/src/synapt/recall/_llm_util.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 
 def parse_llm_json(response: str) -> dict | None:
@@ -12,6 +13,7 @@ def parse_llm_json(response: str) -> dict | None:
     - Clean JSON
     - JSON wrapped in markdown code fences
     - JSON embedded in surrounding text
+    - Markdown-formatted lists (fallback for small models that ignore JSON instructions)
 
     Returns the parsed dict, or None if parsing fails.
     """
@@ -41,4 +43,90 @@ def parse_llm_json(response: str) -> dict | None:
         except json.JSONDecodeError:
             pass
 
+    # Fallback: extract nodes from markdown-formatted lists.
+    # Small models sometimes output numbered lists instead of JSON:
+    #   1. "content here" (category)
+    #      * Category: workflow
+    #      * Confidence: 0.8
+    nodes = _parse_markdown_nodes(response)
+    if nodes:
+        return {"nodes": nodes}
+
     return None
+
+
+def _parse_markdown_nodes(text: str) -> list[dict]:
+    """Extract knowledge nodes from markdown-formatted LLM output.
+
+    Handles patterns like:
+        1. "Train on Alfred, test on Batman" (convention)
+           * Category: convention
+           * Confidence: 0.8
+           * Tags: ["training", "eval"]
+    """
+    nodes = []
+    # Split into numbered items (first element is text before item 1 — skip it)
+    items = re.split(r'\n\s*\d+\.\s+', text)
+    for item in items[1:]:
+        if not item.strip():
+            continue
+        # Extract quoted content
+        content_match = re.search(r'"([^"]+)"', item)
+        if not content_match:
+            # Try unquoted: first line up to parenthetical
+            first_line = item.split('\n')[0].strip()
+            content_match = re.match(r'(.+?)(?:\s*\(|$)', first_line)
+            if not content_match or len(content_match.group(1)) < 5:
+                continue
+            content = content_match.group(1).strip(' "')
+        else:
+            content = content_match.group(1)
+
+        if len(content) < 5:
+            continue
+
+        node: dict = {
+            "action": "create",
+            "existing_id": None,
+            "content": content,
+            "category": "workflow",
+            "confidence": 0.6,
+            "tags": [],
+            "contradiction_note": "",
+        }
+
+        # Extract category
+        cat_match = re.search(
+            r'[Cc]ategory:\s*(\w[\w\s_-]*)', item,
+        )
+        if cat_match:
+            node["category"] = cat_match.group(1).strip().lower()
+
+        # Extract confidence
+        conf_match = re.search(r'[Cc]onfidence:\s*([\d.]+)', item)
+        if conf_match:
+            try:
+                node["confidence"] = min(1.0, max(0.0, float(conf_match.group(1))))
+            except ValueError:
+                pass
+
+        # Extract tags
+        tags_match = re.search(r'[Tt]ags:\s*\[([^\]]*)\]', item)
+        if tags_match:
+            tags_str = tags_match.group(1)
+            node["tags"] = [
+                t.strip().strip('"\'')
+                for t in tags_str.split(",")
+                if t.strip().strip('"\'')
+            ]
+
+        # Extract action (corroborate/contradict)
+        action_match = re.search(
+            r'[Aa]ction:\s*(create|corroborate|contradict)', item,
+        )
+        if action_match:
+            node["action"] = action_match.group(1).lower()
+
+        nodes.append(node)
+
+    return nodes

--- a/src/synapt/recall/_model_router.py
+++ b/src/synapt/recall/_model_router.py
@@ -21,7 +21,7 @@ from enum import Enum
 logger = logging.getLogger(__name__)
 
 # Default models per architecture
-DEFAULT_DECODER_MODEL = "mlx-community/Ministral-3-3B-Instruct-2512-4bit"
+DEFAULT_DECODER_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
 DEFAULT_ENCODER_DECODER_MODEL = "google/flan-t5-base"
 
 # Supported encoder-decoder models with their memory footprints

--- a/tests/recall/test_llm_util.py
+++ b/tests/recall/test_llm_util.py
@@ -1,0 +1,66 @@
+"""Tests for LLM response parsing utilities."""
+
+from synapt.recall._llm_util import parse_llm_json
+
+
+def test_parse_clean_json():
+    result = parse_llm_json('{"nodes": [{"action": "create", "content": "test"}]}')
+    assert result == {"nodes": [{"action": "create", "content": "test"}]}
+
+
+def test_parse_markdown_fenced_json():
+    result = parse_llm_json('```json\n{"nodes": []}\n```')
+    assert result == {"nodes": []}
+
+
+def test_parse_json_with_preamble():
+    result = parse_llm_json('Here is the result:\n{"nodes": []}')
+    assert result == {"nodes": []}
+
+
+def test_parse_markdown_numbered_list():
+    """Small models output markdown lists instead of JSON."""
+    response = (
+        'After analyzing, I found:\n\n'
+        '1. "Always run tests before deploying" (convention)\n'
+        '\t* Category: convention\n'
+        '\t* Confidence: 0.9\n'
+        '\t* Tags: ["testing", "deploy"]\n'
+        '2. "Use Python 3.12 for all projects" (preference)\n'
+        '\t* Category: preference\n'
+        '\t* Confidence: 0.7\n'
+        '\t* Tags: ["python"]\n'
+    )
+    result = parse_llm_json(response)
+    assert result is not None
+    assert len(result["nodes"]) == 2
+    assert result["nodes"][0]["content"] == "Always run tests before deploying"
+    assert result["nodes"][0]["category"] == "convention"
+    assert result["nodes"][0]["confidence"] == 0.9
+    assert result["nodes"][0]["tags"] == ["testing", "deploy"]
+    assert result["nodes"][1]["content"] == "Use Python 3.12 for all projects"
+    assert result["nodes"][1]["category"] == "preference"
+    assert result["nodes"][1]["confidence"] == 0.7
+
+
+def test_parse_markdown_without_metadata():
+    """Numbered list with content but no Category/Confidence fields."""
+    response = (
+        'Knowledge:\n\n'
+        '1. "Database uses PostgreSQL 15"\n'
+        '2. "API rate limit is 100 req/min"\n'
+    )
+    result = parse_llm_json(response)
+    assert result is not None
+    assert len(result["nodes"]) == 2
+    assert result["nodes"][0]["content"] == "Database uses PostgreSQL 15"
+    assert result["nodes"][0]["category"] == "workflow"  # default
+    assert result["nodes"][0]["confidence"] == 0.6  # default
+
+
+def test_parse_empty_response():
+    assert parse_llm_json("") is None
+
+
+def test_parse_gibberish():
+    assert parse_llm_json("no structured output here at all") is None


### PR DESCRIPTION
## Summary
- Switch default decoder model from Ministral-3B (broken tokenizer) to Llama-3.2-3B-Instruct-4bit
- Add markdown fallback parser for LLM responses — small models output numbered lists instead of JSON
- Enables knowledge node generation from non-code conversations (previously 0 nodes created)

## Test plan
- [x] 7 new tests in `test_llm_util.py` covering JSON, markdown fences, numbered lists, edge cases
- [x] All 1080 existing recall tests pass
- [x] Verified knowledge nodes appear in LOCOMO eval retrieval results (72/152 QA pairs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)