### PR TITLE
fix: split_monolithic_db rollback on failure (#189)

### DIFF
--- a/src/synapt/recall/sharding.py
+++ b/src/synapt/recall/sharding.py
@@ -179,11 +179,18 @@ def split_monolithic_db(
 
     plan: dict[str, int] = {"index.db": 0}
 
+    # Write to a temp directory first, then move into place on success.
+    # On failure, clean up temp dir — original recall.db is untouched.
+    import shutil
+    import tempfile
+
+    tmp_dir = Path(tempfile.mkdtemp(dir=index_dir, prefix=".split_tmp_"))
+
     src = sqlite3.connect(str(db_path))
     src.row_factory = sqlite3.Row
     try:
         # Step 1: Create index.db with non-chunk tables
-        idx_path = index_dir / "index.db"
+        idx_path = tmp_dir / "index.db"
         idx = sqlite3.connect(str(idx_path))
         idx.execute("PRAGMA journal_mode=WAL")
         idx.execute(f"ATTACH DATABASE '{db_path}' AS src")
@@ -220,7 +227,7 @@ def split_monolithic_db(
         col_names = [desc[0] for desc in src.execute("SELECT * FROM chunks LIMIT 0").description]
 
         for quarter, rows in chunks_by_quarter.items():
-            shard_path = index_dir / shard_name(quarter)
+            shard_path = tmp_dir / shard_name(quarter)
             shard = sqlite3.connect(str(shard_path))
             shard.execute("PRAGMA journal_mode=WAL")
             try:
@@ -250,6 +257,15 @@ def split_monolithic_db(
                 f"Chunk count mismatch: original={original_count}, split={split_count}"
             )
 
+        # Step 4: Move validated files from temp dir to index dir
+        for f in tmp_dir.iterdir():
+            shutil.move(str(f), str(index_dir / f.name))
+        tmp_dir.rmdir()
+
+    except Exception:
+        # Clean up partial output on any failure
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
     finally:
         src.close()
 

--- a/tests/recall/test_sharding.py
+++ b/tests/recall/test_sharding.py
@@ -218,6 +218,33 @@ class TestSplitMonolithicDb(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             split_monolithic_db(Path(tmpdir))
 
+    def test_failure_cleans_up_temp_files(self):
+        """On failure, partial output is cleaned up — no stale shards left."""
+        tmpdir = tempfile.mkdtemp()
+        self._create_monolithic(tmpdir)
+        d = Path(tmpdir)
+
+        # Make quarter_for_timestamp raise after being called a few times
+        # to simulate a failure during shard creation
+        from unittest.mock import patch
+        real_qft = quarter_for_timestamp
+        call_count = [0]
+
+        def failing_qft(ts):
+            call_count[0] += 1
+            if call_count[0] > 2:
+                raise OSError("Simulated failure")
+            return real_qft(ts)
+
+        with patch("synapt.recall.sharding.quarter_for_timestamp", failing_qft):
+            with self.assertRaises(OSError):
+                split_monolithic_db(d)
+
+        # No partial output left — no index.db, no data shards, no temp dirs
+        self.assertFalse((d / "index.db").exists())
+        self.assertEqual(list(d.glob("data_*.db")), [])
+        self.assertEqual(list(d.glob(".split_tmp_*")), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Split writes to temp dir first, moves into place on success, cleans up on failure. Original recall.db is never modified.

## Test plan
- [x] New test: simulated failure verifies cleanup (no partial output)
- [x] Full suite: 1402 passed

Closes #189. Together with #191 (#188), unblocks #176 (CLI split command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)