### PR TITLE
docs: update website benchmarks with 8B results, Memobase, CodeMemo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -499,14 +499,32 @@
 <span class="dim">          |</span> <span class="hl">Reciprocal Rank</span>  <span class="dim">|               |</span>
 <span class="dim">          |</span> <span class="hl">Fusion (k=60)</span>    <span class="dim">|               |</span>
 <span class="dim">          +------------------+               |</span>
-<span class="dim">                    \                        /</span>
+<span class="dim">                    |                        |</span>
+<span class="dim">          +------------------+               |</span>
+<span class="dim">          |</span> <span class="hl">cross-encoder</span>    <span class="dim">|               |</span>
+<span class="dim">          |</span> <span class="hl">rerank (top 20)</span>  <span class="dim">|               |</span>
+<span class="dim">          +------------------+               |</span>
+<span class="dim">                    |                        /</span>
+<span class="dim">          +------------------+              /</span>
+<span class="dim">          |</span> <span class="hl">cross-session</span>    <span class="dim">|             /</span>
+<span class="dim">          |</span> <span class="hl">link expansion</span>   <span class="dim">|            /</span>
+<span class="dim">          +------------------+           /</span>
+<span class="dim">                    \                   /</span>
 <span class="dim">                 +---------------------------+</span>
 <span class="dim">                 |</span> <span class="hl2">interleave + dedup + boost</span>  <span class="dim">|</span>
+<span class="dim">                 |</span> <span class="hl2">+ adaptive per-session cap</span>  <span class="dim">|</span>
 <span class="dim">                 +---------------------------+</span>
 <span class="dim">                              |</span>
 <span class="dim">                    +-----------------+</span>
 <span class="dim">                    |</span> <span class="hl">ranked context</span>   <span class="dim">|</span>
 <span class="dim">                    +-----------------+</span></div>
+      <h3>v0.6.2 pipeline features</h3>
+      <ul>
+        <li>Sub-chunk splitting at tool-use boundaries</li>
+        <li>Cross-session link expansion via pre-computed cosine neighbors</li>
+        <li>Adaptive proportional per-session cap</li>
+        <li>Content-aware adaptive filtering (code/personal/mixed)</li>
+      </ul>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- **LOCOMO table**: Added synapt v0.6.1 8B cloud row (76.04% overall, #1), kept 3B local (73.38%), added Memobase (75.78%), reordered by overall score
- **CodeMemo section**: New coding memory benchmark table — synapt v0.6.2 at 90.51% vs Mem0 at 76.0% (+14.51pp)
- **Footnote**: Updated to highlight #1 LOCOMO ranking and CodeMemo lead over Mem0

## Test plan
- [ ] Open `docs/index.html` locally and verify LOCOMO table renders correctly with 9 rows
- [ ] Verify CodeMemo table appears below the radar chart with 2 rows and 7 data columns
- [ ] Verify `class="best"` highlights appear in correct cells for each column
- [ ] Check mobile responsiveness of both tables

Generated with [Claude Code](https://claude.com/claude-code)