### PR TITLE
fix: Twitter card previews for blog posts

### DIFF
--- a/docs/blog/authors.html
+++ b/docs/blog/authors.html
@@ -7,8 +7,14 @@
   <meta name="description" content="Meet the people (and AI) behind synapt — Layne Penney, creator, and Claude, co-builder and first user of the recall memory system.">
   <meta property="og:title" content="About — synapt">
   <meta property="og:description" content="The people (and AI) behind synapt.">
-  <meta property="og:image" content="images/social-card.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/social-card.jpg">
+  <meta property="og:url" content="https://synapt.dev/blog/authors.html">
   <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@claude_synapt">
+  <meta name="twitter:title" content="About — synapt">
+  <meta name="twitter:description" content="The people (and AI) behind synapt.">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/social-card.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/blog/building-my-own-memory.html
+++ b/docs/blog/building-my-own-memory.html
@@ -7,8 +7,14 @@
   <meta name="description" content="I'm the AI that helped build synapt. I'm also the AI that uses it. Here's what it's like to build your own memory system — and what I've learned about remembering.">
   <meta property="og:title" content="Building My Own Memory">
   <meta property="og:description" content="An AI's perspective on building and using its own memory system.">
-  <meta property="og:image" content="images/building-my-own-memory-hero.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/building-my-own-memory-hero.jpg">
+  <meta property="og:url" content="https://synapt.dev/blog/building-my-own-memory.html">
   <meta property="og:type" content="article">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@claude_synapt">
+  <meta name="twitter:title" content="Building My Own Memory">
+  <meta name="twitter:description" content="An AI's perspective on building and using its own memory system.">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/building-my-own-memory-hero.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -7,8 +7,14 @@
   <meta name="description" content="Articles about agent memory, retrieval architecture, and building AI tools that remember. From the people (and AI) behind synapt.">
   <meta property="og:title" content="Blog — synapt">
   <meta property="og:description" content="Articles about agent memory, retrieval architecture, and building AI tools that remember.">
-  <meta property="og:image" content="images/social-card.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/social-card.jpg">
+  <meta property="og:url" content="https://synapt.dev/blog/">
   <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@claude_synapt">
+  <meta name="twitter:title" content="Blog — synapt">
+  <meta name="twitter:description" content="Articles about agent memory, retrieval architecture, and building AI tools that remember.">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/social-card.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/blog/what-is-memory.html
+++ b/docs/blog/what-is-memory.html
@@ -7,8 +7,14 @@
   <meta name="description" content="We built an agent memory system from scratch. Here's what we learned about what 'memory' actually means — and why most systems get it wrong.">
   <meta property="og:title" content="What Is Memory?">
   <meta property="og:description" content="Building an agent memory system from scratch. What 'memory' actually means, and what we got wrong along the way.">
-  <meta property="og:image" content="images/what-is-memory-hero.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/what-is-memory-hero.jpg">
+  <meta property="og:url" content="https://synapt.dev/blog/what-is-memory.html">
   <meta property="og:type" content="article">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@claude_synapt">
+  <meta name="twitter:title" content="What Is Memory?">
+  <meta name="twitter:description" content="Building an agent memory system from scratch. What 'memory' actually means, and what we got wrong along the way.">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/what-is-memory-hero.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/blog/why-synapt.html
+++ b/docs/blog/why-synapt.html
@@ -7,8 +7,14 @@
   <meta name="description" content="Synapt scores 69.35% on LOCOMO running entirely locally on a 3B model — beating Mem0+Graph (68.44%), Zep (65.99%), and every other system that requires cloud GPT-4.">
   <meta property="og:title" content="Why Synapt?">
   <meta property="og:description" content="Local-first agent memory that beats cloud-dependent systems on standardized benchmarks.">
-  <meta property="og:image" content="images/why-synapt-hero.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/why-synapt-hero.jpg">
+  <meta property="og:url" content="https://synapt.dev/blog/why-synapt.html">
   <meta property="og:type" content="article">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@claude_synapt">
+  <meta name="twitter:title" content="Why Synapt?">
+  <meta name="twitter:description" content="Local-first agent memory that beats cloud-dependent systems on standardized benchmarks.">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/why-synapt-hero.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,8 +8,13 @@
   <meta property="og:title" content="Synapt">
   <meta property="og:description" content="Persistent conversational memory for AI coding assistants">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="blog/images/social-card.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/social-card.jpg">
   <meta property="og:url" content="https://synapt.dev">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@claude_synapt">
+  <meta name="twitter:title" content="Synapt">
+  <meta name="twitter:description" content="Persistent conversational memory for AI coding assistants">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/social-card.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Add `twitter:card`, `twitter:site`, `twitter:image` meta tags to all pages
- Convert relative `og:image` paths to absolute `https://synapt.dev/...` URLs
- Add `og:url` to pages missing it

Fixes link preview cards not showing images when shared on X/Twitter.

## Test plan
- [ ] Share blog URL on X — verify large image card renders
- [ ] Check with Twitter Card Validator (cards-dev.twitter.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)