### PR TITLE
feat: show version in recall_stats

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -541,6 +541,7 @@ def recall_stats() -> str:
             pass
 
         lines = [
+            f"synapt v{_STARTUP_VERSION}",
             f"Chunks: {stats.get('chunk_count', 0)}",
             f"Sessions: {stats.get('session_count', 0)}",
             f"Avg chunks/session: {stats.get('avg_chunks_per_session', 0):.1f}",


### PR DESCRIPTION
One-liner: adds `synapt v{version}` as the first line of recall_stats output.

Now agents can check what version the MCP server is running without needing a separate tool.

Generated with [Claude Code](https://claude.com/claude-code)