### PR TITLE
Add CLI subcommand discovery via entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ synapt-convert = "synapt._models.convert:main"
 # a module with a register(register_fn) callable. Example:
 # modal = "synapt_private.backends"
 
+[project.entry-points."synapt.commands"]
+# Plugins register CLI subcommands here. Each entry point must reference
+# a callable main() function. Example:
+# repair = "synapt_private.repair.cli:cli_main"
+
 [tool.pytest.ini_options]
 addopts = "--benchmark-disable"
 

--- a/src/synapt/cli.py
+++ b/src/synapt/cli.py
@@ -7,22 +7,39 @@ Usage:
     synapt recall setup
 
     synapt server   # starts unified MCP server
+
+Plugins can register additional subcommands via the ``synapt.commands``
+entry-point group (e.g. ``repair``, ``watch``).
 """
 
 from __future__ import annotations
 
+import importlib.metadata
 import sys
 
 
+def _discover_commands() -> dict[str, callable]:
+    """Discover plugin subcommands via ``synapt.commands`` entry points.
+
+    Each entry point should reference a callable ``main()`` function.
+    """
+    commands: dict[str, callable] = {}
+    for ep in importlib.metadata.entry_points(group="synapt.commands"):
+        commands[ep.name] = ep
+    return commands
+
+
 def main():
+    extra_commands = _discover_commands()
+
     if len(sys.argv) < 2:
-        _print_help()
+        _print_help(extra_commands)
         sys.exit(1)
 
     subcmd = sys.argv[1]
 
     if subcmd in ("-h", "--help", "help"):
-        _print_help()
+        _print_help(extra_commands)
         return
 
     if subcmd == "--version":
@@ -42,22 +59,31 @@ def main():
         from synapt.server import main as server_main
 
         server_main()
+    elif subcmd in extra_commands:
+        ep = extra_commands[subcmd]
+        cli_main = ep.load()
+        cli_main()
     else:
         print(f"Unknown command: {subcmd}", file=sys.stderr)
-        print("(Install synapt-repair for repair/watch commands)", file=sys.stderr)
-        _print_help()
+        _print_help(extra_commands)
         sys.exit(1)
 
 
-def _print_help():
-    print("""synapt -- persistent conversational memory for AI coding assistants
-
-Commands:
-  recall    Search and manage past session transcripts
-  server    Start the unified MCP server
-
-Run 'synapt <command> --help' for details on each command.
-""")
+def _print_help(extra_commands: dict | None = None):
+    lines = [
+        "synapt -- persistent conversational memory for AI coding assistants",
+        "",
+        "Commands:",
+        "  recall    Search and manage past session transcripts",
+        "  server    Start the unified MCP server",
+    ]
+    if extra_commands:
+        for name in sorted(extra_commands):
+            lines.append(f"  {name:<9} (from synapt-private)")
+    lines.append("")
+    lines.append("Run 'synapt <command> --help' for details on each command.")
+    lines.append("")
+    print("\n".join(lines))
 
 
 if __name__ == "__main__":

--- a/tests/recall/test_model_router.py
+++ b/tests/recall/test_model_router.py
@@ -144,6 +144,9 @@ class TestBackendRegistry:
         import synapt.recall._model_router as router
 
         sentinel = object()
+        # Isolate from any co-installed plugins (e.g. synapt-private)
+        monkeypatch.setattr(router, "_extra_backends", {})
+        monkeypatch.setattr(router, "_backends_loaded", True)
         register_backend("test-backend", lambda mt: sentinel)
 
         # Disable built-in backends so plugin backend is reached


### PR DESCRIPTION
## Summary
- Public CLI discovers plugin subcommands via `synapt.commands` entry-point group
- When `synapt-private` is installed, `synapt --help` shows `repair` and `watch`
- Fixes `test_register_backend` isolation when `synapt-private` is co-installed

## Test plan
- [x] 1121 passed, 16 skipped, 0 failures
- [x] `synapt --help` shows repair/watch when synapt-private installed
- [x] `synapt repair --help` and `synapt watch --help` work
- [x] Full integration: package resolution, caching, graph shims all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)