### PR TITLE
feat: intent claiming for issue/PR dedup (#175)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1326,6 +1326,54 @@ def channel_unclaim(
         conn.close()
 
 
+def channel_claim_intent(
+    intent: str,
+    channel: str = "dev",
+    agent_name: str | None = None,
+    project_dir: Path | None = None,
+) -> tuple[bool, str]:
+    """Announce and claim an intent before creating an issue/PR.
+
+    Posts a ``[INTENT]`` message to the channel and claims it atomically.
+    Other agents should check for existing intents before duplicating.
+
+    Args:
+        intent: Description of what you're about to create (e.g.,
+                "filing issue for session-start perf fix").
+        channel: Channel to post in.
+
+    Returns:
+        (True, message) if intent claimed successfully.
+        (False, message) if someone else already claimed the same intent.
+    """
+    aid = agent_name or _agent_id(project_dir)
+    now = _now_iso()
+
+    # Check if anyone recently posted the same intent (dedup by content)
+    path = _channel_path(channel, project_dir)
+    if path.exists():
+        recent = _read_messages(path)
+        # Check last 20 messages for duplicate intents
+        for msg in recent[-20:]:
+            if msg.type == "intent" and msg.from_agent != aid:
+                if intent.lower() in msg.body.lower() or msg.body.lower() in intent.lower():
+                    claimer = _resolve_display_name_for(msg.from_agent, project_dir)
+                    return (False, f"Already claimed by {claimer}: {msg.body}")
+
+    # Post and claim
+    msg = ChannelMessage(
+        timestamp=now, from_agent=aid, channel=channel,
+        type="intent", body=intent,
+    )
+    _append_message(msg, project_dir)
+
+    # Auto-claim the intent message
+    channel_claim(msg.id, channel, agent_name=aid, project_dir=project_dir)
+
+    display = _resolve_display_name_for(aid, project_dir)
+    return (True, f"[INTENT] {display}: {intent}")
+
+
 def channel_list_channels(project_dir: Path | None = None) -> list[str]:
     """Return list of all channel names (from JSONL files)."""
     ch_dir = _channels_dir(project_dir)

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1550,10 +1550,18 @@ def recall_channel(
             from synapt.recall.channel import channel_unclaim
             return channel_unclaim(message_id=message)
 
+        if action == "intent":
+            if not message:
+                return "Error: message is required for 'intent' action (describe what you're about to create)."
+            from synapt.recall.channel import channel_claim_intent
+            ok, result = channel_claim_intent(intent=message, channel=channel)
+            return result
+
         return (
             f"Unknown action: {action}. Use 'join', 'leave', 'post', 'read', "
             f"'who', 'heartbeat', 'unread', 'pin', 'directive', 'mute', "
-            f"'unmute', 'kick', 'broadcast', 'list', 'search', 'rename', 'claim', or 'unclaim'."
+            f"'unmute', 'kick', 'broadcast', 'list', 'search', 'rename', "
+            f"'claim', 'unclaim', or 'intent'."
         )
     except Exception as exc:
         return f"Channel failed: {exc}"

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -37,6 +37,7 @@ from synapt.recall.channel import (
     channel_rename,
     channel_claim,
     channel_unclaim,
+    channel_claim_intent,
     is_claimed,
     check_directives,
 )
@@ -1458,6 +1459,41 @@ class TestClaim(unittest.TestCase):
         result = channel_unclaim(msg_id, agent_name="s_agent2")
         self.assertIn("Cannot unclaim", result)
         self.assertIsNotNone(is_claimed(msg_id))
+
+
+class TestClaimIntent(unittest.TestCase):
+    """Test intent claiming for issue/PR dedup (#175)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self.tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_first_intent_succeeds(self):
+        channel_join("dev", agent_name="s_agent1")
+        ok, msg = channel_claim_intent("filing issue for perf fix", agent_name="s_agent1")
+        self.assertTrue(ok)
+        self.assertIn("INTENT", msg)
+
+    def test_duplicate_intent_blocked(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_join("dev", agent_name="s_agent2")
+        ok1, _ = channel_claim_intent("filing issue for perf fix", agent_name="s_agent1")
+        self.assertTrue(ok1)
+        ok2, msg2 = channel_claim_intent("filing issue for perf fix", agent_name="s_agent2")
+        self.assertFalse(ok2)
+        self.assertIn("Already claimed", msg2)
+
+    def test_different_intents_both_succeed(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_join("dev", agent_name="s_agent2")
+        ok1, _ = channel_claim_intent("filing issue for perf fix", agent_name="s_agent1")
+        ok2, _ = channel_claim_intent("creating PR for auth feature", agent_name="s_agent2")
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
 
 
 class TestBroadcast(unittest.TestCase):


### PR DESCRIPTION
## Summary
`recall_channel(action="intent", message="filing issue for X")` — announce and claim what you're about to create. Blocks duplicate intents from other agents. Fixes the 5+ duplicates we had this session.

## Test plan
- [x] 3 tests (first succeeds, duplicate blocked, different intents ok)
- [x] Full suite: 1406 passed

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)