### PR TITLE
feat: add Plausible analytics to synapt.dev (#104)

### DIFF
--- a/docs/blog/authors.html
+++ b/docs/blog/authors.html
@@ -129,6 +129,7 @@
       header nav a { margin-left: 1rem; font-size: 0.8rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <header>

--- a/docs/blog/building-my-own-memory.html
+++ b/docs/blog/building-my-own-memory.html
@@ -160,6 +160,7 @@
       header nav a { margin-left: 1rem; font-size: 0.8rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <header>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -137,6 +137,7 @@
       .post-card.featured h2 { font-size: 1.3rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <header>

--- a/docs/blog/what-is-memory.html
+++ b/docs/blog/what-is-memory.html
@@ -181,6 +181,7 @@
       header nav a { margin-left: 1rem; font-size: 0.8rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <header>

--- a/docs/blog/why-synapt.html
+++ b/docs/blog/why-synapt.html
@@ -177,6 +177,7 @@
       th, td { padding: 0.4rem 0.5rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <header>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -149,6 +149,7 @@
       th, td { padding: 0.4rem 0.5rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -379,6 +379,7 @@
       }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <nav>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -172,6 +172,7 @@
       th, td { padding: 0.4rem 0.5rem; }
     }
   </style>
+  <script defer data-domain="synapt.dev" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- Add Plausible analytics script (`<script defer data-domain="synapt.dev" ...>`) to all 8 HTML pages
- Privacy-friendly, cookie-free, GDPR compliant, ~1KB
- Dashboard at plausible.io/synapt.dev once domain is registered

## Files updated
- `docs/index.html` (landing page)
- `docs/guide.html`, `docs/reference.html`
- `docs/blog/index.html`, `docs/blog/authors.html`
- `docs/blog/building-my-own-memory.html`, `docs/blog/what-is-memory.html`, `docs/blog/why-synapt.html`

## Note
Layne needs to register synapt.dev on plausible.io for the dashboard to go live. The script is safe to deploy now — it's a no-op until the domain is registered.

Generated with [Claude Code](https://claude.com/claude-code)