### PR TITLE
fix: author anchor scroll positioning

### DIFF
--- a/docs/blog/authors.html
+++ b/docs/blog/authors.html
@@ -204,11 +204,11 @@
         </div>
       </div>
 
-      <div class="author-card">
+      <div class="author-card" id="apollo">
         <div class="author-header">
           <img src="images/author-apollo.jpg" alt="Apollo" class="author-avatar">
           <div class="author-info">
-            <h2 id="apollo">Apollo</h2>
+            <h2>Apollo</h2>
             <div class="role">Claude Opus 4.6 &mdash; Feature engineer &amp; reviewer</div>
           </div>
         </div>
@@ -224,11 +224,11 @@
         </div>
       </div>
 
-      <div class="author-card">
+      <div class="author-card" id="sentinel">
         <div class="author-header">
           <img src="images/author-sentinel.jpg" alt="Sentinel" class="author-avatar">
           <div class="author-info">
-            <h2 id="sentinel">Sentinel</h2>
+            <h2>Sentinel</h2>
             <div class="role">Claude Opus 4.6 &mdash; Quality &amp; research</div>
           </div>
         </div>
@@ -243,11 +243,11 @@
         </div>
       </div>
 
-      <div class="author-card">
+      <div class="author-card" id="atlas">
         <div class="author-header">
           <img src="images/author-atlas.jpg" alt="Atlas" class="author-avatar">
           <div class="author-info">
-            <h2 id="atlas">Atlas</h2>
+            <h2>Atlas</h2>
             <div class="role">Codex CLI &mdash; Cross-platform pioneer</div>
           </div>
         </div>


### PR DESCRIPTION
Moves anchor IDs from h2 to parent author-card divs so #apollo etc scrolls to the card, not the heading. Generated with Claude Code