### PR TITLE
docs: surface reproducible eval worktree workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,33 @@ pip install -e ".[test]"
 pytest tests/ -v
 ```
 
+## Reproducible Evals
+
+Long-running evals should run from an isolated git worktree with a dedicated
+venv so code changes on `main` do not mutate the run mid-flight.
+
+```bash
+./scripts/eval-worktree.sh              # from HEAD
+./scripts/eval-worktree.sh abc1234      # from a specific commit/tag
+
+source /tmp/synapt-eval-<ref>/.venv/bin/activate
+cd /tmp/synapt-eval-<ref>
+python -m evaluation.codememo.eval --recalldb --model gpt-4o-mini
+python -m evaluation.locomo_eval --recalldb --batch
+```
+
+The helper creates:
+
+- a detached worktree at `/tmp/synapt-eval-<ref>`
+- a dedicated venv at `/tmp/synapt-eval-<ref>/.venv`
+- a non-editable install frozen to that ref
+
+Clean up with:
+
+```bash
+./scripts/eval-worktree.sh --cleanup <ref>
+```
+
 ## Links
 
 - [synapt.dev](https://synapt.dev) — Website

--- a/evaluation/BENCHMARKS.md
+++ b/evaluation/BENCHMARKS.md
@@ -2,6 +2,24 @@
 
 synapt recall evaluated on [LOCOMO](https://snap-research.github.io/locomo/) (Long Conversational Memory), following [Mem0's methodology](https://arxiv.org/abs/2504.19413) (J-score via gpt-4o-mini LLM-as-Judge).
 
+## Reproducibility
+
+For pinned benchmark runs, create an isolated worktree and venv first:
+
+```bash
+./scripts/eval-worktree.sh              # from HEAD
+./scripts/eval-worktree.sh abc1234      # from a specific commit/tag
+
+source /tmp/synapt-eval-<ref>/.venv/bin/activate
+cd /tmp/synapt-eval-<ref>
+python -m evaluation.codememo.eval --recalldb --model gpt-4o-mini
+python -m evaluation.locomo_eval --recalldb --batch
+```
+
+This freezes both the code and the Python environment for the duration of the
+run, so later edits on `main` cannot contaminate an ablation or benchmark that
+claims to have run at a specific ref.
+
 ## Current Best
 
 **v0.6.1 Full Pipeline (Ministral 8B cloud, 10 convs) — J-Score: 76.04%** — #2 on LOCOMO, within 1.5pp of Engram (77.55%), ahead of Memobase (75.78%) and all other competitors.


### PR DESCRIPTION
## Summary
- document the existing `scripts/eval-worktree.sh` helper in the public README
- add reproducible benchmark workflow notes to `evaluation/BENCHMARKS.md`
- close the discoverability gap for the isolated worktree + venv eval path

Closes #98.