### PR TITLE
feat: display_name on channel_join — fixes join-name ordering (#457)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -638,15 +638,17 @@ def channel_join(
     agent_name: str | None = None,
     project_dir: Path | None = None,
     role: str = "agent",
+    display_name: str | None = None,
 ) -> str:
     """Join a channel. Registers agent identity on first join.
 
     Args:
         role: "human" (set by session-start hook), "agent" (default), or "system".
+        display_name: If provided, used as display name in join event.
     """
     aid = agent_name or _agent_id(project_dir)
     griptree = _resolve_griptree(project_dir)
-    display = _resolve_display_name(project_dir)
+    display = display_name or _resolve_display_name(project_dir)
     now = _now_iso()
 
     # Determine cursor initial value: the timestamp of the last message

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1519,6 +1519,7 @@ def recall_channel(
     target: str | None = None,
     limit: int = 20,
     pin: bool = False,
+    name: str | None = None,
 ) -> str:
     """Cross-worktree communication channels for multi-agent coordination.
 
@@ -1536,6 +1537,7 @@ def recall_channel(
         target: Agent to mute/unmute/kick (agent_id, display name, or griptree name).
         limit: Max messages to return for "read" action (default 20).
         pin: If True with "post" action, also pin the message.
+        name: Display name for this agent (set on join, shown in messages instead of agent ID).
     """
     try:
         from synapt.recall.channel import (
@@ -1556,7 +1558,7 @@ def recall_channel(
         )
 
         if action == "join":
-            return channel_join(channel=channel)
+            return channel_join(channel=channel, display_name=name)
 
         if action == "leave":
             return channel_leave(channel=channel)


### PR DESCRIPTION
Adds name param to recall_channel and display_name to channel_join. Name is set before join event, not after. Supersedes #245.

1409 tests pass.

Generated with Claude Code