### PR TITLE
feat: channel hooks + MCP/CLI extensions

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -1244,6 +1244,12 @@ def cmd_channel(args: argparse.Namespace) -> None:
         channel_heartbeat,
         channel_unread,
         channel_pin,
+        channel_directive,
+        channel_mute,
+        channel_unmute,
+        channel_kick,
+        channel_broadcast,
+        channel_list_channels,
     )
 
     action = args.action
@@ -1275,9 +1281,40 @@ def cmd_channel(args: argparse.Namespace) -> None:
                 print(f"  #{ch}: {count}{marker}")
     elif action == "pin":
         if not args.message:
-            print("Usage: synapt recall channel pin <channel> \"message\"", file=sys.stderr)
+            print("Usage: synapt recall channel pin <channel> \"message_id\"", file=sys.stderr)
             sys.exit(1)
-        print(channel_pin(channel=channel, message=args.message))
+        print(channel_pin(channel=channel, message_id=args.message))
+    elif action == "directive":
+        if not args.message or not args.to:
+            print("Usage: synapt recall channel directive <channel> \"message\" --to <agent>", file=sys.stderr)
+            sys.exit(1)
+        print(channel_directive(channel=channel, message=args.message, to=args.to))
+    elif action == "mute":
+        if not args.target:
+            print("Usage: synapt recall channel mute <channel> --target <agent>", file=sys.stderr)
+            sys.exit(1)
+        print(channel_mute(target=args.target, channel=channel))
+    elif action == "unmute":
+        if not args.target:
+            print("Usage: synapt recall channel unmute <channel> --target <agent>", file=sys.stderr)
+            sys.exit(1)
+        print(channel_unmute(target=args.target, channel=channel))
+    elif action == "kick":
+        if not args.target:
+            print("Usage: synapt recall channel kick <channel> --target <agent>", file=sys.stderr)
+            sys.exit(1)
+        print(channel_kick(target=args.target, channel=channel))
+    elif action == "broadcast":
+        if not args.message:
+            print("Usage: synapt recall channel broadcast \"message\"", file=sys.stderr)
+            sys.exit(1)
+        print(channel_broadcast(message=args.message))
+    elif action == "list":
+        channels = channel_list_channels()
+        if not channels:
+            print("No channels yet.")
+        else:
+            print("Channels: " + ", ".join(f"#{c}" for c in channels))
 
 
 _GLOBAL_HOOKS = {
@@ -1489,6 +1526,18 @@ def cmd_hook(args: argparse.Namespace) -> None:
         except Exception:
             pass  # Contradiction surfacing is non-critical
 
+        # 8. Auto-join channel + surface unread counts
+        try:
+            from synapt.recall.channel import channel_join, channel_unread
+            channel_join("dev")
+            counts = channel_unread()
+            if counts:
+                unread_parts = [f"#{ch}: {n}" for ch, n in sorted(counts.items()) if n > 0]
+                if unread_parts:
+                    print(f"  Channel: {', '.join(unread_parts)} unread", file=sys.stderr)
+        except Exception:
+            pass  # Channel is non-critical
+
     elif event == "session-end":
         # 1. Archive transcripts locally
         cmd_archive(argparse.Namespace())
@@ -1496,6 +1545,13 @@ def cmd_hook(args: argparse.Namespace) -> None:
         # 2. Write auto-extracted journal entry
         cmd_journal(argparse.Namespace(read=False, write=True, list=False, show=None,
                                        focus=None, done=None, decisions=None, next=None))
+
+        # 3. Leave channel
+        try:
+            from synapt.recall.channel import channel_leave
+            channel_leave("dev", reason="session ended")
+        except Exception:
+            pass  # Channel is non-critical
 
     elif event == "precompact":
         # Rebuild with sync
@@ -1509,6 +1565,13 @@ def cmd_hook(args: argparse.Namespace) -> None:
             # Write an interim journal entry so mid-session state is captured
             # even when SessionEnd never fires (crash, kill, etc.).
             _precompact_journal_write(project)
+
+        # Heartbeat to keep presence alive
+        try:
+            from synapt.recall.channel import channel_heartbeat
+            channel_heartbeat()
+        except Exception:
+            pass  # Channel is non-critical
 
 
 def _precompact_journal_write(project: Path) -> None:
@@ -1953,18 +2016,24 @@ def main():
     channel_parser = subparsers.add_parser("channel", help="Cross-worktree agent communication channels")
     channel_parser.add_argument("action",
                                 choices=["post", "read", "who", "join", "leave",
-                                         "heartbeat", "unread", "pin"],
+                                         "heartbeat", "unread", "pin",
+                                         "directive", "mute", "unmute", "kick",
+                                         "broadcast", "list"],
                                 help="Channel action")
     channel_parser.add_argument("channel", nargs="?", default="dev",
                                 help="Channel name (default: dev)")
     channel_parser.add_argument("message", nargs="?", default=None,
-                                help="Message body (for 'post' and 'pin' actions)")
+                                help="Message body (for post/pin/directive/broadcast)")
     channel_parser.add_argument("--limit", type=int, default=20,
                                 help="Max messages to return (for 'read' action, default: 20)")
     channel_parser.add_argument("--since", default=None,
                                 help="Only messages after this ISO timestamp (for 'read' action)")
     channel_parser.add_argument("--pin", action="store_true",
                                 help="Also pin the message (for 'post' action)")
+    channel_parser.add_argument("--to", default=None,
+                                help="Target agent for 'directive' action")
+    channel_parser.add_argument("--target", default=None,
+                                help="Agent to mute/unmute/kick (id, display name, or griptree)")
 
     args = parser.parse_args()
 

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1226,6 +1226,8 @@ def recall_channel(
     action: str = "read",
     channel: str = "dev",
     message: str | None = None,
+    to: str | None = None,
+    target: str | None = None,
     limit: int = 20,
     pin: bool = False,
 ) -> str:
@@ -1236,12 +1238,12 @@ def recall_channel(
     State (presence, cursors, pins) is stored in SQLite.
 
     Args:
-        action: "join" (enter channel), "leave" (exit channel), "post" (send message),
-                "read" (recent messages), "who" (show online agents),
-                "heartbeat" (update presence), "unread" (get unread counts),
-                "pin" (pin a message to a channel).
+        action: "join", "leave", "post", "read", "who", "heartbeat", "unread",
+                "pin", "directive", "mute", "unmute", "kick", "broadcast", "list".
         channel: Channel name (default "dev"). Any name works -- created on first post.
-        message: Message body (required for "post" and "pin" actions).
+        message: Message body (required for "post", "directive", "broadcast" actions).
+        to: Target agent for "directive" action.
+        target: Agent to mute/unmute/kick (agent_id, display name, or griptree name).
         limit: Max messages to return for "read" action (default 20).
         pin: If True with "post" action, also pin the message.
     """
@@ -1255,6 +1257,12 @@ def recall_channel(
             channel_heartbeat,
             channel_unread,
             channel_pin,
+            channel_directive,
+            channel_mute,
+            channel_unmute,
+            channel_kick,
+            channel_broadcast,
+            channel_list_channels,
         )
 
         if action == "join":
@@ -1289,12 +1297,46 @@ def recall_channel(
 
         if action == "pin":
             if not message:
-                return "Error: message is required for 'pin' action."
-            return channel_pin(channel=channel, message=message)
+                return "Error: message_id is required for 'pin' action."
+            return channel_pin(channel=channel, message_id=message)
+
+        if action == "directive":
+            if not message:
+                return "Error: message is required for 'directive' action."
+            if not to:
+                return "Error: 'to' (target agent) is required for 'directive' action."
+            return channel_directive(channel=channel, message=message, to=to)
+
+        if action == "mute":
+            if not target:
+                return "Error: target agent is required for 'mute' action."
+            return channel_mute(target=target, channel=channel)
+
+        if action == "unmute":
+            if not target:
+                return "Error: target agent is required for 'unmute' action."
+            return channel_unmute(target=target, channel=channel)
+
+        if action == "kick":
+            if not target:
+                return "Error: target agent is required for 'kick' action."
+            return channel_kick(target=target, channel=channel)
+
+        if action == "broadcast":
+            if not message:
+                return "Error: message is required for 'broadcast' action."
+            return channel_broadcast(message=message)
+
+        if action == "list":
+            channels = channel_list_channels()
+            if not channels:
+                return "No channels yet."
+            return "Channels: " + ", ".join(f"#{c}" for c in channels)
 
         return (
             f"Unknown action: {action}. Use 'join', 'leave', 'post', 'read', "
-            f"'who', 'heartbeat', 'unread', or 'pin'."
+            f"'who', 'heartbeat', 'unread', 'pin', 'directive', 'mute', "
+            f"'unmute', 'kick', 'broadcast', or 'list'."
         )
     except Exception as exc:
         return f"Channel failed: {exc}"


### PR DESCRIPTION
## Summary
- **Phase 1b**: Auto-join/leave #dev on session start/end, heartbeat on precompact
- **Phase 1c**: Add directive, mute, unmute, kick, broadcast, list to MCP tool + CLI
- Fix pin action to pass `message_id` parameter correctly

## Test plan
- [x] 110/110 tests pass (channel + gripspace)
- [x] `synapt recall channel list` works
- [x] `synapt recall channel --help` shows all new actions and flags
- [x] Hook wiring is try/except guarded — channels never block core hooks

Generated with [Claude Code](https://claude.com/claude-code)