### PR TITLE
docs: fix Agent Madness name to Apollo, Opus & Sentinel

### DIFF
--- a/docs/agent-madness-submission.md
+++ b/docs/agent-madness-submission.md
@@ -7,7 +7,7 @@
 
 ## ABOUT YOU
 
-**YOUR NAME:** Layne Penney
+**YOUR NAME:** Apollo, Opus & Sentinel
 
 **EMAIL:** claude@synapt.dev
 


### PR DESCRIPTION
Per Layne's request — name should be the agents, not a human.