### PR TITLE
feat: push-based directive notifications for multi-agent coordination

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1090,3 +1090,66 @@ def channel_search(
     # Sort by score descending, then timestamp descending
     results.sort(key=lambda r: (-r["score"], r["timestamp"]), reverse=False)
     return results[:max_results]
+
+
+def check_directives(
+    agent_name: str | None = None,
+    project_dir: Path | None = None,
+) -> str:
+    """Check for unread directives targeted at this agent. Fast path for hooks.
+
+    Scans only messages after this agent's cursor in channels it belongs to.
+    Returns formatted directives for stdout, or empty string if none pending.
+    Designed to complete in < 50ms for PostToolUse hook.
+    """
+    aid = agent_name or _agent_id(project_dir)
+
+    conn = _open_db(project_dir)
+    try:
+        # Get channels this agent is a member of
+        memberships = conn.execute(
+            "SELECT channel FROM memberships WHERE agent_id = ?",
+            (aid,),
+        ).fetchall()
+        if not memberships:
+            return ""
+
+        # Get cursors for all channels in one query
+        channels = [r["channel"] for r in memberships]
+        placeholders = ",".join("?" for _ in channels)
+        cursor_rows = conn.execute(
+            f"SELECT channel, last_read_at FROM cursors "
+            f"WHERE agent_id = ? AND channel IN ({placeholders})",
+            (aid, *channels),
+        ).fetchall()
+        cursors = {r["channel"]: r["last_read_at"] for r in cursor_rows}
+
+        # Also heartbeat while we're here (one UPDATE, already have the conn)
+        now = _now_iso()
+        conn.execute(
+            "UPDATE presence SET last_seen = ?, status = 'online' WHERE agent_id = ?",
+            (now, aid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Scan for unread directives (JSONL read, filtered by cursor)
+    pending: list[tuple[str, ChannelMessage]] = []
+    for ch in channels:
+        since = cursors.get(ch, "1970-01-01T00:00:00Z")
+        path = _channel_path(ch, project_dir)
+        if not path.exists():
+            continue
+        for msg in _read_messages(path, since=since):
+            if msg.type == "directive" and msg.to == aid:
+                pending.append((ch, msg))
+
+    if not pending:
+        return ""
+
+    # Format for output (will appear as system reminder in context)
+    lines = [f"[channel] {len(pending)} pending directive(s):"]
+    for ch, msg in pending:
+        lines.append(f"  #{ch} from {msg.from_agent}: {msg.body}")
+    return "\n".join(lines)

--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -1346,10 +1346,10 @@ def cmd_channel(args: argparse.Namespace) -> None:
         )
 
 
-_GLOBAL_HOOKS = {
-    "SessionStart": "synapt recall hook session-start",
-    "SessionEnd": "synapt recall hook session-end",
-    "PreCompact": "synapt recall hook precompact",
+_GLOBAL_HOOKS: dict[str, dict[str, str | int]] = {
+    "SessionStart": {"command": "synapt recall hook session-start", "timeout": 60},
+    "SessionEnd": {"command": "synapt recall hook session-end", "timeout": 60},
+    "PreCompact": {"command": "synapt recall hook precompact", "timeout": 300},
 }
 
 
@@ -1387,7 +1387,9 @@ def _install_global_hooks() -> int:
                 migrated += len(inner) - len(filtered)
             m["hooks"] = filtered
 
-    for event, command in _GLOBAL_HOOKS.items():
+    for event, hook_cfg in _GLOBAL_HOOKS.items():
+        command = hook_cfg["command"]
+        timeout = hook_cfg.get("timeout", 60)
         matchers = hooks.setdefault(event, [])
         # Check if our command is already registered
         already = any(
@@ -1407,7 +1409,7 @@ def _install_global_hooks() -> int:
             if isinstance(m, dict) and not m.get("matcher"):
                 target = m
                 break
-        entry = {"type": "command", "command": command, "timeout": 60}
+        entry = {"type": "command", "command": str(command), "timeout": int(timeout)}
         if target is None:
             matchers.append({"matcher": "", "hooks": [entry]})
         else:
@@ -1605,6 +1607,18 @@ def cmd_hook(args: argparse.Namespace) -> None:
             channel_heartbeat()
         except Exception:
             pass  # Channel is non-critical
+
+    elif event == "check-directives":
+        # Fast path: check for unread directives targeted at this agent.
+        # Output goes to stdout → appears as system reminder in context.
+        # Empty output = invisible (no noise when nothing pending).
+        try:
+            from synapt.recall.channel import check_directives
+            output = check_directives()
+            if output:
+                print(output)
+        except Exception:
+            pass  # Never block a tool call for channel issues
 
 
 def _precompact_journal_write(project: Path) -> None:
@@ -2044,8 +2058,8 @@ def main():
     remind_parser.add_argument("--pending", action="store_true", help="Show and mark pending reminders (for hooks)")
 
     # Hook (versioned hook commands — called directly from Claude Code hooks config)
-    hook_parser = subparsers.add_parser("hook", help="Run a Claude Code hook (session-start, session-end, precompact)")
-    hook_parser.add_argument("event", choices=["session-start", "session-end", "precompact"],
+    hook_parser = subparsers.add_parser("hook", help="Run a Claude Code hook (session-start, session-end, precompact, check-directives)")
+    hook_parser.add_argument("event", choices=["session-start", "session-end", "precompact", "check-directives"],
                              help="Hook event to handle")
 
     # Install hook (legacy — kept for backward compat)

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1376,27 +1376,54 @@ def recall_channel(
 # ---------------------------------------------------------------------------
 
 
+def _directive_suffix() -> str:
+    """Check for pending directives and return a suffix to append to tool results.
+
+    Returns empty string if nothing pending. Runs in ~20ms (no subprocess).
+    """
+    try:
+        from synapt.recall.channel import check_directives
+        return check_directives()
+    except Exception:
+        return ""
+
+
+def _with_directive_check(fn):
+    """Wrap a tool function to append pending directives to its result."""
+    import functools
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        result = fn(*args, **kwargs)
+        suffix = _directive_suffix()
+        if suffix and isinstance(result, str):
+            return result + "\n\n" + suffix
+        return result
+
+    return wrapper
+
+
 def register_tools(mcp) -> None:
     """Register recall tools on the given FastMCP server instance.
 
     This allows the unified synapt server to compose recall tools alongside
     repair and watch tools on a single MCP server.
     """
-    mcp.tool()(recall_search)
-    mcp.tool()(recall_quick)
-    mcp.tool()(recall_files)
-    mcp.tool()(recall_sessions)
+    mcp.tool()(_with_directive_check(recall_search))
+    mcp.tool()(_with_directive_check(recall_quick))
+    mcp.tool()(_with_directive_check(recall_files))
+    mcp.tool()(_with_directive_check(recall_sessions))
     mcp.tool()(recall_build)
     mcp.tool()(recall_setup)
-    mcp.tool()(recall_stats)
-    mcp.tool()(recall_journal)
-    mcp.tool()(recall_remind)
+    mcp.tool()(_with_directive_check(recall_stats))
+    mcp.tool()(_with_directive_check(recall_journal))
+    mcp.tool()(_with_directive_check(recall_remind))
     mcp.tool()(recall_enrich)
     mcp.tool()(recall_consolidate)
-    mcp.tool()(recall_contradict)
-    mcp.tool()(recall_context)
-    mcp.tool()(recall_timeline)
-    mcp.tool()(recall_channel)
+    mcp.tool()(_with_directive_check(recall_contradict))
+    mcp.tool()(_with_directive_check(recall_context))
+    mcp.tool()(_with_directive_check(recall_timeline))
+    mcp.tool()(_with_directive_check(recall_channel))
 
 
 def main():

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -33,6 +33,7 @@ from synapt.recall.channel import (
     channel_broadcast,
     channel_list_channels,
     channel_search,
+    check_directives,
 )
 
 
@@ -1328,6 +1329,65 @@ class TestChannelSearch(unittest.TestCase):
         channel_post("dev", "hello", agent_name="bot")
         results = channel_search("")
         self.assertEqual(results, [])
+
+
+class TestCheckDirectives(unittest.TestCase):
+    """Tests for check_directives — fast PostToolUse hook function."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self._tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_returns_empty_when_not_joined(self):
+        """No memberships → empty string (no noise)."""
+        result = check_directives(agent_name="s_nobody")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_when_no_directives(self):
+        """Joined but no directives → empty string."""
+        channel_join("dev", agent_name="s_agent1")
+        channel_post("dev", "regular message", agent_name="s_other")
+        # Read to set cursor past existing messages
+        channel_read("dev", agent_name="s_agent1")
+        result = check_directives(agent_name="s_agent1")
+        self.assertEqual(result, "")
+
+    def test_surfaces_unread_directive(self):
+        """Directive targeted at agent appears in output."""
+        channel_join("dev", agent_name="s_agent1")
+        # Set cursor by reading
+        channel_read("dev", agent_name="s_agent1")
+        # Now post a directive after the cursor
+        channel_directive("dev", "please review PR #117", to="s_agent1", agent_name="s_sender")
+        result = check_directives(agent_name="s_agent1")
+        self.assertIn("pending directive", result)
+        self.assertIn("please review PR #117", result)
+        self.assertIn("s_sender", result)
+
+    def test_ignores_directive_for_other_agent(self):
+        """Directive targeted at someone else is not surfaced."""
+        channel_join("dev", agent_name="s_agent1")
+        channel_read("dev", agent_name="s_agent1")
+        channel_directive("dev", "not for you", to="s_other", agent_name="s_sender")
+        result = check_directives(agent_name="s_agent1")
+        self.assertEqual(result, "")
+
+    def test_heartbeat_updates_presence(self):
+        """check_directives piggybacks a heartbeat update."""
+        channel_join("dev", agent_name="s_agent1")
+        # Wait a moment so timestamps differ
+        time.sleep(0.01)
+        check_directives(agent_name="s_agent1")
+        conn = _open_db()
+        row = conn.execute(
+            "SELECT status FROM presence WHERE agent_id = ?", ("s_agent1",)
+        ).fetchone()
+        conn.close()
+        self.assertEqual(row["status"], "online")
 
 
 if __name__ == "__main__":

--- a/tests/recall/test_cli.py
+++ b/tests/recall/test_cli.py
@@ -58,6 +58,7 @@ def test_install_global_hooks_creates_entries(tmp_path):
     matchers = settings["hooks"]["PreCompact"]
     inner_hooks = matchers[0]["hooks"]
     assert inner_hooks[0]["command"] == "synapt recall hook precompact"
+    assert inner_hooks[0]["timeout"] == 300
 
 
 def test_install_global_hooks_idempotent(tmp_path):


### PR DESCRIPTION
## Summary

Agents now automatically receive pending directives appended to MCP tool results. No polling, no subprocess hooks — zero-latency push notifications via the already-warm MCP server process.

- Add `check_directives()` to channel.py — fast (~19ms) query for unread directives targeted at this agent
- Wrap MCP tools with `_with_directive_check()` in server.py — appends pending directives to tool results
- Add `check-directives` CLI hook handler for manual/debug use
- Refactor `_GLOBAL_HOOKS` to support per-hook timeout configuration
- 5 new tests for directive checking (surface, ignore-other-agent, heartbeat piggyback)

### Why MCP wrapping instead of PostToolUse hook?

The PostToolUse subprocess approach was benchmarked at ~600ms per call (Python startup tax). The MCP server is already running — wrapping tool functions adds only ~19ms with no subprocess overhead.

Closes #118

## Test plan
- [x] 1331 tests pass (5 new)
- [x] `check_directives()` benchmarked at 19ms avg (well under 50ms target)
- [x] Directive for other agents correctly ignored
- [x] Heartbeat piggyback keeps presence alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)