### PR TITLE
fix: graceful return when no transcripts exist

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -925,8 +925,7 @@ def cmd_archive(args: argparse.Namespace) -> None:
     project = Path.cwd().resolve()
     transcript_all = project_transcript_dirs(project)
     if not transcript_all:
-        print("No transcript directory found for this project.", file=sys.stderr)
-        sys.exit(1)
+        return  # New project, no transcripts yet — not an error
 
     total_copied: list[str] = []
     for transcript_dir in transcript_all:


### PR DESCRIPTION
SessionEnd hook was crashing with exit(1) when running from a new project with no Claude Code transcripts yet. Changed to a silent return — no transcripts is normal for first-time projects, not an error.

Generated with [Claude Code](https://claude.com/claude-code)