### PR TITLE
feat: add portable recall archive import and export (#222)

### DIFF
--- a/src/synapt/recall/archive.py
+++ b/src/synapt/recall/archive.py
@@ -15,19 +15,626 @@ Data flow:
 from __future__ import annotations
 
 import copy
+import io
 import json
 import os
 import shutil
+import tarfile
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from synapt.recall.core import project_data_dir, project_archive_dir
+
+ARCHIVE_FORMAT_VERSION = "1"
+ARCHIVE_EXTENSION = ".synapt-archive"
+_ROOT_EXPORT_FILES = (
+    "config.json",
+    "dedup_decisions.jsonl",
+    "knowledge.jsonl",
+    "last_sync_time",
+    "reminders.json",
+    "upload_manifest.json",
+)
 
 
 def _data_dir(project_dir: Path) -> Path:
     """Resolve the synapt recall data directory for a project (shared root)."""
     return project_data_dir(project_dir)
+
+
+def _index_dir(project_dir: Path) -> Path:
+    """Return the recall index directory for *project_dir*."""
+    return _data_dir(project_dir) / "index"
+
+
+def _has_index(index_dir: Path) -> bool:
+    """True when *index_dir* contains a recall DB in any supported layout."""
+    return (index_dir / "recall.db").exists() or (index_dir / "index.db").exists()
+
+
+def _archive_output_path(project_dir: Path, output_path: Path | None) -> Path:
+    """Resolve the export destination path."""
+    if output_path is not None:
+        return output_path.expanduser().resolve()
+    return (project_dir / f"{project_dir.name}{ARCHIVE_EXTENSION}").resolve()
+
+
+def _json_dumps(obj: dict) -> bytes:
+    """Serialize JSON deterministically for archive metadata."""
+    return json.dumps(obj, indent=2, sort_keys=True).encode("utf-8")
+
+
+def _file_count(path: Path, pattern: str) -> int:
+    """Count files under *path* matching *pattern*."""
+    if not path.exists():
+        return 0
+    return sum(1 for _ in path.glob(pattern))
+
+
+def _top_level_export_paths(data_dir: Path) -> list[Path]:
+    """Return exportable root-level state files."""
+    return [data_dir / name for name in _ROOT_EXPORT_FILES if (data_dir / name).is_file()]
+
+
+def _iter_export_paths(
+    data_dir: Path,
+    *,
+    include_transcripts: bool,
+    include_channels: bool,
+) -> list[tuple[Path, str]]:
+    """Return archive members as ``(absolute_path, archive_name)`` pairs."""
+    members: list[tuple[Path, str]] = []
+
+    index_dir = data_dir / "index"
+    if index_dir.is_dir():
+        for path in sorted(p for p in index_dir.rglob("*") if p.is_file()):
+            members.append((path, path.relative_to(data_dir).as_posix()))
+
+    if include_channels:
+        channels_dir = data_dir / "channels"
+        if channels_dir.is_dir():
+            for path in sorted(p for p in channels_dir.rglob("*") if p.is_file()):
+                members.append((path, path.relative_to(data_dir).as_posix()))
+
+    worktrees_root = data_dir / "worktrees"
+    if worktrees_root.is_dir():
+        for wt_dir in sorted(p for p in worktrees_root.iterdir() if p.is_dir()):
+            journal_path = wt_dir / "journal.jsonl"
+            if journal_path.is_file():
+                members.append((journal_path, journal_path.relative_to(data_dir).as_posix()))
+            transcript_dir = wt_dir / "transcripts"
+            if include_transcripts and transcript_dir.is_dir():
+                for path in sorted(p for p in transcript_dir.glob("*.jsonl") if p.is_file()):
+                    members.append((path, path.relative_to(data_dir).as_posix()))
+
+    for path in _top_level_export_paths(data_dir):
+        members.append((path, path.relative_to(data_dir).as_posix()))
+
+    members.sort(key=lambda item: item[1])
+    return members
+
+
+def _archive_manifest(
+    project_dir: Path,
+    *,
+    include_transcripts: bool,
+    include_channels: bool,
+) -> dict:
+    """Build manifest metadata for a portable recall archive."""
+    from synapt import __version__ as synapt_version
+    from synapt.recall.sharded_db import ShardedRecallDB
+
+    data_dir = _data_dir(project_dir)
+    index_dir = data_dir / "index"
+    worktrees_root = data_dir / "worktrees"
+
+    chunk_count = 0
+    knowledge_count = 0
+    shard_count = 0
+    is_sharded = False
+    if _has_index(index_dir):
+        db = ShardedRecallDB.open(index_dir)
+        try:
+            chunk_count = db.chunk_count()
+            knowledge_count = len(db.load_knowledge_nodes(status=None))
+            shard_count = db.shard_count
+            is_sharded = not db.is_monolithic
+        finally:
+            db.close()
+
+    transcripts_count = 0
+    journals_count = 0
+    worktree_names: list[str] = []
+    if worktrees_root.is_dir():
+        for wt_dir in sorted(p for p in worktrees_root.iterdir() if p.is_dir()):
+            worktree_names.append(wt_dir.name)
+            if (wt_dir / "journal.jsonl").exists():
+                journals_count += 1
+            if include_transcripts:
+                transcripts_count += _file_count(wt_dir / "transcripts", "*.jsonl")
+
+    channel_files = 0
+    if include_channels:
+        channel_files = _file_count(data_dir / "channels", "*.jsonl")
+
+    return {
+        "version": ARCHIVE_FORMAT_VERSION,
+        "synapt_version": synapt_version,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "source_project": project_dir.name,
+        "chunk_count": chunk_count,
+        "knowledge_count": knowledge_count,
+        "shard_count": shard_count,
+        "is_sharded": is_sharded,
+        "worktrees": worktree_names,
+        "worktree_count": len(worktree_names),
+        "transcript_count": transcripts_count,
+        "journal_count": journals_count,
+        "channel_file_count": channel_files,
+        "includes_transcripts": include_transcripts,
+        "includes_channels": include_channels,
+    }
+
+
+def _tar_add_bytes(tf: tarfile.TarFile, arcname: str, data: bytes) -> None:
+    """Add a bytes payload as a deterministic tar member."""
+    info = tarfile.TarInfo(arcname)
+    info.size = len(data)
+    info.mode = 0o644
+    info.mtime = 0
+    tf.addfile(info, io.BytesIO(data))
+
+
+def _tar_add_file(tf: tarfile.TarFile, path: Path, arcname: str) -> None:
+    """Add a file to the tar with deterministic metadata."""
+    info = tarfile.TarInfo(arcname)
+    stat = path.stat()
+    info.size = stat.st_size
+    info.mode = 0o644
+    info.mtime = 0
+    with open(path, "rb") as f:
+        tf.addfile(info, f)
+
+
+def export_recall_archive(
+    project_dir: Path,
+    output_path: Path | None = None,
+    *,
+    exclude_transcripts: bool = False,
+    exclude_channels: bool = False,
+) -> tuple[Path, dict]:
+    """Export portable recall state to a ``.synapt-archive`` tar.gz file."""
+    project_dir = project_dir.resolve()
+    data_dir = _data_dir(project_dir)
+    if not data_dir.exists():
+        raise FileNotFoundError(f"No recall data found at {data_dir}")
+
+    output_path = _archive_output_path(project_dir, output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    include_transcripts = not exclude_transcripts
+    include_channels = not exclude_channels
+    manifest = _archive_manifest(
+        project_dir,
+        include_transcripts=include_transcripts,
+        include_channels=include_channels,
+    )
+    members = _iter_export_paths(
+        data_dir,
+        include_transcripts=include_transcripts,
+        include_channels=include_channels,
+    )
+
+    with tarfile.open(output_path, "w:gz", format=tarfile.PAX_FORMAT) as tf:
+        _tar_add_bytes(tf, "manifest.json", _json_dumps(manifest))
+        for path, arcname in members:
+            _tar_add_file(tf, path, arcname)
+
+    return output_path, manifest
+
+
+def _load_archive_manifest(archive_path: Path) -> dict:
+    """Read and validate the manifest from a recall archive."""
+    with tarfile.open(archive_path, "r:*") as tf:
+        member = tf.getmember("manifest.json")
+        manifest_file = tf.extractfile(member)
+        if manifest_file is None:
+            raise ValueError("Archive manifest is missing")
+        manifest = json.loads(manifest_file.read().decode("utf-8"))
+    version = str(manifest.get("version", ""))
+    if version != ARCHIVE_FORMAT_VERSION:
+        raise ValueError(
+            f"Unsupported archive version {version!r}; expected {ARCHIVE_FORMAT_VERSION!r}"
+        )
+    return manifest
+
+
+def _safe_extract_archive(archive_path: Path, dest_dir: Path) -> None:
+    """Extract archive members under *dest_dir* with path traversal protection."""
+    root = dest_dir.resolve()
+    with tarfile.open(archive_path, "r:*") as tf:
+        for member in tf.getmembers():
+            if member.name == "manifest.json" or not member.isfile():
+                continue
+            target = (root / member.name).resolve()
+            if not str(target).startswith(str(root)):
+                raise ValueError(f"Unsafe archive member path: {member.name}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                continue
+            with open(target, "wb") as f:
+                shutil.copyfileobj(extracted, f)
+
+
+def _worktree_name_map(extracted_dir: Path, project_dir: Path) -> dict[str, str]:
+    """Map archived worktree names onto destination worktree names.
+
+    If the archive contains exactly one worktree and it differs from the
+    current worktree name, remap it to the current worktree so imported
+    transcripts/journal are immediately visible from the destination.
+    Multi-worktree archives preserve names verbatim.
+    """
+    from synapt.recall.core import _worktree_name
+
+    worktrees_root = extracted_dir / "worktrees"
+    if not worktrees_root.is_dir():
+        return {}
+
+    archived = sorted(p.name for p in worktrees_root.iterdir() if p.is_dir())
+    current = _worktree_name(project_dir)
+    if len(archived) == 1 and archived[0] != current:
+        return {archived[0]: current}
+    return {name: name for name in archived}
+
+
+def _copytree_contents(src: Path, dst: Path) -> None:
+    """Copy all contents from *src* into *dst*."""
+    dst.mkdir(parents=True, exist_ok=True)
+    for path in sorted(src.rglob("*")):
+        rel = path.relative_to(src)
+        target = dst / rel
+        if path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+
+
+def _merge_transcript_archives(src_dir: Path, dst_dir: Path) -> int:
+    """Merge transcript archive files with size-based dedup semantics."""
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    merged = 0
+    for src_file in sorted(src_dir.glob("*.jsonl")):
+        dst_file = dst_dir / src_file.name
+        src_size = src_file.stat().st_size
+        if dst_file.exists():
+            dst_size = dst_file.stat().st_size
+            if src_size == dst_size or src_size < dst_size:
+                continue
+        shutil.copy2(src_file, dst_file)
+        merged += 1
+    return merged
+
+
+def _merge_jsonl_lines(src_path: Path, dst_path: Path) -> int:
+    """Append unique raw JSONL lines from *src_path* into *dst_path*."""
+    if not src_path.exists():
+        return 0
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = set()
+    if dst_path.exists():
+        with open(dst_path, encoding="utf-8") as f:
+            existing = {line.rstrip("\n") for line in f if line.strip()}
+
+    added = 0
+    with open(dst_path, "a", encoding="utf-8") as out:
+        with open(src_path, encoding="utf-8") as src:
+            for line in src:
+                raw = line.rstrip("\n")
+                if not raw or raw in existing:
+                    continue
+                out.write(raw + "\n")
+                existing.add(raw)
+                added += 1
+    return added
+
+
+def _merge_reminders(src_path: Path, dst_path: Path) -> None:
+    """Merge reminder JSON arrays by reminder ID."""
+    try:
+        src_items = json.loads(src_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+
+    dst_items = []
+    if dst_path.exists():
+        try:
+            dst_items = json.loads(dst_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            dst_items = []
+
+    merged: dict[str, dict] = {}
+    for item in dst_items:
+        if isinstance(item, dict) and item.get("id"):
+            merged[item["id"]] = item
+    for item in src_items:
+        if isinstance(item, dict) and item.get("id"):
+            merged[item["id"]] = item
+
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    dst_path.write_text(
+        json.dumps(list(merged.values()), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _write_knowledge_jsonl(nodes: list[dict], path: Path) -> None:
+    """Rewrite ``knowledge.jsonl`` from deduplicated knowledge nodes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ordered = sorted(nodes, key=lambda n: (n.get("updated_at", ""), n.get("id", "")))
+    with open(path, "w", encoding="utf-8") as f:
+        for node in ordered:
+            f.write(json.dumps(node, sort_keys=True) + "\n")
+
+
+def _merge_knowledge_nodes(local_nodes: list[dict], imported_nodes: list[dict]) -> list[dict]:
+    """Merge knowledge nodes by ID, keeping the newest version."""
+    merged: dict[str, dict] = {}
+    for node in local_nodes:
+        if node.get("id"):
+            merged[node["id"]] = node
+    for node in imported_nodes:
+        node_id = node.get("id")
+        if not node_id:
+            continue
+        existing = merged.get(node_id)
+        if existing is None or node.get("updated_at", "") >= existing.get("updated_at", ""):
+            merged[node_id] = node
+    return list(merged.values())
+
+
+def _merge_chunks(local_chunks, imported_chunks):
+    """Merge transcript chunks by stable chunk ID."""
+    merged: dict[str, object] = {}
+    for chunk in local_chunks:
+        merged[chunk.id] = chunk
+    for chunk in imported_chunks:
+        merged.setdefault(chunk.id, chunk)
+    chunks = list(merged.values())
+    chunks.sort(key=lambda c: (c.timestamp, c.session_id, c.turn_index, c.id))
+    return chunks
+
+
+def _merge_pending_contradictions(local_items: list[dict], imported_items: list[dict]) -> list[dict]:
+    """Merge pending contradictions by semantic key."""
+    merged: dict[tuple, dict] = {}
+    for item in local_items + imported_items:
+        key = (
+            item.get("old_node_id"),
+            item.get("new_content"),
+            item.get("category"),
+            item.get("reason"),
+            tuple(item.get("source_sessions", [])),
+            item.get("claim_text"),
+        )
+        merged[key] = item
+    return list(merged.values())
+
+
+def _manifest_from_chunks(chunks: list, extra_manifests: list[dict]) -> dict:
+    """Build merged manifest metadata from transcript chunks."""
+    sessions: dict[str, dict] = {}
+    for chunk in chunks:
+        entry = sessions.setdefault(
+            chunk.session_id,
+            {"chunk_count": 0, "min_ts": chunk.timestamp or "", "max_ts": chunk.timestamp or ""},
+        )
+        entry["chunk_count"] += 1
+        if chunk.timestamp:
+            if not entry["min_ts"] or chunk.timestamp < entry["min_ts"]:
+                entry["min_ts"] = chunk.timestamp
+            if not entry["max_ts"] or chunk.timestamp > entry["max_ts"]:
+                entry["max_ts"] = chunk.timestamp
+
+    source_files: list[str] = []
+    for manifest in extra_manifests:
+        for path in manifest.get("source_files", []) or []:
+            if path not in source_files:
+                source_files.append(path)
+
+    result = {
+        "chunk_count": len(chunks),
+        "session_count": len(sessions),
+        "sessions": sessions,
+        "build_timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if source_files:
+        result["source_files"] = source_files
+    return result
+
+
+def _load_index_state(index_dir: Path) -> tuple[list, dict, list[dict], list[dict]]:
+    """Load chunks, manifest, knowledge, and pending contradictions from *index_dir*."""
+    if not _has_index(index_dir):
+        return [], {}, [], []
+
+    from synapt.recall.core import TranscriptIndex
+
+    index = TranscriptIndex.load(index_dir, use_embeddings=False)
+    try:
+        db = index._db
+        manifest = db.load_manifest() if db else {}
+        knowledge = db.load_knowledge_nodes(status=None) if db else []
+        pending = db.list_pending_contradictions() if db else []
+        return index.chunks, manifest, knowledge, pending
+    finally:
+        if index._db is not None:
+            index._db.close()
+
+
+def _rebuild_merged_index(
+    target_index_dir: Path,
+    local_index_dir: Path,
+    imported_index_dir: Path,
+) -> dict:
+    """Merge two indexes semantically and rewrite a clean destination index."""
+    from synapt.recall.core import TranscriptIndex
+    from synapt.recall.storage import RecallDB
+
+    local_chunks, local_manifest, local_nodes, local_pending = _load_index_state(local_index_dir)
+    imported_chunks, imported_manifest, imported_nodes, imported_pending = _load_index_state(imported_index_dir)
+
+    merged_chunks = _merge_chunks(local_chunks, imported_chunks)
+    merged_nodes = _merge_knowledge_nodes(local_nodes, imported_nodes)
+    merged_pending = _merge_pending_contradictions(local_pending, imported_pending)
+    merged_manifest = _manifest_from_chunks(
+        merged_chunks,
+        [local_manifest, imported_manifest],
+    )
+
+    with tempfile.TemporaryDirectory(prefix="synapt-recall-merge-") as tmp:
+        tmp_index = Path(tmp) / "index"
+        tmp_index.mkdir(parents=True, exist_ok=True)
+        db = RecallDB(tmp_index / "recall.db")
+        try:
+            index = TranscriptIndex(
+                merged_chunks,
+                use_embeddings=False,
+                cache_dir=tmp_index,
+                db=db,
+            )
+            index.save(tmp_index)
+            db.save_knowledge_nodes(merged_nodes)
+            for item in merged_pending:
+                db.add_pending_contradiction(
+                    old_node_id=item.get("old_node_id"),
+                    new_content=item.get("new_content", ""),
+                    category=item.get("category", ""),
+                    reason=item.get("reason", ""),
+                    source_sessions=item.get("source_sessions", []),
+                    detected_by=item.get("detected_by", "archive-import"),
+                    claim_text=item.get("claim_text"),
+                )
+            db.save_manifest(merged_manifest)
+        finally:
+            db.close()
+
+        if target_index_dir.exists():
+            shutil.rmtree(target_index_dir)
+        shutil.copytree(tmp_index, target_index_dir)
+
+    return {
+        "chunk_count": len(merged_chunks),
+        "knowledge_count": len(merged_nodes),
+        "pending_contradiction_count": len(merged_pending),
+    }
+
+
+def import_recall_archive(
+    project_dir: Path,
+    archive_path: Path,
+    *,
+    mode: str = "replace",
+) -> dict:
+    """Import a portable recall archive into *project_dir*.
+
+    ``mode="replace"`` fully restores the archived data directory.
+    ``mode="merge"`` merges transcripts, journals, channels, reminders,
+    and reconstructs a merged monolithic recall index from both sources.
+    """
+    if mode not in {"replace", "merge"}:
+        raise ValueError("mode must be 'replace' or 'merge'")
+
+    project_dir = project_dir.resolve()
+    archive_path = archive_path.expanduser().resolve()
+    manifest = _load_archive_manifest(archive_path)
+
+    with tempfile.TemporaryDirectory(prefix="synapt-recall-import-") as tmp:
+        extracted_dir = Path(tmp) / "archive"
+        extracted_dir.mkdir(parents=True, exist_ok=True)
+        _safe_extract_archive(archive_path, extracted_dir)
+
+        data_dir = _data_dir(project_dir)
+        if mode == "replace":
+            wt_map = _worktree_name_map(extracted_dir, project_dir)
+            for src_name, dst_name in wt_map.items():
+                if src_name == dst_name:
+                    continue
+                src_wt = extracted_dir / "worktrees" / src_name
+                dst_wt = extracted_dir / "worktrees" / dst_name
+                if src_wt.exists() and not dst_wt.exists():
+                    src_wt.rename(dst_wt)
+
+            if data_dir.exists():
+                shutil.rmtree(data_dir)
+            data_dir.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(extracted_dir, data_dir)
+            summary = dict(manifest)
+            summary["mode"] = "replace"
+            return summary
+
+        # Merge mode
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        # Merge per-worktree transcripts and journals
+        imported_worktrees = extracted_dir / "worktrees"
+        if imported_worktrees.is_dir():
+            from synapt.recall.journal import compact_journal
+
+            wt_map = _worktree_name_map(extracted_dir, project_dir)
+            for wt_dir in sorted(p for p in imported_worktrees.iterdir() if p.is_dir()):
+                dst_wt_name = wt_map.get(wt_dir.name, wt_dir.name)
+                dst_wt = data_dir / "worktrees" / dst_wt_name
+                src_transcripts = wt_dir / "transcripts"
+                if src_transcripts.is_dir():
+                    _merge_transcript_archives(src_transcripts, dst_wt / "transcripts")
+                src_journal = wt_dir / "journal.jsonl"
+                if src_journal.is_file():
+                    _merge_jsonl_lines(src_journal, dst_wt / "journal.jsonl")
+                    compact_journal(dst_wt / "journal.jsonl")
+
+        # Merge channels by appending unique JSONL lines. Leave local DB/cursors intact.
+        imported_channels = extracted_dir / "channels"
+        if imported_channels.is_dir():
+            dst_channels = data_dir / "channels"
+            for src_file in sorted(imported_channels.glob("*.jsonl")):
+                _merge_jsonl_lines(src_file, dst_channels / src_file.name)
+
+        # Merge small root-level state files.
+        imported_reminders = extracted_dir / "reminders.json"
+        if imported_reminders.is_file():
+            _merge_reminders(imported_reminders, data_dir / "reminders.json")
+
+        imported_dedup = extracted_dir / "dedup_decisions.jsonl"
+        if imported_dedup.is_file():
+            _merge_jsonl_lines(imported_dedup, data_dir / "dedup_decisions.jsonl")
+
+        for name in ("config.json", "upload_manifest.json", "last_sync_time"):
+            src = extracted_dir / name
+            dst = data_dir / name
+            if src.is_file() and not dst.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+
+        merged_index_stats = _rebuild_merged_index(
+            data_dir / "index",
+            _index_dir(project_dir),
+            extracted_dir / "index",
+        )
+
+        # Regenerate knowledge.jsonl from merged DB state if we have one.
+        merged_chunks, _manifest, merged_nodes, _pending = _load_index_state(data_dir / "index")
+        if merged_nodes:
+            _write_knowledge_jsonl(merged_nodes, data_dir / "knowledge.jsonl")
+
+        summary = dict(manifest)
+        summary.update(merged_index_stats)
+        summary["mode"] = "merge"
+        summary["session_count"] = len({c.session_id for c in merged_chunks})
+        return summary
 
 
 # ---------------------------------------------------------------------------

--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -977,6 +977,54 @@ def cmd_archive(args: argparse.Namespace) -> None:
         print("All transcripts already archived.", file=sys.stderr)
 
 
+def cmd_export(args: argparse.Namespace) -> None:
+    """Export portable recall state to a .synapt-archive file."""
+    from synapt.recall.archive import export_recall_archive
+
+    project = Path.cwd().resolve()
+    try:
+        output_path, manifest = export_recall_archive(
+            project,
+            Path(args.output).expanduser() if args.output else None,
+            exclude_transcripts=args.exclude_transcripts,
+            exclude_channels=args.exclude_channels,
+        )
+    except Exception as exc:
+        print(f"Export failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Exported recall archive to {output_path}")
+    print(
+        f"  chunks={manifest.get('chunk_count', 0)} "
+        f"knowledge={manifest.get('knowledge_count', 0)} "
+        f"worktrees={manifest.get('worktree_count', 0)}"
+    )
+
+
+def cmd_import(args: argparse.Namespace) -> None:
+    """Import portable recall state from a .synapt-archive file."""
+    from synapt.recall.archive import import_recall_archive
+
+    project = Path.cwd().resolve()
+    mode = "merge" if args.merge else "replace"
+    try:
+        summary = import_recall_archive(
+            project,
+            Path(args.archive),
+            mode=mode,
+        )
+    except Exception as exc:
+        print(f"Import failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Imported recall archive from {Path(args.archive).expanduser().resolve()}")
+    print(
+        f"  mode={summary.get('mode', mode)} "
+        f"chunks={summary.get('chunk_count', 0)} "
+        f"knowledge={summary.get('knowledge_count', 0)}"
+    )
+
+
 def cmd_transcript(args: argparse.Namespace) -> None:
     """Display or save a session transcript."""
     from synapt.recall.archive import archive_transcripts
@@ -2193,6 +2241,18 @@ def main():
     # Archive (lightweight local copy, no indexing)
     subparsers.add_parser("archive", help="Archive transcripts locally (no indexing)")
 
+    # Export / Import (portable recall snapshot)
+    export_parser = subparsers.add_parser("export", help="Export portable recall data to a .synapt-archive file")
+    export_parser.add_argument("output", nargs="?", default=None, help="Output .synapt-archive path (default: <project>.synapt-archive)")
+    export_parser.add_argument("--exclude-transcripts", action="store_true", help="Skip raw transcript archives")
+    export_parser.add_argument("--exclude-channels", action="store_true", help="Skip channel history files")
+
+    import_parser = subparsers.add_parser("import", help="Import portable recall data from a .synapt-archive file")
+    import_parser.add_argument("archive", help="Path to a .synapt-archive file")
+    import_mode = import_parser.add_mutually_exclusive_group()
+    import_mode.add_argument("--merge", action="store_true", help="Merge imported data into existing recall state")
+    import_mode.add_argument("--replace", action="store_true", help="Replace existing recall state (default)")
+
     # Transcript (display/save a session)
     transcript_parser = subparsers.add_parser("transcript", help="Display or save a session transcript")
     transcript_parser.add_argument("session_id", nargs="?", default=None, help="Session ID (default: most recent)")
@@ -2304,6 +2364,10 @@ def main():
         cmd_sync(args)
     elif args.command == "archive":
         cmd_archive(args)
+    elif args.command == "export":
+        cmd_export(args)
+    elif args.command == "import":
+        cmd_import(args)
     elif args.command == "transcript":
         cmd_transcript(args)
     elif args.command == "journal":

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -528,6 +528,62 @@ def recall_setup(no_hook: bool = False) -> str:
     return "Setup complete.\n" + "\n".join(f"  - {s}" for s in steps)
 
 
+def recall_export(
+    output_path: str = "",
+    exclude_transcripts: bool = False,
+    exclude_channels: bool = False,
+) -> str:
+    """Export portable recall state to a .synapt-archive file.
+
+    Args:
+        output_path: Destination file path. Defaults to <project>.synapt-archive.
+        exclude_transcripts: If True, omit archived raw transcript JSONL files.
+        exclude_channels: If True, omit channel history files.
+    """
+    from synapt.recall.archive import export_recall_archive
+
+    project = Path.cwd().resolve()
+    try:
+        archive_path, manifest = export_recall_archive(
+            project,
+            Path(output_path).expanduser() if output_path else None,
+            exclude_transcripts=exclude_transcripts,
+            exclude_channels=exclude_channels,
+        )
+    except Exception as e:
+        return f"Export failed: {e}"
+
+    return (
+        f"Recall archive exported to {archive_path}\n"
+        f"  - chunks: {manifest.get('chunk_count', 0)}\n"
+        f"  - knowledge: {manifest.get('knowledge_count', 0)}\n"
+        f"  - worktrees: {manifest.get('worktree_count', 0)}"
+    )
+
+
+def recall_import(archive_path: str, mode: str = "replace") -> str:
+    """Import portable recall state from a .synapt-archive file.
+
+    Args:
+        archive_path: Path to the exported .synapt-archive file.
+        mode: Either "replace" or "merge".
+    """
+    from synapt.recall.archive import import_recall_archive
+
+    project = Path.cwd().resolve()
+    try:
+        summary = import_recall_archive(project, Path(archive_path), mode=mode)
+    except Exception as e:
+        return f"Import failed: {e}"
+
+    return (
+        f"Recall archive imported from {Path(archive_path).expanduser().resolve()}\n"
+        f"  - mode: {summary.get('mode', mode)}\n"
+        f"  - chunks: {summary.get('chunk_count', 0)}\n"
+        f"  - knowledge: {summary.get('knowledge_count', 0)}"
+    )
+
+
 def recall_stats() -> str:
     """Get statistics about the transcript index.
 
@@ -1792,6 +1848,8 @@ def register_tools(mcp) -> None:
     mcp.tool()(_with_directive_check(recall_sessions))
     mcp.tool()(recall_build)
     mcp.tool()(recall_setup)
+    mcp.tool()(recall_export)
+    mcp.tool()(recall_import)
     mcp.tool()(_with_directive_check(recall_stats))
     mcp.tool()(_with_directive_check(recall_journal))
     mcp.tool()(_with_directive_check(recall_remind))

--- a/tests/recall/test_archive.py
+++ b/tests/recall/test_archive.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from synapt.recall.archive import (
+    export_recall_archive,
+    import_recall_archive,
     archive_transcripts,
     load_sync_config,
     save_sync_config,
@@ -14,7 +16,102 @@ from synapt.recall.archive import (
     should_sync,
     _set_last_sync_time,
 )
-from synapt.recall.core import project_archive_dir
+from synapt.recall.core import project_archive_dir, project_worktree_dir, project_index_dir, TranscriptChunk, TranscriptIndex
+from synapt.recall.storage import RecallDB
+
+
+def _seed_recall_project(
+    project: Path,
+    *,
+    session_id: str,
+    chunk_id: str,
+    knowledge_id: str,
+    journal_focus: str,
+    channel_id: str,
+    reminder_id: str,
+) -> None:
+    """Create a small but complete recall dataset for export/import tests."""
+    archive_dir = project_archive_dir(project)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    (archive_dir / f"{session_id}.jsonl").write_text('{"type":"progress","sessionId":"' + session_id + '"}\n')
+
+    wt_dir = project_worktree_dir(project)
+    wt_dir.mkdir(parents=True, exist_ok=True)
+    (wt_dir / "journal.jsonl").write_text(
+        json.dumps({
+            "timestamp": "2026-03-20T09:00:00+00:00",
+            "session_id": session_id,
+            "focus": journal_focus,
+            "done": [],
+            "decisions": [],
+            "next_steps": [],
+            "files_modified": [],
+            "git_log": [],
+            "auto": False,
+            "enriched": False,
+        }) + "\n"
+    )
+
+    channels_dir = project / ".synapt" / "recall" / "channels"
+    channels_dir.mkdir(parents=True, exist_ok=True)
+    (channels_dir / "dev.jsonl").write_text(
+        json.dumps({
+            "id": channel_id,
+            "timestamp": "2026-03-20T09:01:00+00:00",
+            "author": "atlas",
+            "message": f"message-{channel_id}",
+        }) + "\n"
+    )
+
+    (project / ".synapt" / "recall" / "reminders.json").write_text(
+        json.dumps([
+            {
+                "id": reminder_id,
+                "text": f"remember-{reminder_id}",
+                "sticky": False,
+                "shown_count": 0,
+                "created_at": "2026-03-20T09:02:00+00:00",
+            }
+        ])
+    )
+
+    index_dir = project_index_dir(project)
+    index_dir.mkdir(parents=True, exist_ok=True)
+    db = RecallDB(index_dir / "recall.db")
+    try:
+        chunk = TranscriptChunk(
+            id=chunk_id,
+            session_id=session_id,
+            timestamp="2026-03-20T09:00:00+00:00",
+            turn_index=0,
+            user_text=f"user-{session_id}",
+            assistant_text=f"assistant-{session_id}",
+        )
+        index = TranscriptIndex([chunk], use_embeddings=False, cache_dir=index_dir, db=db)
+        index.save(index_dir)
+        db.save_knowledge_nodes([
+            {
+                "id": knowledge_id,
+                "content": f"knowledge-{knowledge_id}",
+                "category": "fact",
+                "confidence": 0.8,
+                "source_sessions": [session_id],
+                "created_at": "2026-03-20T09:00:00+00:00",
+                "updated_at": "2026-03-20T09:00:00+00:00",
+                "status": "active",
+                "superseded_by": "",
+                "contradiction_note": "",
+                "tags": [],
+                "valid_from": None,
+                "valid_until": None,
+                "version": 1,
+                "lineage_id": "",
+                "source_turns": [],
+                "source_offsets": [],
+            }
+        ])
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +223,106 @@ def test_archive_ignores_non_jsonl(tmp_path):
     archive_dir = project_archive_dir(project)
     assert not (archive_dir / "notes.txt").exists()
     assert not (archive_dir / "data.json").exists()
+
+
+def test_export_import_replace_roundtrip(tmp_path):
+    """Portable archive replace-import restores transcripts, channels, and index."""
+    source = tmp_path / "source"
+    source.mkdir()
+    _seed_recall_project(
+        source,
+        session_id="sess-a",
+        chunk_id="sess-a:t0",
+        knowledge_id="know-a",
+        journal_focus="source focus",
+        channel_id="msg-a",
+        reminder_id="rem-a",
+    )
+
+    archive_path = tmp_path / "backup.synapt-archive"
+    out_path, manifest = export_recall_archive(source, archive_path)
+    assert out_path == archive_path
+    assert manifest["chunk_count"] == 1
+    assert manifest["knowledge_count"] == 1
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    summary = import_recall_archive(dest, archive_path, mode="replace")
+    assert summary["mode"] == "replace"
+
+    dest_index = TranscriptIndex.load(project_index_dir(dest), use_embeddings=False)
+    try:
+        assert len(dest_index.chunks) == 1
+        assert dest_index.chunks[0].id == "sess-a:t0"
+        assert dest_index._db is not None
+        assert len(dest_index._db.load_knowledge_nodes(status=None)) == 1
+    finally:
+        if dest_index._db is not None:
+            dest_index._db.close()
+
+    assert (project_archive_dir(dest) / "sess-a.jsonl").exists()
+    assert (project_worktree_dir(dest) / "journal.jsonl").exists()
+    assert (dest / ".synapt" / "recall" / "channels" / "dev.jsonl").exists()
+    reminders = json.loads((dest / ".synapt" / "recall" / "reminders.json").read_text())
+    assert reminders[0]["id"] == "rem-a"
+
+
+def test_import_merge_unions_chunks_knowledge_journal_and_channels(tmp_path):
+    """Merge import unions semantic recall state without dropping local data."""
+    local = tmp_path / "local"
+    local.mkdir()
+    _seed_recall_project(
+        local,
+        session_id="sess-local",
+        chunk_id="sess-local:t0",
+        knowledge_id="know-local",
+        journal_focus="local focus",
+        channel_id="msg-local",
+        reminder_id="rem-local",
+    )
+
+    imported = tmp_path / "imported"
+    imported.mkdir()
+    _seed_recall_project(
+        imported,
+        session_id="sess-imported",
+        chunk_id="sess-imported:t0",
+        knowledge_id="know-imported",
+        journal_focus="imported focus",
+        channel_id="msg-imported",
+        reminder_id="rem-imported",
+    )
+
+    archive_path = tmp_path / "merge.synapt-archive"
+    export_recall_archive(imported, archive_path)
+
+    summary = import_recall_archive(local, archive_path, mode="merge")
+    assert summary["mode"] == "merge"
+    assert summary["chunk_count"] == 2
+    assert summary["knowledge_count"] == 2
+
+    merged_index = TranscriptIndex.load(project_index_dir(local), use_embeddings=False)
+    try:
+        chunk_ids = {chunk.id for chunk in merged_index.chunks}
+        assert chunk_ids == {"sess-local:t0", "sess-imported:t0"}
+        assert merged_index._db is not None
+        node_ids = {node["id"] for node in merged_index._db.load_knowledge_nodes(status=None)}
+        assert node_ids == {"know-local", "know-imported"}
+    finally:
+        if merged_index._db is not None:
+            merged_index._db.close()
+
+    journal_text = (project_worktree_dir(local) / "journal.jsonl").read_text()
+    assert "sess-local" in journal_text
+    assert "sess-imported" in journal_text
+
+    channel_text = (local / ".synapt" / "recall" / "channels" / "dev.jsonl").read_text()
+    assert "msg-local" in channel_text
+    assert "msg-imported" in channel_text
+
+    reminders = json.loads((local / ".synapt" / "recall" / "reminders.json").read_text())
+    reminder_ids = {item["id"] for item in reminders}
+    assert reminder_ids == {"rem-local", "rem-imported"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recall/test_cli.py
+++ b/tests/recall/test_cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -449,6 +450,56 @@ def test_recall_setup_no_transcripts(tmp_path):
         result = recall_setup()
 
     assert "No Claude Code transcripts found" in result
+
+
+def test_main_dispatches_export_command(tmp_path):
+    """CLI main dispatches the export command to cmd_export."""
+    with patch.object(sys, "argv", ["synapt", "export", "backup.synapt-archive"]), \
+         patch("synapt.recall.cli.cmd_export") as mock_export:
+        main()
+    mock_export.assert_called_once()
+    assert mock_export.call_args[0][0].output == "backup.synapt-archive"
+
+
+def test_main_dispatches_import_command(tmp_path):
+    """CLI main dispatches the import command to cmd_import."""
+    with patch.object(sys, "argv", ["synapt", "import", "backup.synapt-archive", "--merge"]), \
+         patch("synapt.recall.cli.cmd_import") as mock_import:
+        main()
+    mock_import.assert_called_once()
+    args = mock_import.call_args[0][0]
+    assert args.archive == "backup.synapt-archive"
+    assert args.merge is True
+
+
+def test_recall_export_tool_formats_success(tmp_path):
+    """recall_export MCP tool returns a concise summary."""
+    from synapt.recall.server import recall_export
+
+    archive_path = tmp_path / "project.synapt-archive"
+    with patch("synapt.recall.server.Path.cwd", return_value=tmp_path), \
+         patch("synapt.recall.archive.export_recall_archive",
+               return_value=(archive_path, {"chunk_count": 3, "knowledge_count": 2, "worktree_count": 1})):
+        result = recall_export()
+
+    assert str(archive_path) in result
+    assert "chunks: 3" in result
+    assert "knowledge: 2" in result
+
+
+def test_recall_import_tool_formats_success(tmp_path):
+    """recall_import MCP tool returns a concise summary."""
+    from synapt.recall.server import recall_import
+
+    archive_path = tmp_path / "project.synapt-archive"
+    with patch("synapt.recall.server.Path.cwd", return_value=tmp_path), \
+         patch("synapt.recall.archive.import_recall_archive",
+               return_value={"mode": "merge", "chunk_count": 5, "knowledge_count": 4}):
+        result = recall_import(str(archive_path), mode="merge")
+
+    assert str(archive_path) in result
+    assert "mode: merge" in result
+    assert "chunks: 5" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add portable recall archive export/import helpers with a versioned manifest and `.synapt-archive` tarball format
- expose `synapt recall export` / `synapt recall import` plus MCP tools `recall_export` / `recall_import`
- cover replace roundtrip, merge behavior, CLI dispatch, and MCP wrappers with focused tests

## Notes
- `replace` performs a full data restore from the archive payload
- `merge` is semantic: it unions transcripts, journals, channels, reminders, chunks, knowledge nodes, and pending contradictions, then rewrites a clean monolithic `recall.db` from the merged state
- single-worktree archives remap onto the current worktree on import so migrated data is immediately visible from the destination project

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts= tests/recall/test_archive.py tests/recall/test_cli.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/archive.py src/synapt/recall/cli.py src/synapt/recall/server.py`