### PR TITLE
Add embedding-based inline dedup for knowledge nodes

### DIFF
--- a/src/synapt/recall/consolidate.py
+++ b/src/synapt/recall/consolidate.py
@@ -258,9 +258,9 @@ _INLINE_COSINE_THRESHOLD = 0.80
 
 def _inline_embedding_dedup(
     candidate_content: str,
-    existing_nodes: list,
+    existing_nodes: "list[KnowledgeNode]",
     threshold: float = _INLINE_COSINE_THRESHOLD,
-) -> tuple:
+) -> "tuple[KnowledgeNode | None, float]":
     """Check if candidate is a semantic duplicate of any existing node.
 
     Uses the embedding provider (cached per process) to compute cosine

--- a/tests/recall/test_consolidate.py
+++ b/tests/recall/test_consolidate.py
@@ -682,6 +682,44 @@ class TestGenericFilterInApply(unittest.TestCase):
         finally:
             mod._inline_embedding_dedup = original_fn
 
+    def test_embedding_below_threshold_still_creates(self):
+        """Low cosine similarity should NOT auto-corroborate; node is created normally."""
+        import synapt.recall.consolidate as mod
+
+        existing = KnowledgeNode.create(
+            content="Kotlin Multiplatform projects are linked to Xcode for iOS builds",
+            category="architecture",
+            source_sessions=["s0"],
+        )
+        append_node(existing, self.kn_path)
+
+        original_fn = mod._inline_embedding_dedup
+
+        def mock_emb_dedup(candidate, existing_nodes, threshold=0.80):
+            # Simulate: cosine similarity below threshold
+            if existing_nodes:
+                return (None, 0.60)
+            return (None, 0.0)
+
+        mod._inline_embedding_dedup = mock_emb_dedup
+        try:
+            parsed = {
+                "nodes": [{
+                    "action": "create",
+                    "content": "Gradle builds use the Kotlin DSL for configuration",
+                    "category": "tooling",
+                    "confidence": 0.7,
+                    "tags": [],
+                }]
+            }
+            result = _apply_consolidation_result(
+                parsed, [existing], self.cluster, self.kn_path,
+            )
+            self.assertEqual(result.nodes_created, 1)
+            self.assertEqual(result.nodes_corroborated, 0)
+        finally:
+            mod._inline_embedding_dedup = original_fn
+
     def test_generic_contradict_rejected(self):
         """Contradict with generic replacement content should be rejected."""
         existing = KnowledgeNode.create(


### PR DESCRIPTION
## Summary
- Add embedding cosine similarity (threshold 0.80) as second inline dedup signal during consolidation
- Prevents semantic duplicates that slip through keyword Jaccard (e.g. different wording, same meaning)
- Lower post-consolidation dedup embedding threshold from 0.85 to 0.80 for consistency
- Addresses #1 recall quality feedback: near-identical knowledge nodes consuming result budget

## How it works
During `_apply_consolidation_result`, when a new node is about to be created:
1. Check keyword Jaccard >= 0.5 against existing nodes (existing behavior)
2. If Jaccard doesn't trigger, check embedding cosine >= 0.80 (NEW)
3. Either signal triggers auto-corroborate instead of creating a duplicate

The embedding provider is cached per-process and degrades gracefully if unavailable.

## Test plan
- [x] New test: `test_embedding_auto_corroborate_semantic_duplicate`
- [x] All 1122 tests pass (94 consolidation, 45 knowledge)
- [x] Existing auto-corroborate behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)