### PR TITLE
feat: channel unclaim action (#146)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1209,6 +1209,32 @@ def is_claimed(
         conn.close()
 
 
+def channel_unclaim(
+    message_id: str,
+    agent_name: str | None = None,
+    project_dir: Path | None = None,
+) -> str:
+    """Release a claim on a message. Only the original claimant can unclaim."""
+    aid = agent_name or _agent_id(project_dir)
+
+    conn = _open_db(project_dir)
+    try:
+        row = conn.execute(
+            "SELECT claimed_by FROM claims WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()
+        if not row:
+            return f"Message {message_id} is not claimed."
+        if row["claimed_by"] != aid:
+            display = _resolve_display_name_for(row["claimed_by"], project_dir)
+            return f"Cannot unclaim — owned by {display} ({row['claimed_by']})."
+        conn.execute("DELETE FROM claims WHERE message_id = ?", (message_id,))
+        conn.commit()
+        return f"Released claim on {message_id}."
+    finally:
+        conn.close()
+
+
 def channel_list_channels(project_dir: Path | None = None) -> list[str]:
     """Return list of all channel names (from JSONL files)."""
     ch_dir = _channels_dir(project_dir)

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1519,10 +1519,16 @@ def recall_channel(
             from synapt.recall.channel import channel_claim
             return channel_claim(message_id=message, channel=channel)
 
+        if action == "unclaim":
+            if not message:
+                return "Error: message is required for 'unclaim' action (the message_id to release)."
+            from synapt.recall.channel import channel_unclaim
+            return channel_unclaim(message_id=message)
+
         return (
             f"Unknown action: {action}. Use 'join', 'leave', 'post', 'read', "
             f"'who', 'heartbeat', 'unread', 'pin', 'directive', 'mute', "
-            f"'unmute', 'kick', 'broadcast', 'list', 'search', 'rename', or 'claim'."
+            f"'unmute', 'kick', 'broadcast', 'list', 'search', 'rename', 'claim', or 'unclaim'."
         )
     except Exception as exc:
         return f"Channel failed: {exc}"

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -36,6 +36,7 @@ from synapt.recall.channel import (
     channel_search,
     channel_rename,
     channel_claim,
+    channel_unclaim,
     is_claimed,
     check_directives,
 )
@@ -1375,6 +1376,28 @@ class TestClaim(unittest.TestCase):
         result2 = check_directives(agent_name="s_agent2")
         self.assertIn("create an issue", result1)
         self.assertEqual(result2, "")
+
+    def test_unclaim_by_owner(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_post("dev", "task", agent_name="s_agent1")
+        msgs = _read_messages(_channels_dir() / "dev.jsonl")
+        msg_id = [m for m in msgs if m.type == "message"][-1].id
+
+        channel_claim(msg_id, "dev", agent_name="s_agent1")
+        result = channel_unclaim(msg_id, agent_name="s_agent1")
+        self.assertIn("Released", result)
+        self.assertIsNone(is_claimed(msg_id))
+
+    def test_unclaim_by_non_owner_rejected(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_post("dev", "task", agent_name="s_agent1")
+        msgs = _read_messages(_channels_dir() / "dev.jsonl")
+        msg_id = [m for m in msgs if m.type == "message"][-1].id
+
+        channel_claim(msg_id, "dev", agent_name="s_agent1")
+        result = channel_unclaim(msg_id, agent_name="s_agent2")
+        self.assertIn("Cannot unclaim", result)
+        self.assertIsNotNone(is_claimed(msg_id))
 
 
 class TestBroadcast(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `channel_unclaim(message_id)` — releases a claim, only by original claimant
- MCP: `recall_channel(action="unclaim", message="<msg_id>")`
- Prevents permanently locked tasks when agents disconnect

## Test plan
- [x] 2 new tests (owner unclaim, non-owner rejected)
- [x] Full suite: 1364 passed

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)