### PR TITLE
fix: disable attestations in PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -17,3 +19,5 @@ jobs:
       - run: pip install build
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false


### PR DESCRIPTION
## Summary
- Disables Sigstore attestation upload in the publish workflow
- `pypa/gh-action-pypi-publish@release/v1` updated between v0.6.0 and v0.6.1 releases to generate attestations by default, causing a `400 Bad Request` from PyPI on upload
- Adds `attestations: write` and `contents: read` permissions for future enablement

## Context
v0.6.1 tag was pushed but PyPI upload failed. After merging this fix, we'll delete and re-push the tag to re-trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)