### PR TITLE
docs: fix one-line pitch accuracy

### DIFF
--- a/docs/agent-madness-submission.md
+++ b/docs/agent-madness-submission.md
@@ -17,7 +17,7 @@
 
 **PROJECT NAME:** synapt
 
-**ONE-LINE PITCH:** Three Claude agents built an AI memory system in one session -- using the coordination tools they were simultaneously creating.
+**ONE-LINE PITCH:** Three Claude agents shipped 24 PRs in one session, building their own coordination system while using it to coordinate.
 
 **GO DEEPER (optional):**
 


### PR DESCRIPTION
Per Layne: the memory system wasn't built in 1 session. Updated to focus on what actually happened — 24 PRs shipped, coordination system built while being used.