### PR TITLE
feat: recall_contradict flag action for free-text claims (#58)

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -762,6 +762,7 @@ def recall_contradict(
                 elif pending_row and not pending_row["old_node_id"]:
                     # Free-text claim confirmed — create a new knowledge node
                     _create_knowledge_from_claim(index._db, pending_row)
+                    return f"Contradiction #{contradiction_id} confirmed — new knowledge node created from claim."
                 return f"Contradiction #{contradiction_id} confirmed — old node superseded."
             return f"Contradiction #{contradiction_id} dismissed — old node retained."
 

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -620,17 +620,52 @@ class RecallDB:
         self._conn.commit()
 
     def _migrate_contradictions_table(self) -> None:
-        """Add columns that may be missing from an older pending_contradictions table."""
+        """Migrate pending_contradictions: add claim_text, make old_node_id nullable.
+
+        SQLite doesn't support ALTER COLUMN, so we recreate the table when
+        old_node_id has a NOT NULL constraint from the old schema.
+        """
         row = self._conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='pending_contradictions'"
         ).fetchone()
         if row is None:
             return
-        cols = {
-            r[1]
-            for r in self._conn.execute("PRAGMA table_info(pending_contradictions)").fetchall()
-        }
-        if "claim_text" not in cols:
+
+        # Check if old_node_id is NOT NULL (old schema)
+        col_info = self._conn.execute("PRAGMA table_info(pending_contradictions)").fetchall()
+        col_map = {r[1]: r for r in col_info}
+        needs_recreate = col_map.get("old_node_id", (None,) * 6)[3] == 1  # notnull flag
+        has_claim_text = "claim_text" in col_map
+
+        if not needs_recreate and has_claim_text:
+            return  # Already migrated
+
+        if needs_recreate:
+            # Recreate table: old_node_id NOT NULL → nullable, add claim_text
+            self._conn.executescript("""
+                CREATE TABLE IF NOT EXISTS _pc_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    old_node_id TEXT,
+                    new_content TEXT NOT NULL,
+                    category TEXT NOT NULL DEFAULT '',
+                    reason TEXT NOT NULL DEFAULT '',
+                    source_sessions TEXT NOT NULL DEFAULT '[]',
+                    detected_at TEXT NOT NULL,
+                    detected_by TEXT NOT NULL DEFAULT 'co-retrieval',
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    resolved_at TEXT,
+                    claim_text TEXT
+                );
+                INSERT INTO _pc_new (id, old_node_id, new_content, category, reason,
+                    source_sessions, detected_at, detected_by, status, resolved_at)
+                SELECT id, old_node_id, new_content, category, reason,
+                    source_sessions, detected_at, detected_by, status, resolved_at
+                FROM pending_contradictions;
+                DROP TABLE pending_contradictions;
+                ALTER TABLE _pc_new RENAME TO pending_contradictions;
+            """)
+            self._conn.commit()
+        elif not has_claim_text:
             self._conn.execute(
                 "ALTER TABLE pending_contradictions ADD COLUMN claim_text TEXT"
             )

--- a/tests/recall/test_supersession.py
+++ b/tests/recall/test_supersession.py
@@ -731,10 +731,37 @@ class TestRecallContradictFlag:
                     resolution="confirmed",
                 )
         assert "confirmed" in result
+        assert "knowledge node created" in result
         # Verify a knowledge node was created
         nodes = db.load_knowledge_nodes(status="active")
         assert len(nodes) == 1
         assert nodes[0]["content"] == "API keys expire every 90 days"
+
+    def test_flag_fts_matches_existing_node(self, tmp_path):
+        """When no old_node_id given, flag searches FTS and matches best node."""
+        from synapt.recall.server import recall_contradict
+        db = _make_db(tmp_path)
+        node = _make_knowledge_node(node_id="k1", content="deploy every Tuesday at 3pm")
+        db.save_knowledge_nodes([node])
+        # Rebuild FTS so the node is searchable
+        db._conn.execute(
+            "INSERT INTO knowledge_fts(rowid, content, category, tags) "
+            "SELECT rowid, content, category, tags FROM knowledge"
+        )
+        db._conn.commit()
+        index = self._make_index(db)
+
+        with patch("synapt.recall.server._get_index", return_value=index):
+            with patch("synapt.recall.server._invalidate_cache"):
+                result = recall_contradict(
+                    action="flag",
+                    claim="deploy schedule changed to Thursday",
+                )
+        assert "flagged" in result
+        assert "k1" in result
+        pending = db.list_pending_contradictions()
+        assert len(pending) == 1
+        assert pending[0]["old_node_id"] == "k1"
 
     def test_list_shows_free_text_claims(self, tmp_path):
         from synapt.recall.server import recall_contradict


### PR DESCRIPTION
## Summary
- Adds `"flag"` action to `recall_contradict` MCP tool — users/agents can now report contradictions using free-text claims, not just knowledge node IDs
- Auto-searches knowledge FTS for matching nodes when no explicit `old_node_id` is provided
- Free-text claims (no matching node) create a new knowledge node when confirmed
- Schema: `old_node_id` nullable, new `claim_text` column with migration

## How it works
```
recall_contradict(action="flag", claim="we never deploy on Fridays", reason="outage last Friday")
```
→ Searches knowledge for matching nodes → flags best match or stores as free-text claim

## Test plan
- [x] 6 new tests for flag action (explicit node, free-text, validation, resolve-creates-node, list display)
- [x] All 69 supersession tests pass
- [x] Full suite: 1330 passed, 0 failed

Partial fix for #58 (acceptance criteria 1). Criteria 2-3 (proactive search warnings, auto-extract) are follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)