### PR TITLE
feat: @mention notifications in channels (#153)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import time
 from dataclasses import asdict, dataclass
@@ -148,6 +149,55 @@ def _resolve_display_name(project_dir: Path | None = None) -> str:
     except Exception:
         pass
     return _resolve_griptree(project_dir)
+
+
+_MENTION_RE = re.compile(r"@(\w[\w.-]*)")
+
+
+def extract_mentions(text: str) -> list[str]:
+    """Extract @mention names from message text.
+
+    Returns list of mentioned names (without the @ prefix).
+
+    >>> extract_mentions("hey @opus review this @apollo")
+    ['opus', 'apollo']
+    """
+    return _MENTION_RE.findall(text)
+
+
+def _mentions_agent(
+    text: str,
+    agent_id: str,
+    conn: sqlite3.Connection,
+) -> bool:
+    """Check if a message text @mentions a specific agent.
+
+    Resolves the agent's display_name and griptree from the presence
+    table, then checks if any @mention in the text matches.
+    """
+    mentions = extract_mentions(text)
+    if not mentions:
+        return False
+
+    row = conn.execute(
+        "SELECT display_name, griptree FROM presence WHERE agent_id = ?",
+        (agent_id,),
+    ).fetchone()
+    if not row:
+        return False
+
+    # Match against display_name, griptree, or agent_id itself
+    names = {agent_id.lower()}
+    if row["display_name"]:
+        names.add(row["display_name"].lower())
+    if row["griptree"]:
+        names.add(row["griptree"].lower())
+        # Also match the last segment (e.g., "synapt" from "synapt/synapt")
+        parts = row["griptree"].split("/")
+        if len(parts) > 1:
+            names.add(parts[-1].lower())
+
+    return any(m.lower() in names for m in mentions)
 
 
 def _resolve_target_id(target: str, conn: sqlite3.Connection) -> str:
@@ -1379,25 +1429,48 @@ def check_directives(
     finally:
         conn2.close()
 
+    # Load presence data for @mention resolution
+    conn3 = _open_db(project_dir)
+    try:
+        mention_conn = conn3
+    except Exception:
+        mention_conn = None
+
     pending: list[tuple[str, ChannelMessage]] = []
-    for ch in channels:
-        since = cursors.get(ch, "1970-01-01T00:00:00Z")
-        path = _channel_path(ch, project_dir)
-        if not path.exists():
-            continue
-        for msg in _read_messages(path, since=since):
-            if msg.type == "directive" and (msg.to == aid or msg.to == "*"):
-                # Skip broadcast directives claimed by another agent
-                claimer = all_claims.get(msg.id)
-                if msg.to == "*" and claimer and claimer != aid:
-                    continue
-                pending.append((ch, msg))
+    try:
+        for ch in channels:
+            since = cursors.get(ch, "1970-01-01T00:00:00Z")
+            path = _channel_path(ch, project_dir)
+            if not path.exists():
+                continue
+            for msg in _read_messages(path, since=since):
+                if msg.type == "directive" and (msg.to == aid or msg.to == "*"):
+                    # Skip broadcast directives claimed by another agent
+                    claimer = all_claims.get(msg.id)
+                    if msg.to == "*" and claimer and claimer != aid:
+                        continue
+                    pending.append((ch, msg))
+                elif msg.type == "message" and mention_conn:
+                    # Check if this message @mentions us
+                    if _mentions_agent(msg.body, aid, mention_conn):
+                        pending.append((ch, msg))
+    finally:
+        if mention_conn:
+            conn3.close()
 
     if not pending:
         return ""
 
     # Format for output (will appear as system reminder in context)
-    lines = [f"[channel] {len(pending)} pending directive(s):"]
-    for ch, msg in pending:
-        lines.append(f"  #{ch} from {msg.from_agent}: {msg.body}")
-    return "\n".join(lines)
+    directives = [(ch, m) for ch, m in pending if m.type == "directive"]
+    mentions = [(ch, m) for ch, m in pending if m.type != "directive"]
+    parts = []
+    if directives:
+        parts.append(f"[channel] {len(directives)} pending directive(s):")
+        for ch, msg in directives:
+            parts.append(f"  #{ch} from {msg.from_agent}: {msg.body}")
+    if mentions:
+        parts.append(f"[channel] {len(mentions)} @mention(s):")
+        for ch, msg in mentions:
+            parts.append(f"  #{ch} from {msg.from_agent}: {msg.body}")
+    return "\n".join(parts)

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -38,6 +38,7 @@ from synapt.recall.channel import (
     channel_claim,
     channel_unclaim,
     is_claimed,
+    extract_mentions,
     check_directives,
 )
 
@@ -1655,6 +1656,55 @@ class TestChannelSearch(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertIn("type", results[0])
         self.assertEqual(results[0]["type"], "message")
+
+
+class TestMentions(unittest.TestCase):
+    """Tests for @mention parsing and notification (#153)."""
+
+    def test_extract_mentions(self):
+        self.assertEqual(extract_mentions("hey @opus review this"), ["opus"])
+        self.assertEqual(extract_mentions("@apollo @opus both look"), ["apollo", "opus"])
+        self.assertEqual(extract_mentions("no mentions here"), [])
+        self.assertEqual(extract_mentions("email@test.com"), ["test.com"])
+
+    def test_mention_surfaces_in_check_directives(self):
+        """Messages with @mention show up in check_directives."""
+        tmpdir = tempfile.mkdtemp()
+        patcher = _patch_data_dir(tmpdir)
+        patcher.start()
+        try:
+            channel_join("dev", agent_name="s_agent1")
+            channel_rename("apollo", agent_name="s_agent1")
+            channel_join("dev", agent_name="s_agent2")
+            # Both read to set cursors
+            channel_read("dev", agent_name="s_agent1")
+            channel_read("dev", agent_name="s_agent2")
+            # Agent2 posts mentioning agent1 by display name
+            channel_post("dev", "hey @apollo review my PR", agent_name="s_agent2")
+            result = check_directives(agent_name="s_agent1")
+            self.assertIn("@mention", result)
+            self.assertIn("review my PR", result)
+        finally:
+            patcher.stop()
+
+    def test_non_mentioned_agent_doesnt_see_it(self):
+        """Agent not @mentioned doesn't get notified."""
+        tmpdir = tempfile.mkdtemp()
+        patcher = _patch_data_dir(tmpdir)
+        patcher.start()
+        try:
+            channel_join("dev", agent_name="s_agent1")
+            channel_rename("apollo", agent_name="s_agent1")
+            channel_join("dev", agent_name="s_agent2")
+            channel_rename("opus", agent_name="s_agent2")
+            channel_join("dev", agent_name="s_agent3")
+            channel_read("dev", agent_name="s_agent3")
+            channel_post("dev", "hey @apollo review this", agent_name="s_agent2")
+            # agent3 is not mentioned
+            result = check_directives(agent_name="s_agent3")
+            self.assertEqual(result, "")
+        finally:
+            patcher.stop()
 
 
 class TestCheckDirectives(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Parse @name from message bodies, resolve against presence DB
- Surface @mentions in check_directives alongside directives
- Matches display_name, griptree, griptree suffix, and agent_id

## Test plan
- [x] 3 tests (extraction, mention notification, non-mentioned skip)
- [x] Full suite: 1381 passed

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)