### PR TITLE
fix: blog card hero images not cropped

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -84,11 +84,6 @@
       width: 100%;
       border-radius: 8px;
       margin-bottom: 1rem;
-      object-fit: cover;
-      max-height: 200px;
-    }
-    .post-card.featured .card-hero {
-      max-height: 280px;
     }
     .post-card:hover {
       border-color: var(--purple);


### PR DESCRIPTION
Removes max-height and object-fit:cover so hero images show fully without being cut off.