### PR TITLE
feat: split_monolithic_db migration (#89 Phase 3)

### DIFF
--- a/src/synapt/recall/sharding.py
+++ b/src/synapt/recall/sharding.py
@@ -144,6 +144,118 @@ _DATA_TABLES = frozenset({
 })
 
 
+def split_monolithic_db(
+    index_dir: Path,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Split a monolithic recall.db into index.db + quarterly data shards.
+
+    Creates:
+      - index.db: knowledge, clusters, metadata, access tracking
+      - data_YYYY_qN.db: chunks grouped by quarter
+
+    Args:
+        index_dir: Directory containing recall.db.
+        dry_run: If True, only returns the split plan without writing.
+
+    Returns:
+        Dict mapping shard name to chunk count (including "index.db": 0).
+
+    Raises:
+        FileNotFoundError: If recall.db doesn't exist.
+        RuntimeError: If already sharded.
+    """
+    db_path = index_dir / "recall.db"
+    if not db_path.exists():
+        raise FileNotFoundError(f"No recall.db found at {index_dir}")
+    if is_sharded(index_dir):
+        raise RuntimeError(f"Already sharded at {index_dir}")
+
+    # Plan the split
+    if dry_run:
+        plan = estimate_split(db_path)
+        plan["index.db"] = 0
+        return plan
+
+    plan: dict[str, int] = {"index.db": 0}
+
+    src = sqlite3.connect(str(db_path))
+    src.row_factory = sqlite3.Row
+    try:
+        # Step 1: Create index.db with non-chunk tables
+        idx_path = index_dir / "index.db"
+        idx = sqlite3.connect(str(idx_path))
+        idx.execute("PRAGMA journal_mode=WAL")
+        idx.execute(f"ATTACH DATABASE '{db_path}' AS src")
+        try:
+            # Copy schema + data for index tables (skip FTS virtual tables —
+            # they'll be recreated by RecallDB.__init__ on first open)
+            for table_info in src.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name"
+            ).fetchall():
+                tname = table_info["name"]
+                tsql = table_info["sql"]
+                if tname in _INDEX_TABLES and tsql and not tname.endswith(("_data", "_idx", "_docsize", "_config")):
+                    idx.execute(tsql)
+                    idx.execute(f"INSERT INTO [{tname}] SELECT * FROM src.[{tname}]")
+            # Copy indexes
+            for idx_info in src.execute(
+                "SELECT sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL"
+            ).fetchall():
+                try:
+                    idx.execute(idx_info["sql"])
+                except sqlite3.OperationalError:
+                    pass  # Index for table not in index.db
+            idx.commit()
+        finally:
+            idx.execute("DETACH DATABASE src")
+            idx.close()
+
+        # Step 2: Create data shards grouped by quarter
+        chunks_by_quarter: dict[str, list[sqlite3.Row]] = {}
+        for row in src.execute("SELECT * FROM chunks ORDER BY timestamp"):
+            q = quarter_for_timestamp(row["timestamp"])
+            chunks_by_quarter.setdefault(q, []).append(row)
+
+        col_names = [desc[0] for desc in src.execute("SELECT * FROM chunks LIMIT 0").description]
+
+        for quarter, rows in chunks_by_quarter.items():
+            shard_path = index_dir / shard_name(quarter)
+            shard = sqlite3.connect(str(shard_path))
+            shard.execute("PRAGMA journal_mode=WAL")
+            try:
+                # Create chunks table with same schema
+                chunks_sql = src.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='chunks'"
+                ).fetchone()["sql"]
+                shard.execute(chunks_sql)
+
+                # Insert chunks
+                placeholders = ",".join("?" for _ in col_names)
+                for row in rows:
+                    shard.execute(
+                        f"INSERT INTO chunks ({','.join(col_names)}) VALUES ({placeholders})",
+                        tuple(row[c] for c in col_names),
+                    )
+                shard.commit()
+            finally:
+                shard.close()
+            plan[shard_name(quarter)] = len(rows)
+
+        # Step 3: Validate total chunk count
+        original_count = src.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        split_count = sum(v for k, v in plan.items() if k != "index.db")
+        if split_count != original_count:
+            raise RuntimeError(
+                f"Chunk count mismatch: original={original_count}, split={split_count}"
+            )
+
+    finally:
+        src.close()
+
+    return plan
+
+
 def is_sharded(index_dir: Path) -> bool:
     """Check if an index directory uses the sharded layout.
 

--- a/tests/recall/test_sharding.py
+++ b/tests/recall/test_sharding.py
@@ -12,6 +12,7 @@ from synapt.recall.sharding import (
     group_chunks_by_quarter,
     estimate_split,
     is_sharded,
+    split_monolithic_db,
 )
 
 
@@ -137,6 +138,85 @@ class TestIsSharded(unittest.TestCase):
         (d / "index.db").touch()
         (d / "data_2025_q1.db").touch()
         self.assertTrue(is_sharded(d))
+
+
+class TestSplitMonolithicDb(unittest.TestCase):
+    """Test the migration from monolithic to sharded layout."""
+
+    def _create_monolithic(self, tmpdir):
+        """Create a minimal monolithic recall.db with test data."""
+        from synapt.recall.storage import RecallDB
+        db = RecallDB(Path(tmpdir) / "recall.db")
+        # Insert some knowledge
+        db._conn.execute(
+            "INSERT INTO knowledge (id, content, category, confidence, status, "
+            "source_sessions, source_turns, source_offsets, created_at, updated_at, "
+            "superseded_by, contradiction_note, tags, valid_from, valid_until, version, lineage_id) "
+            "VALUES ('k1', 'test fact', 'workflow', 0.8, 'active', '[]', '[]', '[]', "
+            "'2025-01-01', '2025-01-01', '', '', '', NULL, NULL, 1, '')"
+        )
+        # Insert chunks across two quarters
+        for i, ts in enumerate([
+            "2025-01-10T10:00:00Z", "2025-02-15T10:00:00Z",  # Q1
+            "2025-04-05T10:00:00Z",  # Q2
+        ]):
+            db._conn.execute(
+                "INSERT INTO chunks (id, session_id, timestamp, turn_index, user_text, "
+                "assistant_text, tools_used, files_touched, tool_content, transcript_path, "
+                "byte_offset, byte_length) "
+                f"VALUES ('c{i}', 's1', '{ts}', {i}, 'user', 'assistant', '[]', '[]', '', '', 0, 0)"
+            )
+        db._conn.commit()
+        db.close()
+
+    def test_split_creates_index_and_shards(self):
+        tmpdir = tempfile.mkdtemp()
+        self._create_monolithic(tmpdir)
+        d = Path(tmpdir)
+
+        plan = split_monolithic_db(d)
+
+        self.assertIn("index.db", plan)
+        self.assertTrue((d / "index.db").exists())
+        self.assertTrue((d / "data_2025_q1.db").exists())
+        self.assertTrue((d / "data_2025_q2.db").exists())
+        self.assertEqual(plan["data_2025_q1.db"], 2)
+        self.assertEqual(plan["data_2025_q2.db"], 1)
+
+    def test_split_preserves_knowledge_in_index(self):
+        tmpdir = tempfile.mkdtemp()
+        self._create_monolithic(tmpdir)
+        d = Path(tmpdir)
+        split_monolithic_db(d)
+
+        conn = sqlite3.connect(str(d / "index.db"))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM knowledge WHERE id = 'k1'").fetchone()
+        conn.close()
+        self.assertIsNotNone(row)
+        self.assertEqual(row["content"], "test fact")
+
+    def test_dry_run_doesnt_write(self):
+        tmpdir = tempfile.mkdtemp()
+        self._create_monolithic(tmpdir)
+        d = Path(tmpdir)
+
+        plan = split_monolithic_db(d, dry_run=True)
+        self.assertIn("2025_q1", plan)
+        self.assertFalse((d / "index.db").exists())
+
+    def test_already_sharded_raises(self):
+        tmpdir = tempfile.mkdtemp()
+        d = Path(tmpdir)
+        (d / "index.db").touch()
+        (d / "recall.db").touch()
+        with self.assertRaises(RuntimeError):
+            split_monolithic_db(d)
+
+    def test_no_recall_db_raises(self):
+        tmpdir = tempfile.mkdtemp()
+        with self.assertRaises(FileNotFoundError):
+            split_monolithic_db(Path(tmpdir))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Migration function that splits monolithic recall.db into index.db + quarterly data shards. Uses ATTACH DATABASE for efficient cross-DB copying.

## What this completes
With this PR, #89 has all the pieces:
- Phase 1: sharding utilities + ShardedRecallDB wrapper (#151, #152)
- Phase 2: wired into TranscriptIndex.load (#163)
- **Phase 3: migration function (this PR)**

## Test plan
- [x] 5 new tests (creates shards, preserves knowledge, dry run, error cases)
- [x] Full suite: 1400 passed

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)