### PR TITLE
feat: grep -C context expansion for recall_search (#429)

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1544,7 +1544,7 @@ class TranscriptIndex:
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=_knowledge_boost,
                 now=now, max_knowledge=max_knowledge,
-                intent=intent, min_confidence=min_confidence,
+                intent=intent, min_confidence=min_confidence, context=context,
             )
 
         # Cache the result (LRU eviction when full)
@@ -1573,6 +1573,7 @@ class TranscriptIndex:
         max_knowledge: int | None = None,
         intent: str = "",
         min_confidence: float = 0.0,
+        context: int = 0,
     ) -> str:
         """Score all chunks globally, return top-K."""
         if self._db and self._rowid_to_idx:
@@ -1582,7 +1583,7 @@ class TranscriptIndex:
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=knowledge_boost,
                 now=now, max_knowledge=max_knowledge, intent=intent,
-                min_confidence=min_confidence,
+                min_confidence=min_confidence, context=context,
             )
         return self._global_lookup_bm25(
             query, query_tokens, max_chunks, max_tokens, date_filter,
@@ -1607,6 +1608,7 @@ class TranscriptIndex:
         max_knowledge: int | None = None,
         intent: str = "",
         min_confidence: float = 0.0,
+        context: int = 0,
     ) -> str:
         """Global lookup using FTS5 (SQLite backend)."""
         # Extract entities once and share across knowledge + FTS search
@@ -1815,6 +1817,32 @@ class TranscriptIndex:
 
         # Pass extra candidates to _format_results to compensate for
         # near-duplicate filtering — the token budget is the real limiter.
+        # Context expansion (grep -C): for each matched chunk, also include
+        # surrounding chunks from the same session.
+        if context > 0:
+            expanded = []
+            seen = set()
+            for idx, score in top:
+                if idx >= len(self.chunks):
+                    continue
+                chunk = self.chunks[idx]
+                sid = chunk.session_id
+                ti = chunk.turn_index
+                # Add surrounding turns from same session
+                for offset in range(-context, context + 1):
+                    target_ti = ti + offset
+                    if target_ti < 0:
+                        continue
+                    # Find chunk with matching session_id and turn_index
+                    for ci, c in enumerate(self.chunks):
+                        if c.session_id == sid and c.turn_index == target_ti and ci not in seen:
+                            # Context chunks get the matched chunk's score (discounted)
+                            ctx_score = score if offset == 0 else score * 0.5
+                            expanded.append((ci, ctx_score))
+                            seen.add(ci)
+                            break
+            top = expanded
+
         dedup_headroom = _dedup_limit(max_chunks)
         return self._format_results(
             top[:dedup_headroom], max_tokens,

--- a/tests/recall/test_supersession.py
+++ b/tests/recall/test_supersession.py
@@ -406,7 +406,7 @@ class TestFormatKnowledgeBlock:
     def test_active_node_normal_format(self):
         node = _make_knowledge_node(confidence=0.8, category="architecture")
         block = TranscriptIndex._format_knowledge_block(node)
-        assert "[knowledge] architecture (high confidence)" in block
+        assert "[knowledge] architecture (high" in block
         assert "historical" not in block
 
     def test_contradicted_node_historical_label(self):
@@ -415,8 +415,8 @@ class TestFormatKnowledgeBlock:
             contradiction_note="replaced by newer approach",
         )
         block = TranscriptIndex._format_knowledge_block(node)
-        assert "[knowledge, historical]" in block
-        assert "Superseded: replaced by newer approach" in block
+        assert "CONTRADICTED" in block
+        assert "replaced by newer approach" in block
 
     def test_valid_from_only(self):
         node = _make_knowledge_node(valid_from="2026-01-15T00:00:00+00:00")
@@ -435,17 +435,17 @@ class TestFormatKnowledgeBlock:
         high = TranscriptIndex._format_knowledge_block(
             _make_knowledge_node(confidence=0.8)
         )
-        assert "high confidence" in high
+        assert "(high" in high
 
         medium = TranscriptIndex._format_knowledge_block(
             _make_knowledge_node(confidence=0.5)
         )
-        assert "medium confidence" in medium
+        assert "(medium" in medium
 
         low = TranscriptIndex._format_knowledge_block(
             _make_knowledge_node(confidence=0.2)
         )
-        assert "low confidence" in low
+        assert "(low" in low
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements the context expansion logic for the `context` parameter added in #212:

```python
recall_search("deploy schedule", context=2)  # matching chunk + 2 before/after
```

For each matched chunk, fetches N surrounding chunks from the same session by turn_index. Context chunks get 50% of the matched chunk's score to maintain relevance ordering.

Also fixes test assertions for #211 freshness label changes.

## Test plan
- [x] 1406 passed

Completes #429 (grep-style search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)