### PR TITLE
feat: surface co-retrieval contradiction notices

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -873,6 +873,7 @@ class TranscriptIndex:
 
         # Search diagnostics (populated on empty results for caller inspection)
         self._last_diagnostics: SearchDiagnostics | None = None
+        self._last_conflicts: list[tuple[dict, dict]] = []
 
         # Query result cache — avoids re-computing BM25/embedding/RRF for
         # identical queries within the same index lifetime. LRU with max 32 entries.
@@ -2595,6 +2596,26 @@ class TranscriptIndex:
         meta_line = f"[{'. '.join(meta_parts)}]" if meta_parts else ""
         return f"{header}\n{content}\n{meta_line}" if meta_line else f"{header}\n{content}"
 
+    def _format_conflict_notice(self) -> str:
+        """Render a short user-facing notice for co-retrieval contradictions."""
+        if not self._last_conflicts:
+            return ""
+
+        previews: list[str] = []
+        for old, new in self._last_conflicts[:2]:
+            old_text = (old.get("content", "") or old.get("id", "unknown"))[:50]
+            new_text = (new.get("content", "") or new.get("id", "unknown"))[:50]
+            previews.append(f'"{old_text}" vs "{new_text}"')
+
+        summary = "; ".join(previews)
+        extra = ""
+        if len(self._last_conflicts) > 2:
+            extra = f" (+{len(self._last_conflicts) - 2} more)"
+        return (
+            "[Potential contradiction detected in retrieved knowledge: "
+            f"{summary}{extra}. Review with "
+            "`recall_contradict(action=\"list\")`.]"
+        )
     def _format_results(
         self,
         ranked: list[tuple[int, float]],
@@ -2911,6 +2932,10 @@ class TranscriptIndex:
             elif item["item_type"] == "knowledge":
                 content = knowledge_content.get(item["item_id"], "")
             wm.record(item["item_type"], item["item_id"], content)
+
+        conflict_notice = self._format_conflict_notice()
+        if conflict_notice:
+            lines.append(conflict_notice)
 
         if len(lines) <= 1:
             return ""

--- a/tests/recall/test_supersession.py
+++ b/tests/recall/test_supersession.py
@@ -1397,6 +1397,33 @@ class TestCoRetrievalConflictDetection:
         index.lookup("nonexistent query that matches nothing")
         assert index._last_conflicts == []
 
+    def test_format_results_surfaces_conflict_notice(self, tmp_path):
+        """Visible search output should surface detected knowledge conflicts."""
+        db = _make_db(tmp_path)
+        index = TranscriptIndex([], db=db)
+        old = _make_knowledge_node(
+            node_id="n1",
+            content="always use unittest for Python testing",
+            category="tooling",
+            confidence=0.7,
+        )
+        new = _make_knowledge_node(
+            node_id="n2",
+            content="prefer pytest with fixtures and markers",
+            category="tooling",
+            confidence=0.8,
+        )
+        index._last_conflicts = [(old, new)]
+
+        result = index._format_results(
+            [],
+            max_tokens=2000,
+            knowledge_results=[old, new],
+        )
+
+        assert "Potential contradiction detected in retrieved knowledge" in result
+        assert "recall_contradict(action=\"list\")" in result
+
     def test_has_pending_contradiction_for(self, tmp_path):
         """Test the storage dedup helper."""
         db = _make_db(tmp_path)


### PR DESCRIPTION
## Summary
- surface a short contradiction notice in recall search output when the existing co-retrieval conflict detector finds conflicting knowledge nodes
- point the user/agent directly at `recall_contradict(action="list")` so pending contradictions are easier to discover and review
- add a focused test that verifies the notice appears in formatted search results

## Notes
- This does not add a new contradiction detector. It only exposes the `_last_conflicts` signal that the search pipeline already computes and queues as pending contradictions.
- The notice is appended only when conflicts were actually detected during the current lookup.

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts= tests/recall/test_supersession.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/core.py`