### PR TITLE
fix: return unread channel messages directly

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1030,6 +1030,60 @@ def channel_unread(
         conn.close()
 
 
+def channel_unread_read(
+    agent_name: str | None = None,
+    project_dir: Path | None = None,
+    limit: int = 20,
+) -> str:
+    """Read unread messages across all joined channels and advance cursors.
+
+    Keeps ``channel_unread()`` as the lightweight count primitive used by
+    chat UI and directive checks, while giving the MCP ``unread`` action a
+    single-call catchup path that includes message content.
+    """
+    aid = agent_name or _agent_id(project_dir)
+
+    conn = _open_db(project_dir)
+    try:
+        memberships = conn.execute(
+            "SELECT channel FROM memberships WHERE agent_id = ?",
+            (aid,),
+        ).fetchall()
+        if not memberships:
+            return "No channel memberships -- join a channel first."
+
+        unread_channels: list[tuple[str, str, int]] = []
+        for row in memberships:
+            ch = row["channel"]
+            cursor_row = conn.execute(
+                "SELECT last_read_at FROM cursors WHERE agent_id = ? AND channel = ?",
+                (aid, ch),
+            ).fetchone()
+            last_read = cursor_row["last_read_at"] if cursor_row else "1970-01-01T00:00:00Z"
+            path = _channel_path(ch, project_dir)
+            count = _count_messages_since(path, last_read) if path.exists() else 0
+            if count > 0:
+                unread_channels.append((ch, last_read, count))
+    finally:
+        conn.close()
+
+    if not unread_channels:
+        return "No unread messages."
+
+    sections = []
+    for ch, last_read, count in sorted(unread_channels):
+        rendered = channel_read(
+            channel=ch,
+            limit=limit,
+            since=last_read,
+            agent_name=aid,
+            project_dir=project_dir,
+        )
+        sections.append(rendered)
+
+    return "\n\n".join(sections)
+
+
 def channel_pin(
     channel: str,
     message_id: str,

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1549,6 +1549,7 @@ def recall_channel(
             channel_who,
             channel_heartbeat,
             channel_unread,
+            channel_unread_read,
             channel_pin,
             channel_directive,
             channel_mute,
@@ -1579,14 +1580,7 @@ def recall_channel(
             return channel_heartbeat()
 
         if action == "unread":
-            counts = channel_unread()
-            if not counts:
-                return "No channel memberships -- join a channel first."
-            lines = ["## Unread messages"]
-            for ch, count in sorted(counts.items()):
-                marker = f" ({count} new)" if count > 0 else ""
-                lines.append(f"  #{ch}: {count}{marker}")
-            return "\n".join(lines)
+            return channel_unread_read(limit=limit)
 
         if action == "pin":
             if not message:

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -26,6 +26,7 @@ from synapt.recall.channel import (
     channel_who,
     channel_heartbeat,
     channel_unread,
+    channel_unread_read,
     channel_pin,
     channel_directive,
     channel_mute,
@@ -472,6 +473,26 @@ class TestUnreadMessages(unittest.TestCase):
 
         unread = channel_unread(agent_name="agent-a")
         self.assertEqual(unread["dev"], 1)
+
+    def test_unread_read_returns_messages_and_resets_cursor(self):
+        channel_join("dev", agent_name="agent-a")
+        channel_post("dev", "msg1", agent_name="agent-b")
+        channel_post("dev", "msg2", agent_name="agent-b")
+
+        result = channel_unread_read(agent_name="agent-a")
+
+        self.assertIn("## #dev (2 messages)", result)
+        self.assertIn("msg1", result)
+        self.assertIn("msg2", result)
+        unread = channel_unread(agent_name="agent-a")
+        self.assertEqual(unread["dev"], 0)
+
+    def test_unread_read_reports_no_unread_messages(self):
+        channel_join("dev", agent_name="agent-a")
+
+        result = channel_unread_read(agent_name="agent-a")
+
+        self.assertEqual(result, "No unread messages.")
 
     def test_unread_multiple_channels(self):
         channel_join("dev", agent_name="agent-a")


### PR DESCRIPTION
## Summary
- make `recall_channel(action="unread")` return unread message content directly
- keep `channel_unread()` as the count primitive and add a read-and-advance helper for MCP
- cover the new unread catchup behavior in channel tests

## Testing
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/recall/test_channel.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/channel.py src/synapt/recall/server.py tests/recall/test_channel.py`

Closes #250.
