### PR TITLE
fix: add verbose PyPI upload logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,3 +21,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           attestations: false
+          verbose: true


### PR DESCRIPTION
## Summary
- Adds `verbose: true` to the PyPI publish action to get the actual error body from PyPI's 400 response
- The `attestations: false` fix from #68 didn't resolve the issue — the 400 is from something else

## Context
Need the verbose output to diagnose what PyPI is rejecting. Will delete the tag and re-push after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)