### PR TITLE
fix: deterministic judge scoring with seed=42

### DIFF
--- a/evaluation/codememo/eval.py
+++ b/evaluation/codememo/eval.py
@@ -454,6 +454,7 @@ def _api_call_with_retry(client, messages, max_tokens=100, retries=10, model="gp
                     messages=messages,
                     temperature=0.0,
                     max_tokens=max_tokens,
+                    seed=42,
                 )
                 return response.choices[0].message.content.strip()
         except Exception as e:


### PR DESCRIPTION
## Summary
- Add `seed=42` to all OpenAI API calls in both CodeMemo and LOCOMO eval
- Eliminates LLM judge variance between runs

## Context
Ablation analysis (v4, ref=73de4ec) showed that **~85% of question flips between configs are judge noise**, not feature effects. Same retrieval recall, same context, near-identical generated answers — but the binary judge scores differently.

Evidence from cm_full vs cm_-boosts:
- 6 questions where boosts "hurt" → only 1 had a real retrieval regression (recall 1.0→0.5)
- 5 of 6 had identical retrieval recall and near-identical answers

Evidence from cm_full vs cm_-intent:
- 9 questions where intent "hurt" → only 1 real retrieval failure, 1 context reduction
- 7 of 9 were pure judge variance

With `seed=42`, same prompt = same output, making ablation results directly comparable across configs without needing multiple runs to average out judge noise.

## Test plan
- [x] Verified both eval scripts compile
- [ ] Re-run ablation with seed to confirm reduced variance

🤖 Generated with [Claude Code](https://claude.com/claude-code)