### PR TITLE
fix: replace invalid PyPI classifier

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,3 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           attestations: false
-          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Text Processing :: Linguistic",
-    "Topic :: Information Retrieval",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
## Summary
- Replace invalid trove classifier `Topic :: Information Retrieval` with `Topic :: Software Development :: Libraries :: Python Modules`
- Remove verbose logging from publish workflow (was added temporarily for diagnostics)

## Context
PyPI rejects uploads with invalid classifiers. The verbose output from run #69 revealed:
> `400 'Topic :: Information Retrieval' is not a valid classifier`

This was the root cause of the v0.6.1 publish failure — not attestations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)