### PR TITLE
feat: channel_search type filter (#147)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1222,34 +1222,56 @@ def channel_list_channels(project_dir: Path | None = None) -> list[str]:
 def channel_search(
     query: str,
     max_results: int = 10,
+    msg_type: str | None = None,
     project_dir: Path | None = None,
 ) -> list[dict]:
     """Search all channels for messages matching a query.
 
+    Args:
+        query: Text to search for in message bodies.
+        max_results: Maximum results to return.
+        msg_type: Optional filter by message type (e.g. "directive",
+                  "message", "join", "leave"). When set, only messages
+                  of that type are searched.
+
     Returns a list of dicts with channel, message_id, from, timestamp, body,
-    and a match_score (number of query terms found).
+    type, and a match_score (number of query terms found).
     """
     terms = query.lower().split()
-    if not terms:
+    if not terms and not msg_type:
         return []
+
+    # When filtering by type with no query, match all messages of that type
+    match_all = not terms
 
     results: list[dict] = []
     for ch in channel_list_channels(project_dir):
         path = _channel_path(ch, project_dir)
         for msg in _read_messages(path):
-            if msg.type not in ("message", "directive"):
+            # Type filter
+            if msg_type:
+                if msg.type != msg_type:
+                    continue
+            elif msg.type not in ("message", "directive"):
                 continue
-            body_lower = msg.body.lower()
-            score = sum(1 for t in terms if t in body_lower)
-            if score > 0:
-                results.append({
-                    "channel": ch,
-                    "message_id": msg.id,
-                    "from": msg.from_agent,
-                    "timestamp": msg.timestamp,
-                    "body": msg.body,
-                    "score": score,
-                })
+
+            if match_all:
+                score = 1
+            else:
+                body_lower = msg.body.lower()
+                score = sum(1 for t in terms if t in body_lower)
+                if score == 0:
+                    continue
+
+            results.append({
+                "channel": ch,
+                "message_id": msg.id,
+                "from": msg.from_agent,
+                "timestamp": msg.timestamp,
+                "body": msg.body,
+                "type": msg.type,
+                "score": score,
+            })
 
     # Sort by score descending, then timestamp descending
     results.sort(key=lambda r: (-r["score"], r["timestamp"]), reverse=False)

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -1560,6 +1560,44 @@ class TestChannelSearch(unittest.TestCase):
         self.assertEqual(results, [])
 
 
+class TestChannelSearch(unittest.TestCase):
+    """Tests for channel_search with type filtering (#147)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self.tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_search_by_type_directive(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_post("dev", "regular message", agent_name="s_agent1")
+        channel_directive("dev", "do this task", to="s_agent2", agent_name="s_agent1")
+        results = channel_search("task", msg_type="directive")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["type"], "directive")
+
+    def test_search_type_only_no_query(self):
+        """Search with type filter but no query returns all of that type."""
+        channel_join("dev", agent_name="s_agent1")
+        channel_directive("dev", "first directive", to="*", agent_name="s_agent1")
+        channel_directive("dev", "second directive", to="*", agent_name="s_agent1")
+        channel_post("dev", "not a directive", agent_name="s_agent1")
+        # Empty query but type filter — should return all directives
+        results = channel_search("", msg_type="directive")
+        self.assertEqual(len(results), 2)
+
+    def test_search_includes_type_field(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_post("dev", "hello world", agent_name="s_agent1")
+        results = channel_search("hello")
+        self.assertEqual(len(results), 1)
+        self.assertIn("type", results[0])
+        self.assertEqual(results[0]["type"], "message")
+
+
 class TestCheckDirectives(unittest.TestCase):
     """Tests for check_directives — fast PostToolUse hook function."""
 


### PR DESCRIPTION
## Summary
- `channel_search("query", msg_type="directive")` — filter by message type
- Type-only search (empty query + type) returns all messages of that type
- Results now include `type` field

## Test plan
- [x] 3 new tests
- [x] Full suite: 1356 passed

Closes #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)