### PR TITLE
feat: entity-anchored FTS search for multi-hop retrieval

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1245,17 +1245,54 @@ class TranscriptIndex:
 
         fts_results = self._db.fts_search(query, limit=max_chunks * 10)
 
-        # Entity-focused supplementary search: when the query mentions
-        # specific entities (person names, etc.), run a second search for
-        # just entity terms. This catches chunks where entities co-occur
-        # but content words (e.g. "nickname") don't appear in the text.
+        # Entity-anchored supplementary search: when the query mentions
+        # entities, run two additional searches:
+        # 1. Entity AND (content1 OR content2 OR ...) — finds entity
+        #    chunks matching any content keyword. This is the key middle
+        #    ground between strict AND (misses synonym/paraphrase) and
+        #    pure entity search (too broad). Critical for multi-hop
+        #    queries like "When did Caroline go to the LGBTQ support group?"
+        #    where the AND query fails if the chunk uses "queer" instead.
+        # 2. Entity-only search — catches chunks where entities co-occur
+        #    but content words don't appear at all.
         if query_entities:
-            entity_query = " ".join(query_entities)
-            entity_fts = self._db.fts_search(entity_query, limit=max_chunks * 5)
+            from synapt.recall.storage import (
+                _build_entity_anchored_query,
+                _escape_fts_tokens,
+                _FTS_WEIGHTS,
+            )
+            entity_tokens = sorted(query_entities)  # deterministic ordering
+            all_tokens = _escape_fts_tokens(query)
+            content_tokens = [t for t in all_tokens if t.lower().strip('"') not in query_entities]
             seen_rowids = {r for r, _ in fts_results}
+
+            # Tier 2: Entity-anchored OR (entity AND (content1 OR content2 ...))
+            # Discount: 0.95 — slightly below tier 1 (full AND) which has
+            # stronger co-occurrence signal.
+            if content_tokens:
+                anchored_q = _build_entity_anchored_query(entity_tokens, content_tokens)
+                if anchored_q:
+                    try:
+                        anchored_rows = self._db.fts_search_raw(
+                            anchored_q, limit=max_chunks * 8,
+                        )
+                        for rowid, score in anchored_rows:
+                            if rowid not in seen_rowids:
+                                fts_results.append((rowid, score * 0.95))
+                                seen_rowids.add(rowid)
+                    except Exception:
+                        logger.debug(
+                            "Entity-anchored FTS query failed: %s",
+                            anchored_q, exc_info=True,
+                        )
+
+            # Tier 3: Entity-only search (broadest)
+            # Discount: 0.85 — weakest signal, just entity mention.
+            entity_query = " ".join(entity_tokens)
+            entity_fts = self._db.fts_search(entity_query, limit=max_chunks * 5)
             for rowid, score in entity_fts:
                 if rowid not in seen_rowids:
-                    fts_results.append((rowid, score * 0.85))  # Slight discount
+                    fts_results.append((rowid, score * 0.85))
                     seen_rowids.add(rowid)
 
         # Convert rowids to chunk indices, applying date and depth filters

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -285,6 +285,13 @@ END;
 
 _FTS5_KEYWORDS = frozenset({"and", "or", "not", "near"})
 
+
+def _escape_fts_token(tok: str) -> str:
+    """Quote a single FTS5 token if it contains dots or is a keyword."""
+    if "." in tok or tok in _FTS5_KEYWORDS:
+        return f'"{tok}"'
+    return tok
+
 # Common stop words to strip from FTS queries. These are too frequent
 # to be useful in full-text search and cause AND queries to fail when
 # they don't co-occur with content words in the same chunk.
@@ -314,13 +321,7 @@ def _escape_fts_tokens(query: str) -> list[str]:
         t for t in re.sub(r"[^a-zA-Z0-9_.]", " ", query.lower()).split()
         if len(t) > 1 and t not in _FTS_STOP_WORDS
     ]
-    escaped = []
-    for tok in tokens:
-        if "." in tok or tok in _FTS5_KEYWORDS:
-            escaped.append(f'"{tok}"')
-        else:
-            escaped.append(tok)
-    return escaped
+    return [_escape_fts_token(tok) for tok in tokens]
 
 
 def _escape_fts_query(query: str, use_or: bool = False) -> str:
@@ -338,6 +339,26 @@ def _escape_fts_query(query: str, use_or: bool = False) -> str:
         return ""
     joiner = " OR " if use_or else " "
     return joiner.join(tokens)
+
+
+def _build_entity_anchored_query(
+    entity_tokens: list[str],
+    content_tokens: list[str],
+) -> str:
+    """Build an FTS5 query that requires entity terms AND any content term.
+
+    Returns e.g. ``caroline AND (lgbtq OR support OR group)`` which finds
+    chunks mentioning the entity with at least one content keyword.
+    Returns empty string if either list is empty.
+    """
+    if not entity_tokens or not content_tokens:
+        return ""
+    entity_part = " ".join(_escape_fts_token(t) for t in entity_tokens)
+    if len(content_tokens) == 1:
+        content_part = _escape_fts_token(content_tokens[0])
+    else:
+        content_part = "(" + " OR ".join(_escape_fts_token(t) for t in content_tokens) + ")"
+    return f"{entity_part} AND {content_part}"
 
 
 # ---------------------------------------------------------------------------
@@ -774,6 +795,29 @@ class RecallDB:
                 (fts_or, limit),
             ).fetchall()
 
+        return [(r[0], r[1]) for r in rows]
+
+    def fts_search_raw(
+        self,
+        fts_query: str,
+        limit: int = 100,
+    ) -> list[tuple[int, float]]:
+        """Execute a pre-built FTS5 query (no escaping/tokenization).
+
+        Used for custom query syntax like entity-anchored OR queries.
+        Returns list of (rowid, score) tuples sorted by relevance.
+        """
+        if not fts_query:
+            return []
+        rows = self._conn.execute(
+            f"SELECT chunks_fts.rowid, "
+            f"  -bm25(chunks_fts, {_FTS_WEIGHTS}) AS score "
+            f"FROM chunks_fts "
+            f"WHERE chunks_fts MATCH ? "
+            f"ORDER BY score DESC "
+            f"LIMIT ?",
+            (fts_query, limit),
+        ).fetchall()
         return [(r[0], r[1]) for r in rows]
 
     def fts_search_by_session(

--- a/tests/recall/test_storage.py
+++ b/tests/recall/test_storage.py
@@ -479,6 +479,83 @@ class TestFTSEscaping:
         assert "go" not in tokens
 
 
+class TestEntityAnchoredQuery:
+    """Tests for _build_entity_anchored_query (multi-hop retrieval)."""
+
+    def test_basic_entity_anchored(self):
+        from synapt.recall.storage import _build_entity_anchored_query
+        result = _build_entity_anchored_query(
+            ["caroline"], ["lgbtq", "support", "group"],
+        )
+        assert result == "caroline AND (lgbtq OR support OR group)"
+
+    def test_single_content_token(self):
+        from synapt.recall.storage import _build_entity_anchored_query
+        result = _build_entity_anchored_query(["caroline"], ["lgbtq"])
+        assert result == "caroline AND lgbtq"
+
+    def test_empty_entity(self):
+        from synapt.recall.storage import _build_entity_anchored_query
+        assert _build_entity_anchored_query([], ["lgbtq"]) == ""
+
+    def test_empty_content(self):
+        from synapt.recall.storage import _build_entity_anchored_query
+        assert _build_entity_anchored_query(["caroline"], []) == ""
+
+    def test_multiple_entities(self):
+        from synapt.recall.storage import _build_entity_anchored_query
+        result = _build_entity_anchored_query(["john", "smith"], ["drums"])
+        assert result == "john smith AND drums"
+
+    def test_dot_token_quoted(self):
+        from synapt.recall.storage import _build_entity_anchored_query
+        result = _build_entity_anchored_query(["fix"], ["api_index.py"])
+        assert '"api_index.py"' in result
+
+    def test_entity_anchored_finds_partial_match(self, db):
+        """Entity-anchored query finds chunks with entity + any content term."""
+        chunks = [
+            TranscriptChunk(
+                id="s1:t0", session_id="s1", timestamp="2026-03-01T10:00:00Z",
+                turn_index=0,
+                user_text="Caroline went to the queer support group meeting.",
+                assistant_text="Good for her.",
+                tools_used=[], files_touched=[],
+            ),
+            TranscriptChunk(
+                id="s1:t1", session_id="s1", timestamp="2026-03-01T10:05:00Z",
+                turn_index=1,
+                user_text="John likes pizza",
+                assistant_text="Cool.",
+                tools_used=[], files_touched=[],
+            ),
+        ]
+        db.save_chunks(chunks)
+
+        from synapt.recall.storage import _build_entity_anchored_query, _FTS_WEIGHTS
+
+        # AND query "caroline lgbtq support group" would fail because
+        # "lgbtq" isn't in the chunk. Entity-anchored should work:
+        # caroline AND (lgbtq OR support OR group) → matches "support" + "group"
+        q = _build_entity_anchored_query(
+            ["caroline"], ["lgbtq", "support", "group"],
+        )
+        rows = db._conn.execute(
+            f"SELECT chunks_fts.rowid, -bm25(chunks_fts, {_FTS_WEIGHTS}) AS score "
+            f"FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY score DESC LIMIT 10",
+            (q,),
+        ).fetchall()
+        assert len(rows) >= 1, "Entity-anchored query should find partial match"
+        # The matching chunk should be about Caroline (not John)
+        matched_rowids = {r[0] for r in rows}
+        # Verify via content
+        for rowid in matched_rowids:
+            row = db._conn.execute(
+                "SELECT user_text FROM chunks WHERE rowid = ?", (rowid,)
+            ).fetchone()
+            assert "caroline" in row[0].lower() or "support" in row[0].lower()
+
+
 class TestFTSOrFallback:
     """Tests for the OR-fallback behavior when AND returns no results."""
 


### PR DESCRIPTION
## Summary

- Add entity-anchored FTS search as a middle tier between strict AND and broad entity-only OR queries
- Extract shared `_escape_fts_token()` helper to eliminate DRY violation  
- Add `fts_search_raw()` to RecallDB for custom FTS5 query syntax
- Add debug logging for entity-anchored query failures (not silent swallow)

### Three-tier FTS cascade for entity queries

1. **Full AND** (existing) — all terms must co-occur in one chunk
2. **Entity-anchored OR** (new) — entity required + any content term: `caroline AND (lgbtq OR support OR group)`
3. **Entity-only** (existing) — broadest, just entity mention

### Why

Multi-hop Recall@20 is 43.23% (primary bottleneck at v0.5.0). The most common failure: AND query fails because the evidence chunk uses different words than the query (e.g., "queer" vs "LGBTQ"). Entity-anchored search finds chunks mentioning the entity with at least one content keyword — more selective than OR, more permissive than AND.

72.6% of LOCOMO multi-hop questions are entity+action temporal queries ("When did X do Y?"), which is exactly what entity-anchored search targets.

## Test plan

- [x] Unit tests for `_build_entity_anchored_query` (7 tests including FTS5 integration)
- [x] All existing tests pass (1147 passed, 16 skipped)
- [ ] LOCOMO eval with entity-anchored search (next eval run after current v0.5.0 10-conv completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)