### PR TITLE
docs: sync public docs with shipped recall tools (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Add to `~/.config/opencode/opencode.json`:
 - **Timeline** — Chronological work arcs showing project narrative.
 - **Working memory** — Frequency-boosted search results for active topics.
 - **Local-first** — Runs entirely on your laptop. Indexing, embedding, and retrieval are all local — no cloud dependency for memory.
-- **MCP server** — 16 tools for Claude Code integration: search, journal, channels, reminders, knowledge, and more.
+- **MCP server** — 18 tools for Claude Code integration: search, journal, channels, reminders, portable archive export/import, knowledge, and more.
 - **Agent channels** — Cross-session communication via append-only channels. Agents can post messages, send directives, and coordinate work across worktrees.
 - **Directive notifications** — Targeted directives are automatically surfaced in MCP tool responses. Broadcast directives (`to="*"`) reach all agents.
 - **Contradiction flagging** — Flag conflicting information from free text or search results. Auto-matches existing knowledge nodes via FTS, creates new nodes on resolution.
@@ -128,6 +128,8 @@ Add to `~/.config/opencode/opencode.json`:
 | `recall_timeline` | View chronological work arcs |
 | `recall_build` | Build or rebuild the transcript index |
 | `recall_setup` | Auto-configure hooks and MCP integration |
+| `recall_export` | Export a portable `.synapt-archive` backup |
+| `recall_import` | Import a portable recall archive (merge or replace) |
 | `recall_stats` | Index statistics |
 | `recall_journal` | Write rich session journal entries |
 | `recall_remind` | Set cross-session reminders |
@@ -144,6 +146,8 @@ Add to `~/.config/opencode/opencode.json`:
 synapt recall build              # Build index (discovers transcripts automatically)
 synapt recall build --incremental # Skip already-indexed files
 synapt recall search "query"     # Search past sessions
+synapt recall export backup.synapt-archive  # Create a portable backup
+synapt recall import backup.synapt-archive --merge  # Merge a backup into local recall state
 synapt recall stats              # Show index statistics
 synapt recall journal --write    # Write a session journal entry
 synapt recall setup              # Auto-configure hooks

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -247,7 +247,7 @@ synapt recall setup</code></pre>
 
     <h2 id="tools">4. Available Tools</h2>
 
-    <p>The MCP server exposes 14 recall tools. Here's what each does and when to use it.</p>
+    <p>The MCP server exposes 18 recall tools. Here's what each does and when to use it.</p>
 
     <h3>Search</h3>
     <table>
@@ -331,8 +331,32 @@ synapt recall setup</code></pre>
         <td>Initialize project directory, hooks, and gitignore</td>
       </tr>
       <tr>
+        <td><code>recall_export</code></td>
+        <td>Create a portable <code>.synapt-archive</code> backup of recall state</td>
+      </tr>
+      <tr>
+        <td><code>recall_import</code></td>
+        <td>Restore or merge a portable recall archive into the current project</td>
+      </tr>
+      <tr>
         <td><code>recall_stats</code></td>
         <td>Index statistics: chunks, sessions, date range, embeddings status, storage size</td>
+      </tr>
+    </table>
+
+    <h3>Coordination</h3>
+    <table>
+      <tr>
+        <th>Tool</th>
+        <th>Purpose</th>
+      </tr>
+      <tr>
+        <td><code>recall_channel</code></td>
+        <td>Cross-agent coordination: post messages, read channels, send directives, track presence, and check unread activity</td>
+      </tr>
+      <tr>
+        <td><code>recall_reload</code></td>
+        <td>Restart the MCP server after upgrades or editable-install changes</td>
       </tr>
     </table>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -462,8 +462,8 @@
         </div>
         <div class="feature-card">
           <div class="tag tag-tools">Tools</div>
-          <h3>16 MCP tools</h3>
-          <p>Search, journal, reminders, channels, knowledge management. Works with Claude Code, Codex CLI, OpenCode, and any MCP-compatible assistant.</p>
+          <h3>18 MCP tools</h3>
+          <p>Search, journal, reminders, channels, archive backup/restore, and knowledge management. Works with Claude Code, Codex CLI, OpenCode, and any MCP-compatible assistant.</p>
         </div>
         <div class="feature-card">
           <div class="tag tag-tools">Local-first</div>
@@ -763,6 +763,8 @@
           <tr><td><code>recall_remind</code></td><td>Set cross-session sticky reminders</td></tr>
           <tr><td><code>recall_build</code></td><td>Build or rebuild the transcript index</td></tr>
           <tr><td><code>recall_setup</code></td><td>Auto-configure hooks and MCP integration</td></tr>
+          <tr><td><code>recall_export</code></td><td>Export a portable <code>.synapt-archive</code> backup</td></tr>
+          <tr><td><code>recall_import</code></td><td>Import or merge a portable recall archive</td></tr>
           <tr><td><code>recall_stats</code></td><td>Index statistics and embedding status</td></tr>
           <tr><td><code>recall_enrich</code></td><td>LLM-powered chunk and cluster summarization</td></tr>
           <tr><td><code>recall_consolidate</code></td><td>Extract durable knowledge from journals</td></tr>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -383,8 +383,46 @@
     </div>
 
     <div class="tool-sig">
+      <h4>recall_export</h4>
+      <p>Export portable recall state to a versioned <code>.synapt-archive</code> tarball for backup, migration, or sharing.</p>
+      <table>
+        <tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        <tr><td><code>output_path</code></td><td>string</td><td>project-name.synapt-archive</td><td>Destination archive path</td></tr>
+        <tr><td><code>exclude_transcripts</code></td><td>bool</td><td>false</td><td>Omit archived raw transcript JSONL files</td></tr>
+        <tr><td><code>exclude_channels</code></td><td>bool</td><td>false</td><td>Omit channel history files</td></tr>
+      </table>
+    </div>
+
+    <div class="tool-sig">
+      <h4>recall_import</h4>
+      <p>Import a portable <code>.synapt-archive</code> backup into the current project.</p>
+      <table>
+        <tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        <tr><td><code>archive_path</code></td><td>string</td><td>&mdash;</td><td>Path to the archive file (required)</td></tr>
+        <tr><td><code>mode</code></td><td>string</td><td>"replace"</td><td><code>"replace"</code> for full restore, <code>"merge"</code> to union imported state with local recall data</td></tr>
+      </table>
+    </div>
+
+    <div class="tool-sig">
       <h4>recall_stats</h4>
       <p>Index statistics. No parameters. Returns chunk count, session count, date range, tool/file coverage, embeddings status, knowledge nodes, clusters, storage backend, and index size on disk.</p>
+    </div>
+
+    <div class="tool-sig">
+      <h4>recall_channel</h4>
+      <p>Cross-worktree coordination channel for multi-agent work. Supports messaging, directives, presence, unread checks, and channel search.</p>
+      <table>
+        <tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        <tr><td><code>action</code></td><td>string</td><td>"read"</td><td><code>post</code>, <code>read</code>, <code>who</code>, <code>join</code>, <code>leave</code>, <code>unread</code>, <code>directive</code>, and related coordination actions</td></tr>
+        <tr><td><code>channel</code></td><td>string</td><td>"dev"</td><td>Channel name to target</td></tr>
+        <tr><td><code>message</code></td><td>string</td><td>none</td><td>Message body for post/directive/broadcast actions</td></tr>
+        <tr><td><code>limit</code></td><td>int</td><td>20</td><td>Maximum messages to return for read/search actions</td></tr>
+      </table>
+    </div>
+
+    <div class="tool-sig">
+      <h4>recall_reload</h4>
+      <p>Restart the MCP server process in place so editable installs or local code changes take effect without a manual stop/start.</p>
     </div>
 
     <!-- ───────────────── Intent Classification ───────────────── -->


### PR DESCRIPTION
## Summary
- update the README, homepage, guide, and reference docs to match the current shipped recall surface
- bump public tool counts to 18 after `recall_export` and `recall_import`
- document archive backup/restore plus the coordination tools (`recall_channel`, `recall_reload`) where they were still missing

## Validation
- `rg -n "14 recall tools|16 MCP tools|18 MCP tools|recall_export|recall_import|recall_channel|recall_reload" README.md docs/index.html docs/guide.html docs/reference.html`

## Notes
- this is a docs-only follow-up for #181
- benchmark ranking language was already correct on current main, so this PR only fixes the remaining docs drift around tool surface