### PR TITLE
chore: bump version to 0.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.7.3"
+version = "0.7.4"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
## Summary
- Bump version 0.7.3 → 0.7.4
- Covers: size-based sharding (#219), push-style notifications (#220), three owls hero (#208)

## Test plan
- [ ] `pip install -e .` succeeds
- [ ] `synapt --version` shows 0.7.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)