### PR TITLE
Show source session IDs on knowledge nodes

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1975,8 +1975,14 @@ class TranscriptIndex:
         else:
             header = f"--- [knowledge] {category} ({conf_label} confidence) ---"
 
-        # Temporal metadata
-        meta_parts = [f"Based on {len(sources)} session(s), last updated {updated}"]
+        # Temporal metadata with source attribution
+        if sources:
+            source_refs = ", ".join(s[:8] for s in sources[-5:])
+            if len(sources) > 5:
+                source_refs += f" +{len(sources) - 5} more"
+            meta_parts = [f"Sources: {source_refs}. Updated {updated}"]
+        else:
+            meta_parts = [f"Last updated {updated}"]
         valid_from = node.get("valid_from")
         valid_until = node.get("valid_until")
         if valid_from and valid_until:


### PR DESCRIPTION
## Summary
- Knowledge nodes now display "Sources: s001c00, s003c00. Updated 2026-03-12" instead of "Based on 2 session(s), last updated 2026-03-12"
- Shows up to 5 most recent session IDs with "+N more" for larger source sets
- Falls back to "Last updated DATE" when no source sessions available

Addresses recall quality feedback item #5 (no source attribution on knowledge nodes).

## Test plan
- [x] All 1157 tests pass (format tests verified)
- [x] Existing `_format_knowledge_block` tests unaffected (use nodes without source_sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)