### PR TITLE
feat: persist working memory across sessions

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -879,9 +879,11 @@ class TranscriptIndex:
         self._query_cache: dict[tuple, str] = {}
         self._query_cache_max = 32
 
-        # Working memory (session-scoped, in-memory LRU)
+        # Working memory — seeded from recent access_log for cross-session persistence
         from synapt.recall.working_memory import WorkingMemory
         self._working_memory = WorkingMemory()
+        if db is not None:
+            self._working_memory.seed_from_db(db)
 
         # Current session ID (set by MCP server for access tracking)
         self._current_session_id: str = ""

--- a/src/synapt/recall/working_memory.py
+++ b/src/synapt/recall/working_memory.py
@@ -1,11 +1,11 @@
-"""Session-scoped working memory for recall search.
+"""Working memory for recall search — with cross-session persistence.
 
 A small in-memory LRU buffer of recently accessed items. Items in
 working memory get a relevance boost in search results — mimicking how
 human working memory keeps recently-used context readily available.
 
-Not persisted — resets when the MCP server restarts, like human working
-memory clears on sleep.
+On startup, seeds from the access_log DB table so frequently accessed
+topics from recent sessions carry forward with natural decay.
 """
 
 from __future__ import annotations
@@ -110,6 +110,59 @@ class WorkingMemory:
         if slot.access_count >= 3:
             return base_score * 2.0
         return base_score * 1.5
+
+    def seed_from_db(self, db, days: int = 7) -> int:
+        """Seed working memory from recent access_log entries.
+
+        Loads the most frequently accessed items from the last N days
+        and pre-populates working memory slots. This gives cross-session
+        persistence — topics you searched for yesterday still get a mild
+        boost today, with natural decay via the LRU eviction.
+
+        Args:
+            db: RecallDB instance with access_log table.
+            days: How many days of history to consider (default: 7).
+
+        Returns:
+            Number of slots seeded.
+        """
+        if db is None:
+            return 0
+
+        try:
+            from datetime import datetime, timedelta, timezone
+            cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+            # Get top accessed items by frequency in the last N days
+            rows = db._conn.execute(
+                "SELECT item_type, item_id, COUNT(*) as cnt, "
+                "  MAX(query) as last_query "
+                "FROM access_log "
+                "WHERE created_at > ? "
+                "GROUP BY item_type, item_id "
+                "ORDER BY cnt DESC "
+                "LIMIT ?",
+                (cutoff, MAX_SLOTS),
+            ).fetchall()
+
+            seeded = 0
+            for row in rows:
+                item_id = row["item_id"]
+                if item_id in self._slots:
+                    continue  # Already populated (e.g., from current session)
+                self._access_seq += 1
+                self._slots[item_id] = WorkingMemorySlot(
+                    item_type=row["item_type"],
+                    item_id=item_id,
+                    content_preview=row["last_query"][:200] if row["last_query"] else "",
+                    tokens=_tokenize(row["last_query"] or ""),
+                    last_accessed=self._access_seq,
+                    access_count=row["cnt"],
+                )
+                seeded += 1
+            return seeded
+        except Exception:
+            return 0
 
     def __len__(self) -> int:
         return len(self._slots)


### PR DESCRIPTION
## Summary

Working memory now carries forward across sessions. On startup, seeds from the access_log DB table — frequently accessed topics from recent sessions get a mild relevance boost.

- `WorkingMemory.seed_from_db(db, days=7)` queries top accessed items from last 7 days
- Pre-populates LRU slots with access counts from the DB
- Called in `TranscriptIndex.__init__` when a DB is available
- Natural decay via LRU eviction and the 7-day window
- Backward compatible — seed_from_db is a no-op with no DB or empty access_log

## Why

Layne's insight: "human memory accesses reinforce memory in a way that lasts." Our access_log already tracks this data — we just weren't using it across sessions. Topics you searched for yesterday now get a mild boost today.

Closes #168

## Test plan
- [x] 1387 tests pass (existing working_memory tests + full suite)
- [x] seed_from_db handles empty DB gracefully
- [x] No regression on existing in-session working memory behavior

Generated with [Claude Code](https://claude.com/claude-code)