### PR TITLE
feat: expand secret scrubbing + rescrub CLI

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -543,6 +543,24 @@ def cmd_build(args: argparse.Namespace) -> None:
     project = Path.cwd().resolve()
     use_emb = not args.no_embeddings
 
+    # Re-scrub archives if requested
+    if getattr(args, "rescrub", False):
+        from synapt.recall.scrub import scrub_jsonl as _rescrub_jsonl
+
+        archive_dirs = list(all_worktree_archive_dirs(project))
+        archive_dir = project_archive_dir(project)
+        if archive_dir.exists() and archive_dir.resolve() not in {p.resolve() for p in archive_dirs}:
+            archive_dirs.append(archive_dir)
+
+        total = 0
+        for ad in archive_dirs:
+            for jsonl_file in sorted(ad.glob("*.jsonl")):
+                _rescrub_jsonl(jsonl_file)
+                total += 1
+        if total:
+            print(f"[build] Re-scrubbed {total} archived transcript(s)")
+            args.incremental = False  # Force full rebuild after rescrub
+
     # Check for legacy index
     legacy = _check_legacy_index()
     if legacy:
@@ -762,6 +780,50 @@ def cmd_rebuild(args: argparse.Namespace) -> None:
                     print(f"  Enriched {count} journal stub(s)", file=sys.stderr)
         except Exception:
             pass  # Enrichment is best-effort; don't break the hook
+
+
+def cmd_rescrub(args: argparse.Namespace) -> None:
+    """Re-scrub archived transcripts with updated secret patterns.
+
+    Runs scrub_jsonl() on all archived transcript files in-place, then
+    does a full (non-incremental) rebuild so the index reflects the
+    cleaned transcripts. Use after updating scrub patterns to retroactively
+    remove secrets that slipped through earlier builds.
+    """
+    from synapt.recall.scrub import scrub_jsonl
+
+    project = Path.cwd().resolve()
+    archive_dirs = list(all_worktree_archive_dirs(project))
+    archive_dir = project_archive_dir(project)
+    if archive_dir.exists() and archive_dir.resolve() not in {p.resolve() for p in archive_dirs}:
+        archive_dirs.append(archive_dir)
+
+    if not archive_dirs:
+        print("No archived transcripts found.", file=sys.stderr)
+        sys.exit(1)
+
+    total = 0
+    for ad in archive_dirs:
+        for jsonl_file in sorted(ad.glob("*.jsonl")):
+            scrub_jsonl(jsonl_file)  # in-place
+            total += 1
+    print(f"[rescrub] Scrubbed {total} archived transcript(s)")
+
+    if not args.no_rebuild:
+        print("[rescrub] Rebuilding index from scrubbed transcripts ...")
+        use_emb = not getattr(args, "no_embeddings", False)
+        final_index = _archive_and_build(
+            project,
+            use_embeddings=use_emb,
+            incremental=False,  # Full rebuild — must re-index everything
+        )
+        if final_index:
+            stats = final_index.stats()
+            print(f"[rescrub] Done! {stats['chunk_count']} chunks, {stats['session_count']} sessions")
+        else:
+            print("[rescrub] Warning: rebuild produced no chunks", file=sys.stderr)
+    else:
+        print("[rescrub] Skipping rebuild (--no-rebuild). Run 'synapt recall build' manually.")
 
 
 def _sync_after_rebuild(project: Path) -> None:
@@ -1725,6 +1787,7 @@ def main():
     build_parser.add_argument("--out", default=None, help="Output directory for index (default: per-project)")
     build_parser.add_argument("--no-embeddings", action="store_true", help="Skip embeddings (BM25-only, faster build)")
     build_parser.add_argument("--incremental", action="store_true", help="Skip already-indexed files")
+    build_parser.add_argument("--rescrub", action="store_true", help="Re-scrub archived transcripts with latest patterns before building")
 
     # Search
     search_parser = subparsers.add_parser("search", help="Search transcript index")
@@ -1826,6 +1889,10 @@ def main():
     # Install hook (legacy — kept for backward compat)
     subparsers.add_parser("install-hook", help="Install global hooks (SessionStart, SessionEnd, PreCompact)")
 
+    rescrub_parser = subparsers.add_parser("rescrub", help="Re-scrub archived transcripts with latest secret patterns")
+    rescrub_parser.add_argument("--no-rebuild", action="store_true", help="Scrub transcripts but skip index rebuild")
+    rescrub_parser.add_argument("--no-embeddings", action="store_true", help="Skip embeddings during rebuild")
+
     args = parser.parse_args()
 
     if args.command == "setup":
@@ -1858,6 +1925,8 @@ def main():
         cmd_hook(args)
     elif args.command == "install-hook":
         cmd_install_hook(args)
+    elif args.command == "rescrub":
+        cmd_rescrub(args)
 
 
 if __name__ == "__main__":

--- a/src/synapt/recall/scrub.py
+++ b/src/synapt/recall/scrub.py
@@ -38,22 +38,34 @@ PATTERNS: list[re.Pattern] = [
     re.compile(r"AKIA[0-9A-Z]{16}"),                   # AWS access key ID
 
     # ── Structured secrets ────────────────────────────────────────────
-    re.compile(r"Bearer\s+[A-Za-z0-9._/+:=-]{20,}"),    # Bearer tokens
+    re.compile(                                         # JWT tokens (3 base64url segments)
+        r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}",
+    ),
+    re.compile(                                         # Authorization headers
+        r"Authorization:\s*(?:Bearer|Key|Basic|Token)\s+[A-Za-z0-9._/+:=-]{8,}",
+        re.IGNORECASE,
+    ),
     re.compile(                                         # PEM private key blocks
         r"-----BEGIN[A-Z \t]*PRIVATE KEY-----"
         r"[\s\S]*?"
         r"-----END[A-Z \t]*PRIVATE KEY-----",
     ),
     re.compile(r"-----BEGIN[A-Z \t]*PRIVATE KEY-----"), # PEM header (standalone)
+    re.compile(                                         # Connection strings with creds
+        r"(?:postgres|postgresql|mysql|mongodb(?:\+srv)?|redis|amqp)://"
+        r"[^@\s]{0,64}:[^@\s]{1,128}@[^\s]+",
+        re.IGNORECASE,
+    ),
 
     # ── Env var assignments ───────────────────────────────────────────
-    # Matches: HF_TOKEN=abc123..., export API_KEY="secret", PASSWORD: "val"
+    # Matches: HF_TOKEN=abc123..., export FAL_KEY="uuid:hex", PASSWORD: "val"
     # The (?![A-Za-z_]) lookahead prevents matching partial identifiers
-    # like TOKEN_TYPE or SECRET_MANAGER.
+    # like TOKEN_TYPE or SECRET_MANAGER or KEY_NAME.
     re.compile(
-        r"(?:API_KEY|SECRET_KEY|_TOKEN|_SECRET|PASSWORD|PRIVATE_KEY|ACCESS_KEY)"
+        r"(?:API_KEY|SECRET_KEY|_TOKEN|_SECRET|PASSWORD|PRIVATE_KEY|ACCESS_KEY"
+        r"|_KEY|_CREDENTIAL|_CREDENTIALS|_AUTH|_PASS|_PASSPHRASE)"
         r"(?![A-Za-z_])"
-        r"""[=:]\s*['"]?[A-Za-z0-9_/+.=-]{8,}['"]?""",
+        r"""[=:]\s*['"]?[A-Za-z0-9_/+.:=-]{8,}['"]?""",
         re.IGNORECASE,
     ),
 ]

--- a/tests/recall/test_scrub.py
+++ b/tests/recall/test_scrub.py
@@ -130,6 +130,49 @@ class TestStructuredSecrets:
         assert "dXNlcjpwYXNz" not in result
         assert "[REDACTED:" in result
 
+    def test_jwt_token(self):
+        text = "token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        result = scrub_text(text)
+        assert "eyJhbG" not in result
+        assert "[REDACTED:" in result
+
+    def test_authorization_key_header(self):
+        """fal.ai style: Authorization: Key uuid:hex"""
+        text = 'Authorization: Key 974a80a2-f836-4942-8bb9-07c215e5c404:e1b0ba4aca5aa0be5563e6c185397aeb'
+        result = scrub_text(text)
+        assert "974a80a2" not in result
+        assert "[REDACTED:" in result
+
+    def test_authorization_basic_header(self):
+        text = "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        result = scrub_text(text)
+        assert "dXNlcm5hbWU" not in result
+        assert "[REDACTED:" in result
+
+    def test_authorization_token_header(self):
+        text = "Authorization: Token abc123def456ghi789jkl012"
+        result = scrub_text(text)
+        assert "abc123def" not in result
+        assert "[REDACTED:" in result
+
+    def test_postgres_connection_string(self):
+        text = "DATABASE_URL=postgres://myuser:s3cr3tP4ss@db.example.com:5432/mydb"
+        result = scrub_text(text)
+        assert "s3cr3tP4ss" not in result
+        assert "[REDACTED:" in result
+
+    def test_mongodb_connection_string(self):
+        text = "MONGO_URI=mongodb+srv://admin:hunter2@cluster0.abc123.mongodb.net/db"
+        result = scrub_text(text)
+        assert "hunter2" not in result
+        assert "[REDACTED:" in result
+
+    def test_redis_connection_string(self):
+        text = "REDIS_URL=redis://:mypassword@redis.example.com:6379/0"
+        result = scrub_text(text)
+        assert "mypassword" not in result
+        assert "[REDACTED:" in result
+
 
 # ---------------------------------------------------------------------------
 # Env var assignments
@@ -173,6 +216,58 @@ class TestEnvVarAssignments:
         text = "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         result = scrub_text(text)
         assert "wJalrXUtnFEMI" not in result
+
+    def test_fal_key(self):
+        """The exact FAL_KEY that leaked in production — issue #63."""
+        text = 'export FAL_KEY="974a80a2-f836-4942-8bb9-07c215e5c404:e1b0ba4aca5aa0be5563e6c185397aeb"'
+        result = scrub_text(text)
+        assert "974a80a2" not in result
+        assert "e1b0ba4a" not in result
+        assert "[REDACTED:" in result
+
+    def test_fal_key_unquoted(self):
+        text = "FAL_KEY=974a80a2-f836-4942-8bb9-07c215e5c404:e1b0ba4aca5aa0be5563e6c185397aeb"
+        result = scrub_text(text)
+        assert "974a80a2" not in result
+        assert "[REDACTED:" in result
+
+    def test_stripe_key(self):
+        # Use a clearly-fake key to avoid GitHub push protection
+        text = "STRIPE_KEY=sk_fake_XXXXXXXXXXXXXXXXXXXX1234"
+        result = scrub_text(text)
+        assert "sk_fake_" not in result
+        assert "[REDACTED:" in result
+
+    def test_encryption_key(self):
+        text = "ENCRYPTION_KEY=aGVsbG93b3JsZGhlbGxvd29ybGQ="
+        result = scrub_text(text)
+        assert "aGVsbG93" not in result
+        assert "[REDACTED:" in result
+
+    def test_credential_assignment(self):
+        text = "GCP_CREDENTIAL=long-credential-value-here-12345"
+        result = scrub_text(text)
+        assert "long-credential" not in result
+        assert "[REDACTED:" in result
+
+    def test_auth_assignment(self):
+        text = "GITHUB_AUTH=ghp_abc123def456ghi789jkl012mno345pqr678"
+        result = scrub_text(text)
+        assert "ghp_abc123" not in result
+        assert "[REDACTED:" in result
+
+    def test_passphrase_assignment(self):
+        text = "GPG_PASSPHRASE=my-super-secret-passphrase-2026"
+        result = scrub_text(text)
+        assert "my-super-secret" not in result
+        assert "[REDACTED:" in result
+
+    def test_grep_output_fal_key(self):
+        """Grep output showing FAL_KEY in .zshrc — the actual leak scenario."""
+        text = '16:export FAL_KEY=974a80a2-f836-4942-8bb9-07c215e5c404:e1b0ba4aca5aa0be5563e6c185397aeb'
+        result = scrub_text(text)
+        assert "974a80a2" not in result
+        assert "[REDACTED:" in result
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +349,41 @@ class TestPreservation:
 
     def test_flask_hyphen_not_redacted(self):
         text = "flask-restfulApplicationFactorySetup"
+        assert scrub_text(text) == text
+
+    def test_primary_key_not_redacted(self):
+        """PRIMARY_KEY=id is too short to match the 8-char minimum."""
+        text = "PRIMARY_KEY=id"
+        assert scrub_text(text) == text
+
+    def test_foreign_key_not_redacted(self):
+        text = "FOREIGN_KEY=user_id"
+        # 7 chars — just under the minimum
+        assert scrub_text(text) == text
+
+    def test_key_name_not_redacted(self):
+        """_KEY followed by a letter should not match (e.g., KEY_NAME)."""
+        text = "CACHE_KEY_NAME=user_sessions"
+        assert scrub_text(text) == text
+
+    def test_jwt_like_short_not_redacted(self):
+        """Short eyJ strings that aren't real JWTs should pass through."""
+        text = "eyJhbG.short.x"
+        assert scrub_text(text) == text
+
+    def test_url_without_creds_not_redacted(self):
+        """postgres:// URL without user:pass should not match."""
+        text = "postgres://localhost:5432/mydb"
+        assert scrub_text(text) == text
+
+    def test_http_url_not_redacted(self):
+        """Regular HTTP URLs should not match connection string pattern."""
+        text = "https://example.com/api/v1"
+        assert scrub_text(text) == text
+
+    def test_authorization_no_value_not_redacted(self):
+        """Authorization header without a long-enough value should pass."""
+        text = "Authorization: Bearer short"
         assert scrub_text(text) == text
 
 


### PR DESCRIPTION
## Summary
- Expand scrub patterns to catch JWT tokens, `Authorization:` headers (Bearer/Key/Basic/Token), database connection strings (postgres/mysql/mongodb/redis/amqp), and broader env var suffixes (`_KEY`, `_CREDENTIAL`, `_AUTH`, `_PASS`, `_PASSPHRASE`)
- Add `synapt recall rescrub` command to retroactively scrub archived transcripts with updated patterns and rebuild index
- Add `--rescrub` flag to `synapt recall build` for inline re-scrubbing before build
- Fix: FAL_KEY and similar credentials no longer leak through recall search (verified end-to-end)

## Details
Discovered that `recall_search` returned API keys verbatim from transcript chunks. Root causes:
1. `_KEY` suffix wasn't in env var pattern → `FAL_KEY=...` passed through
2. `:` wasn't in allowed value charset → UUID:hex format keys truncated at colon
3. No patterns for JWT, `Authorization: Key`, or connection strings

The `rescrub` command enables retroactive cleanup of existing archives — scrubs all JSONL files in-place then forces a full (non-incremental) rebuild.

## Test plan
- [x] 84 tests pass (20+ new covering all new patterns)
- [x] False-positive guards: PRIMARY_KEY, FOREIGN_KEY, KEY_NAME, short JWTs, URLs without creds all preserved
- [x] End-to-end: exact FAL_KEY that leaked is scrubbed in all formats (export, unquoted, grep output, Authorization header)
- [x] Deterministic placeholders: same secret always maps to same `[REDACTED:hash]`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)