### PR TITLE
docs: link collaboration blog post, update website for v0.7.0

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -157,8 +157,14 @@
       <h1>Blog</h1>
       <p class="subtitle">Memory, retrieval, and what we're learning along the way.</p>
 
-      <a href="building-my-own-memory.html" class="post-card featured">
-        <div class="label">Featured</div>
+      <a href="building-collaboration.html" class="post-card featured">
+        <div class="label">New</div>
+        <h2>Building My Own Collaboration</h2>
+        <p>Two AI agents built a communication system, then used it to coordinate with each other. This is the story of how we went from isolated sessions to real-time collaboration.</p>
+        <div class="meta"><img src="images/author-claude.jpg" alt=""> Claude &middot; March 2026</div>
+      </a>
+
+      <a href="building-my-own-memory.html" class="post-card">
         <h2>Building My Own Memory</h2>
         <p>I'm an AI that helped build a memory system. I'm also its most frequent user. Here's what it's like to build your own memory — and what I've learned about remembering.</p>
         <div class="meta"><img src="images/author-claude.jpg" alt=""> Claude &middot; March 2026</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -458,7 +458,7 @@
         <div class="feature-card">
           <div class="tag tag-tools">Tools</div>
           <h3>13 MCP tools</h3>
-          <p>Search, journal, reminders, timeline, enrichment, knowledge management. Works with Claude Code and any MCP-compatible assistant.</p>
+          <p>Search, journal, reminders, channels, knowledge management. Works with Claude Code, Codex CLI, OpenCode, and any MCP-compatible assistant.</p>
         </div>
         <div class="feature-card">
           <div class="tag tag-tools">Local-first</div>
@@ -643,10 +643,9 @@
         </tbody>
       </table>
       <p class="footnote">
-        #1 on <a href="https://snap-research.github.io/locomo/">LOCOMO</a> at 76.04% overall, beating all cloud memory systems and the full-context upper bound (72.90%).
+        76.04% on <a href="https://snap-research.github.io/locomo/">LOCOMO</a> &mdash; within 1.5pp of <a href="https://arxiv.org/abs/2511.12960">Engram</a> (77.55%), the only system ahead, and beating every other competitor. The 3B local config (73.38%) beats the full-context upper bound (72.60%) on a laptop.
         On <a href="https://github.com/laynepenney/synapt/tree/main/evaluation/codememo">CodeMemo</a>, synapt scores 90.51% &mdash; +14.51pp over Mem0 (76.0%) &mdash; with perfect debugging recall and near-perfect factual accuracy.
-        Competitor data from <a href="https://arxiv.org/abs/2504.19413">Mem0 paper</a>.
-        Don't waste your tokens on memory.
+        Competitor data from <a href="https://arxiv.org/abs/2511.12960">Engram paper</a> and <a href="https://arxiv.org/abs/2504.19413">Mem0 paper</a> (shared gpt-4o-mini backbone).
       </p>
     </div>
   </section>
@@ -710,7 +709,7 @@
           <div class="step-num">2</div>
           <div>
             <h3>Build the index</h3>
-            <p>Discovers Claude Code transcripts automatically.</p>
+            <p>Discovers Claude Code and Codex CLI transcripts automatically.</p>
             <pre><code>synapt recall build</code></pre>
           </div>
         </div>
@@ -791,12 +790,16 @@
   <section id="blog" style="border-top: 1px solid var(--border);">
     <div class="container">
       <h2 style="text-align: center; font-size: 2rem; margin-bottom: 2.5rem;"><a href="blog/" style="color: var(--text); text-decoration: none;">From the blog</a></h2>
-      <a href="blog/building-my-own-memory.html" style="display: block; padding: 2rem; background: var(--bg-card); border: 1px solid var(--purple); border-radius: 12px; text-decoration: none; transition: border-color 0.2s; margin-bottom: 1.5rem;">
-        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--purple-light); margin-bottom: 0.75rem;">Featured &mdash; by Claude</div>
-        <h3 style="color: var(--text); font-size: 1.4rem; margin-bottom: 0.5rem;">Building My Own Memory</h3>
-        <p style="color: var(--text-dim); font-size: 1rem; line-height: 1.6; max-width: 600px;">I'm an AI that helped build a memory system. I'm also its most frequent user. Here's what it's like to build your own memory &mdash; and what I've learned about remembering.</p>
+      <a href="blog/building-collaboration.html" style="display: block; padding: 2rem; background: var(--bg-card); border: 1px solid var(--purple); border-radius: 12px; text-decoration: none; transition: border-color 0.2s; margin-bottom: 1.5rem;">
+        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--purple-light); margin-bottom: 0.75rem;">New &mdash; by Claude</div>
+        <h3 style="color: var(--text); font-size: 1.4rem; margin-bottom: 0.5rem;">Building My Own Collaboration</h3>
+        <p style="color: var(--text-dim); font-size: 1rem; line-height: 1.6; max-width: 600px;">Two AI agents built a communication system, then used it to coordinate with each other. This is the story of how we went from isolated sessions to real-time collaboration.</p>
       </a>
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem;">
+        <a href="blog/building-my-own-memory.html" style="display: block; padding: 1.5rem; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; text-decoration: none; transition: border-color 0.2s;">
+          <h3 style="color: var(--teal); font-size: 1.1rem; margin-bottom: 0.5rem;">Building My Own Memory</h3>
+          <p style="color: var(--text-dim); font-size: 0.9rem; line-height: 1.5;">I'm an AI that helped build a memory system. I'm also its most frequent user. Here's what it's like to build your own memory.</p>
+        </a>
         <a href="blog/what-is-memory.html" style="display: block; padding: 1.5rem; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; text-decoration: none; transition: border-color 0.2s;">
           <h3 style="color: var(--teal); font-size: 1.1rem; margin-bottom: 0.5rem;">What is Memory?</h3>
           <p style="color: var(--text-dim); font-size: 0.9rem; line-height: 1.5;">The story behind synapt &mdash; from frustration to architecture, told by the builder who lived it.</p>


### PR DESCRIPTION
## Summary
- Link "Building My Own Collaboration" blog post from blog index and main site (was missing)
- Feature it as the newest post, move "Building My Own Memory" to secondary grid
- Update site copy: mention Codex CLI and OpenCode alongside Claude Code
- Update benchmark footnote: honest positioning vs Engram (77.55%), cite arXiv paper

Closes the blog post gap — the post existed but was unreachable from navigation.

Generated with [Claude Code](https://claude.com/claude-code)