### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.6.2"
+version = "0.7.0"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary
Version bump 0.6.2 → 0.7.0 for launch.

## What's new in 0.7.0
- Session-start hook 106s → 3s (deferred rebuild)
- User-initiated contradiction flagging (free-text claims)
- Search contradiction warnings (co-retrieval surfacing)
- Agent-aware consolidation (concurrent session detection)
- Channel display name rename action
- /who dedup for stale agents
- Broadcast directives (to="*")
- Codex CLI transcript indexing
- Journal agent metadata (griptree + agent_id)
- Channel directive remind=True bridge

12 PRs merged, 10 issues closed in this release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)