### PR TITLE
fix: linked griptrees share parent .synapt/

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3466,7 +3466,11 @@ def _resolve_griptree_parent(griptree_path: Path) -> Path | None:
     then walks up from there to find the gripspace root.
     """
     # Find any sub-repo with a .git file (linked worktree pointer)
-    for child in griptree_path.iterdir():
+    try:
+        children = list(griptree_path.iterdir())
+    except OSError:
+        return None
+    for child in children:
         git_path = child / ".git"
         if git_path.is_file():
             # .git file contains: "gitdir: /path/to/main/.git/worktrees/<name>/"

--- a/tests/recall/test_gripspace.py
+++ b/tests/recall/test_gripspace.py
@@ -121,6 +121,20 @@ class TestFindGripspaceRoot:
         result = project_data_dir(griptree)
         assert result == grip / ".synapt" / "recall"
 
+    def test_linked_griptree_no_subrepos_returns_none(self, tmp_path):
+        """A linked griptree with no sub-repos can't resolve — returns None."""
+        griptree = tmp_path / "orphan-tree"
+        griptree.mkdir()
+        (griptree / ".gitgrip").mkdir()
+        (griptree / ".gitgrip" / "griptree.json").write_text(
+            '{"branch": "dev", "path": "' + str(griptree) + '"}'
+        )
+        # No sub-repos with .git files
+        (griptree / "docs").mkdir()
+
+        result = _find_gripspace_root(griptree)
+        assert result is None
+
     def test_stops_at_home_directory(self, tmp_path):
         """Should not walk above $HOME."""
         # Put a .gitgrip ABOVE the fake $HOME


### PR DESCRIPTION
## Summary
- `_find_gripspace_root()` now distinguishes gripspace root (`griptrees.json` plural) from linked griptree (`griptree.json` singular)
- Linked griptrees resolve back to parent gripspace via git worktree pointers in sub-repos
- Fixes bug where each linked griptree created its own `.synapt/` directory instead of sharing the parent's

## Test plan
- [x] 23/23 gripspace tests pass (2 new: linked griptree resolution, data dir matches parent)
- [x] Verified `project_data_dir()` from `synapt-dev/` now returns `/Users/layne/Development/synapt/.synapt/recall`
- [x] Verified `project_data_dir()` from `synapt-dev/synapt/` still works (was already correct via git worktree)
- [x] Verified `project_data_dir()` from `synapt/synapt/` unchanged

Generated with [Claude Code](https://claude.com/claude-code)