### PR TITLE
test: channel directive remind=True coverage (#115)

### DIFF
--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -995,6 +995,24 @@ class TestDirective(unittest.TestCase):
         self.assertEqual(directive_msgs[0].to, "s_target01")
         self.assertEqual(directive_msgs[0].body, "do the thing")
 
+    def test_directive_remind_bridges_to_reminders(self):
+        """When remind=True, directive also calls add_reminder."""
+        with patch("synapt.recall.reminders.add_reminder") as mock_add:
+            channel_directive(
+                "dev", "deploy by EOD", to="s_target01",
+                agent_name="admin", remind=True,
+            )
+            mock_add.assert_called_once()
+            call_text = mock_add.call_args[0][0]
+            self.assertIn("deploy by EOD", call_text)
+            self.assertIn("admin", call_text)
+
+    def test_directive_no_remind_by_default(self):
+        """Default remind=False should not call add_reminder."""
+        with patch("synapt.recall.reminders.add_reminder") as mock_add:
+            channel_directive("dev", "no reminder", to="s_target01", agent_name="admin")
+            mock_add.assert_not_called()
+
 
 class TestMuteUnmute(unittest.TestCase):
     """Test muting and unmuting agents."""


### PR DESCRIPTION
## Summary
- Adds test for `channel_directive(remind=True)` — verifies the reminders bridge calls `add_reminder`
- Adds test confirming `remind=False` (default) does not trigger reminders
- Reviewed FIX #5, #7, #8 from channel Phase 1a — all already working correctly

## Context
Part of channel fixes split with other agent (s_84097adf). Fixes #5-#8 were assigned to us. After review:
- **#5** (mute display names): already works via `_resolve_target_id`
- **#6** (missing tests): only gap was `remind=True` path — added here
- **#7** (reminders import): correct, verified
- **#8** (message ID collision): documented, acceptable risk

## Test plan
- [x] 6/6 directive tests pass
- [x] Full suite: 1318 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)