### PR TITLE
feat: tag working-memory-boosted search results

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -2616,6 +2616,17 @@ class TranscriptIndex:
             f"{summary}{extra}. Review with "
             "`recall_contradict(action=\"list\")`.]"
         )
+
+    @staticmethod
+    def _annotate_boosted_block(block: str, label: str) -> str:
+        """Append a boost label to the first line of a rendered result block."""
+        if not block:
+            return block
+        lines = block.splitlines()
+        if not lines:
+            return block
+        lines[0] = f"{lines[0]} [{label}]"
+        return "\n".join(lines)
     def _format_results(
         self,
         ranked: list[tuple[int, float]],
@@ -2798,10 +2809,16 @@ class TranscriptIndex:
             top_unboosted = max(s for s, _, _, _ in emit_items)
             boost_ceiling = top_unboosted * 0.95  # never exceed 95% of top score
             for i, (score, block, item_type, item_id) in enumerate(emit_items):
+                wm_multiplier = wm.boost_multiplier(item_id)
                 boosted = wm.boost_score(score, item_id)
                 boosted = self._access_frequency_boost(boosted, item_type, item_id)
                 if boosted != score:
                     boosted = min(boosted, max(score, boost_ceiling))
+                    if boosted != score and wm_multiplier > 1.0:
+                        block = self._annotate_boosted_block(
+                            block,
+                            f"boosted: working-memory {wm_multiplier:.1f}x",
+                        )
                     emit_items[i] = (boosted, block, item_type, item_id)
 
         # Sort by score descending (highest relevance first)

--- a/src/synapt/recall/working_memory.py
+++ b/src/synapt/recall/working_memory.py
@@ -98,18 +98,18 @@ class WorkingMemory:
         scored.sort(key=lambda x: x[0], reverse=True)
         return [slot for _, slot in scored[:max_results]]
 
-    def boost_score(self, base_score: float, item_id: str) -> float:
-        """Apply working memory boost to a search result score.
-
-        Items in working memory: 1.5x.
-        Items accessed 3+ times this session: 2.0x.
-        """
+    def boost_multiplier(self, item_id: str) -> float:
+        """Return the working-memory multiplier for an item."""
         slot = self._slots.get(item_id)
         if slot is None:
-            return base_score
+            return 1.0
         if slot.access_count >= 3:
-            return base_score * 2.0
-        return base_score * 1.5
+            return 2.0
+        return 1.5
+
+    def boost_score(self, base_score: float, item_id: str) -> float:
+        """Apply working memory boost to a search result score."""
+        return base_score * self.boost_multiplier(item_id)
 
     def seed_from_db(self, db, days: int = 7) -> int:
         """Seed working memory from recent access_log entries.

--- a/tests/recall/test_working_memory.py
+++ b/tests/recall/test_working_memory.py
@@ -2,6 +2,7 @@
 
 import time
 
+from synapt.recall.core import TranscriptChunk, TranscriptIndex
 from synapt.recall.working_memory import WorkingMemory, WorkingMemorySlot, MAX_SLOTS
 
 
@@ -112,3 +113,40 @@ class TestWorkingMemory:
         wm.record("chunk", "s1:t0", "content")
         assert len(wm) == 1
         assert "s1:t0" in wm
+
+
+def _chunk(id: str, user: str = "", assistant: str = "") -> TranscriptChunk:
+    return TranscriptChunk(
+        id=id,
+        session_id="sess-1",
+        timestamp="2026-03-20T09:00:00Z",
+        turn_index=0,
+        user_text=user,
+        assistant_text=assistant,
+    )
+
+
+class TestWorkingMemoryResultFormatting:
+    def test_format_results_tags_working_memory_boost(self):
+        idx = TranscriptIndex([
+            _chunk("sess-1:t0", user="Show the strongest result", assistant="Top unboosted result."),
+            _chunk("sess-1:t1", user="What drink do I prefer?", assistant="You prefer tea."),
+        ])
+        idx._working_memory.record("chunk", "sess-1:t1", "You prefer tea.")
+
+        result = idx._format_results([(0, 10.0), (1, 7.0)], max_tokens=2000)
+
+        assert "[boosted: working-memory 1.5x]" in result
+
+    def test_format_results_tags_frequent_working_memory_boost(self):
+        idx = TranscriptIndex([
+            _chunk("sess-1:t0", user="Show the strongest result", assistant="Top unboosted result."),
+            _chunk("sess-1:t1", user="What drink do I prefer?", assistant="You prefer tea."),
+        ])
+        idx._working_memory.record("chunk", "sess-1:t1", "You prefer tea.")
+        idx._working_memory.record("chunk", "sess-1:t1", "You prefer tea.")
+        idx._working_memory.record("chunk", "sess-1:t1", "You prefer tea.")
+
+        result = idx._format_results([(0, 10.0), (1, 7.0)], max_tokens=2000)
+
+        assert "[boosted: working-memory 2.0x]" in result


### PR DESCRIPTION
## Summary
- expose working-memory influence directly in recall search output by tagging result headers when a returned item received a working-memory multiplier that actually survived the ranking ceiling
- factor the multiplier logic into `WorkingMemory.boost_multiplier()` so the scoring path and the display path use the same source of truth
- add focused tests covering both the 1.5x and 2.0x visible-tag cases

## Notes
- This is a first observability pass for #437. It makes boosts visible in normal search results without adding a separate debug UI yet.
- The tag only appears when the boost has a real effect after the existing ceiling cap, so top-ranked items that get capped back to their original score stay untagged.

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts= tests/recall/test_working_memory.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/core.py src/synapt/recall/working_memory.py`