### PR TITLE
fix: deduplicate stale agents in /who

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -777,8 +777,23 @@ def channel_who(project_dir: Path | None = None) -> str:
         if not agents:
             return "No agents online."
 
+        # Deduplicate by (griptree, display_name): when multiple agents share
+        # the same griptree AND display name (dead sessions from the same
+        # worktree that haven't been reaped yet), only show the most recently
+        # seen one to avoid noisy /who output. Agents with distinct display
+        # names (e.g., different worktrees) always appear separately.
+        best_by_identity: dict[tuple[str, str], sqlite3.Row] = {}
+        for row in agents:
+            gt = row["griptree"] or row["agent_id"]
+            dn = row["display_name"] or ""
+            key = (gt, dn)
+            existing = best_by_identity.get(key)
+            if existing is None or row["last_seen"] > existing["last_seen"]:
+                best_by_identity[key] = row
+        deduped_agents = list(best_by_identity.values())
+
         lines = ["## Agents"]
-        for row in sorted(agents, key=lambda r: r["display_name"] or r["griptree"] or r["agent_id"]):
+        for row in sorted(deduped_agents, key=lambda r: r["display_name"] or r["griptree"] or r["agent_id"]):
             aid = row["agent_id"]
             last_seen = row["last_seen"]
             status = _agent_status(last_seen)

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -766,6 +766,61 @@ class TestWho(unittest.TestCase):
         result = channel_who()
         self.assertIn("No agents", result)
 
+    def test_who_deduplicates_same_griptree_and_display_name(self):
+        """Multiple agents with same griptree+display_name show only the most recent."""
+        old_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        new_time = (datetime.now(timezone.utc) - timedelta(minutes=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        conn = _open_db()
+        try:
+            # Two agents, same griptree AND display_name (dead session scenario)
+            for aid, ts in [("s_old_session", old_time), ("s_new_session", new_time)]:
+                conn.execute(
+                    "INSERT INTO presence (agent_id, griptree, display_name, status, last_seen, joined_at) "
+                    "VALUES (?, 'synapt/synapt', 'synapt', 'online', ?, ?)",
+                    (aid, ts, ts),
+                )
+                conn.execute(
+                    "INSERT INTO memberships (agent_id, channel, joined_at) "
+                    "VALUES (?, 'dev', ?)",
+                    (aid, ts),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = channel_who()
+        # Only the newer session should appear
+        self.assertIn("s_new_session", result)
+        self.assertNotIn("s_old_session", result)
+
+    def test_who_keeps_different_display_names(self):
+        """Agents with same griptree but different display names should all show."""
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        conn = _open_db()
+        try:
+            for aid, name in [("s_agent1", "worker-1"), ("s_agent2", "worker-2")]:
+                conn.execute(
+                    "INSERT INTO presence (agent_id, griptree, display_name, status, last_seen, joined_at) "
+                    "VALUES (?, 'synapt/synapt', ?, 'online', ?, ?)",
+                    (aid, name, now, now),
+                )
+                conn.execute(
+                    "INSERT INTO memberships (agent_id, channel, joined_at) "
+                    "VALUES (?, 'dev', ?)",
+                    (aid, now),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = channel_who()
+        self.assertIn("worker-1", result)
+        self.assertIn("worker-2", result)
+
 
 class TestLegacyMigration(unittest.TestCase):
     """Test migration from _presence.json to SQLite."""
@@ -957,6 +1012,18 @@ class TestConcurrentAccess(unittest.TestCase):
         for i in range(5):
             channel_join("dev", agent_name=f"agent-{i}")
             channel_post("dev", f"hello from agent-{i}", agent_name=f"agent-{i}")
+
+        # Give each agent a distinct display_name so /who dedup doesn't collapse them
+        conn = _open_db()
+        try:
+            for i in range(5):
+                conn.execute(
+                    "UPDATE presence SET display_name = ? WHERE agent_id = ?",
+                    (f"agent-{i}", f"agent-{i}"),
+                )
+            conn.commit()
+        finally:
+            conn.close()
 
         result = channel_read("dev", limit=50)
         for i in range(5):


### PR DESCRIPTION
Deduplicates agents in /who by (griptree, display_name) — only the most recently seen session shown. Agents with distinct display names still appear separately.

Closes #115

Generated with [Claude Code](https://claude.com/claude-code)