### PR TITLE
feat: shard-aware incremental build (#177)

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -249,9 +249,15 @@ def _archive_and_build_locked(
     if not build_sources and source_dirs:
         build_sources = [source_dirs[0]]
 
-    # Step 3: Open or create SQLite database
+    # Step 3: Open or create SQLite database (shard-aware)
     index_dir.mkdir(parents=True, exist_ok=True)
-    db = RecallDB(index_dir / "recall.db")
+    from synapt.recall.sharding import is_sharded
+    if is_sharded(index_dir):
+        from synapt.recall.sharded_db import ShardedRecallDB
+        db = ShardedRecallDB.open(index_dir)
+        print(f"  Sharded layout: {db.shard_count} data shard(s)")
+    else:
+        db = RecallDB(index_dir / "recall.db")
 
     # Step 4: Load existing data for incremental builds
     incremental_manifest = None

--- a/src/synapt/recall/sharded_db.py
+++ b/src/synapt/recall/sharded_db.py
@@ -117,16 +117,37 @@ class ShardedRecallDB:
     def save_chunks(self, chunks: list["TranscriptChunk"]) -> None:  # noqa: F821
         """Save chunks to the appropriate database.
 
-        In monolithic mode, delegates directly. In sharded mode, raises
-        NotImplementedError — Phase 2 will route chunks to the correct
-        quarterly shard based on timestamp.
+        In monolithic mode, delegates directly to the single DB.
+        In sharded mode, groups chunks by quarter and saves each group
+        to the corresponding shard. New shards are created as needed.
         """
-        if self._data_dbs:
-            raise NotImplementedError(
-                "Sharded save_chunks not yet implemented. "
-                "Phase 2 will route chunks to quarterly shards by timestamp."
-            )
-        self._index.save_chunks(chunks)
+        if not self._data_dbs:
+            self._index.save_chunks(chunks)
+            return
+
+        # Group chunks by quarter
+        from synapt.recall.sharding import quarter_for_timestamp, shard_name
+
+        by_quarter: dict[str, list] = {}
+        for chunk in chunks:
+            q = quarter_for_timestamp(chunk.timestamp)
+            by_quarter.setdefault(q, []).append(chunk)
+
+        # Map existing shards by name
+        shard_map = {db._path.name: db for db in self._data_dbs}
+
+        for quarter, q_chunks in by_quarter.items():
+            s_name = shard_name(quarter)
+            if s_name in shard_map:
+                # Save to existing shard
+                shard_map[s_name].save_chunks(q_chunks)
+            else:
+                # Create new shard
+                shard_path = self._index._path.parent / s_name
+                new_db = RecallDB(shard_path)
+                new_db.save_chunks(q_chunks)
+                self._data_dbs.append(new_db)
+                shard_map[s_name] = new_db
 
     def fts_search(self, query: str, limit: int = 100, **kwargs) -> list[tuple]:
         """FTS search across all shards, merging results by score.

--- a/tests/recall/test_sharded_db.py
+++ b/tests/recall/test_sharded_db.py
@@ -101,13 +101,29 @@ class TestShardedRecallDBSharded(unittest.TestCase):
         self.assertEqual(db.shard_count, 3)
         db.close()
 
-    def test_save_chunks_raises_in_sharded_mode(self):
-        """Sharded save_chunks is not yet implemented (Phase 2)."""
+    def test_save_chunks_routes_to_correct_shard(self):
+        """Sharded save_chunks groups chunks by quarter."""
+        from synapt.recall.core import TranscriptChunk
         RecallDB(self.index_dir / "index.db").close()
         RecallDB(self.index_dir / "data_2025_q1.db").close()
         db = ShardedRecallDB.open(self.index_dir)
-        with self.assertRaises(NotImplementedError):
-            db.save_chunks([])
+        # Save a chunk for Q2 (new shard needed)
+        chunk = TranscriptChunk(
+            id="test:t0", session_id="s1", timestamp="2025-04-15T10:00:00Z",
+            turn_index=0, user_text="hello", assistant_text="hi",
+        )
+        db.save_chunks([chunk])
+        # New shard should exist
+        self.assertTrue((self.index_dir / "data_2025_q2.db").exists())
+        self.assertEqual(db.shard_count, 2)
+        db.close()
+
+    def test_save_chunks_empty_is_noop(self):
+        """Saving empty list to sharded DB doesn't crash."""
+        RecallDB(self.index_dir / "index.db").close()
+        RecallDB(self.index_dir / "data_2025_q1.db").close()
+        db = ShardedRecallDB.open(self.index_dir)
+        db.save_chunks([])
         db.close()
 
 


### PR DESCRIPTION
## Summary
Build pipeline now works correctly with sharded layout:
- Detects shards → uses ShardedRecallDB
- save_chunks routes by quarter, creates new shards on demand
- Old shards untouched during incremental builds

## Flow
```
synapt recall split          # split monolithic DB into shards
synapt recall build --incremental  # new chunks → current quarter's shard only
```

## Test plan
- [x] 2 new tests (shard routing, empty noop)
- [x] Full suite: 1403 passed

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)