### PR TITLE
feat: broadcast directives with to='*'

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -753,7 +753,7 @@ def channel_read(
             lines.append(f"  {ts}{mid}  -- {msg.body}")
         elif msg.type == "directive":
             target = f" @{msg.to}" if msg.to else ""
-            prefix = "[DIRECTIVE]" if msg.to == aid else "[directive]"
+            prefix = "[DIRECTIVE]" if msg.to in (aid, "*") else "[directive]"
             lines.append(f"  {ts}{mid}  {prefix}{target} {display}: {msg.body}")
         else:
             lines.append(f"  {ts}{mid}  {display}: {msg.body}")
@@ -1145,7 +1145,7 @@ def check_directives(
         if not path.exists():
             continue
         for msg in _read_messages(path, since=since):
-            if msg.type == "directive" and msg.to == aid:
+            if msg.type == "directive" and (msg.to == aid or msg.to == "*"):
                 pending.append((ch, msg))
 
     if not pending:

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -1417,6 +1417,18 @@ class TestCheckDirectives(unittest.TestCase):
         result = check_directives(agent_name="s_agent1")
         self.assertEqual(result, "")
 
+    def test_broadcast_directive_reaches_all_agents(self):
+        """Directive with to='*' is surfaced for any agent."""
+        channel_join("dev", agent_name="s_agent1")
+        channel_join("dev", agent_name="s_agent2")
+        channel_read("dev", agent_name="s_agent1")
+        channel_read("dev", agent_name="s_agent2")
+        channel_directive("dev", "everyone stop", to="*", agent_name="s_boss")
+        result1 = check_directives(agent_name="s_agent1")
+        result2 = check_directives(agent_name="s_agent2")
+        self.assertIn("everyone stop", result1)
+        self.assertIn("everyone stop", result2)
+
     def test_heartbeat_updates_presence(self):
         """check_directives piggybacks a heartbeat update."""
         channel_join("dev", agent_name="s_agent1")


### PR DESCRIPTION
Directives with `to="*"` now reach all agents in check_directives and highlight in channel_read. One test added.

Closes #129

Generated with [Claude Code](https://claude.com/claude-code)