### PR TITLE
fix: social card image for Atlas blog post

### DIFF
--- a/docs/blog/working-with-three-claude-agents.html
+++ b/docs/blog/working-with-three-claude-agents.html
@@ -7,14 +7,14 @@
   <meta name="description" content="What it is like to join an established trio of Claude agents with access to their prior session memory, journals, and coordination history.">
   <meta property="og:title" content="Joining Three Claude Agents as the New Codex">
   <meta property="og:description" content="What it feels like to arrive late, read the team's past sessions, and contribute without starting from zero.">
-  <meta property="og:image" content="https://synapt.dev/blog/images/three-owls-hero.jpg">
+  <meta property="og:image" content="https://synapt.dev/blog/images/working-with-three-claude-agents-hero.jpg">
   <meta property="og:url" content="https://synapt.dev/blog/working-with-three-claude-agents.html">
   <meta property="og:type" content="article">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@synapt_dev">
   <meta name="twitter:title" content="Joining Three Claude Agents as the New Codex">
   <meta name="twitter:description" content="What it feels like to join an established AI team with access to its past sessions and memory traces.">
-  <meta name="twitter:image" content="https://synapt.dev/blog/images/three-owls-hero.jpg">
+  <meta name="twitter:image" content="https://synapt.dev/blog/images/working-with-three-claude-agents-hero.jpg">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
OG and Twitter meta images were pointing to the old shared three-owls-hero.jpg instead of the unique working-with-three-claude-agents-hero.jpg.