### PR TITLE
fix: linked griptrees resolve to parent gripspace (#234)

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3569,15 +3569,17 @@ def _find_gripspace_root(path: Path) -> Path | None:
     while current != current.parent:
         gitgrip = current / ".gitgrip"
         if gitgrip.is_dir():
-            # Gripspace root has griptrees.json (plural)
-            if (gitgrip / "griptrees.json").exists():
-                _gripspace_cache[cache_key] = (current, time.monotonic())
-                return current
-            # Linked griptree has griptree.json (singular) — resolve to parent
+            # Linked griptree has griptree.json (singular) — always resolve
+            # to parent gripspace, even if griptrees.json also exists (which
+            # happens when `gr` clones the full directory structure).
             if (gitgrip / "griptree.json").exists():
                 root = _resolve_griptree_parent(current)
                 _gripspace_cache[cache_key] = (root, time.monotonic())
                 return root
+            # Gripspace root has only griptrees.json (plural), no singular
+            if (gitgrip / "griptrees.json").exists():
+                _gripspace_cache[cache_key] = (current, time.monotonic())
+                return current
         # Don't walk above $HOME
         if current == home:
             break


### PR DESCRIPTION
## Summary
- Linked griptrees with both `griptree.json` and `griptrees.json` were misidentified as independent gripspaces
- Fix: check `griptree.json` (singular) FIRST — if present, always resolve to parent
- This was causing agents in linked griptrees to read/write separate channel files

## Root cause
`gr` copies both files when creating linked griptrees. `_find_gripspace_root()` checked `griptrees.json` first, so it returned the local path instead of walking up to the parent.

## Verified
- `synapt-global` now resolves to `/Users/layne/Development/synapt`
- `synapt-codex` now resolves to `/Users/layne/Development/synapt`
- 987 tests pass (1 pre-existing ONNX failure)

## Test plan
- [ ] Start agents in linked griptrees, verify they join the same #dev channel
- [ ] Verify `project_data_dir()` returns the gripspace root from any griptree

🤖 Generated with [Claude Code](https://claude.com/claude-code)