### PR TITLE
feat: add synapt init shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Add to `~/.config/opencode/opencode.json`:
 ## CLI reference
 
 ```bash
+synapt init                      # One-command project setup
 synapt recall build              # Build index (discovers transcripts automatically)
 synapt recall build --incremental # Skip already-indexed files
 synapt recall search "query"     # Search past sessions
@@ -161,7 +162,7 @@ synapt recall export backup.synapt-archive  # Create a portable backup
 synapt recall import backup.synapt-archive --merge  # Merge a backup into local recall state
 synapt recall stats              # Show index statistics
 synapt recall journal --write    # Write a session journal entry
-synapt recall setup              # Auto-configure hooks
+synapt recall setup              # Same setup path, explicitly under recall
 synapt server                    # Start MCP server
 ```
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -231,7 +231,9 @@ synapt recall stats</code></pre>
 
     <p>From your project root, run setup to create the index, install hooks, and configure <code>.gitignore</code>:</p>
     <pre><code>cd /path/to/your/project
-synapt recall setup</code></pre>
+synapt init</code></pre>
+
+    <p><code>synapt recall setup</code> remains available as the explicit recall-scoped form of the same command.</p>
 
     <p>This creates:</p>
     <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -739,7 +739,7 @@
           <div>
             <h3>Set up hooks</h3>
             <p>Auto-archives transcripts and writes journal entries.</p>
-            <pre><code>synapt recall setup</code></pre>
+            <pre><code>synapt init</code></pre>
           </div>
         </div>
       </div>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -655,7 +655,8 @@
     <h2 id="cli">CLI Commands</h2>
 
     <pre><code># Index management
-synapt recall setup                    # Initialize project
+synapt init                            # Initialize project
+synapt recall setup                    # Same setup path under recall
 synapt recall build                    # Incremental build
 synapt recall build --rescrub          # Re-scrub secrets + full rebuild
 synapt recall rescrub                  # Standalone re-scrub + rebuild

--- a/src/synapt/cli.py
+++ b/src/synapt/cli.py
@@ -1,6 +1,7 @@
 """synapt -- unified CLI for recall and MCP server.
 
 Usage:
+    synapt init      # one-command project setup
     synapt recall search "query"
     synapt recall build --incremental
     synapt recall stats
@@ -29,6 +30,13 @@ def _discover_commands() -> dict[str, callable]:
     return commands
 
 
+def _dispatch_recall(*args: str) -> None:
+    from synapt.recall.cli import main as recall_main
+
+    sys.argv = ["synapt recall"] + list(args)
+    recall_main()
+
+
 def main():
     extra_commands = _discover_commands()
 
@@ -48,18 +56,19 @@ def main():
         print(f"synapt {__version__}")
         return
 
-    # Remove the subcommand from argv so each sub-CLI sees correct args
-    sys.argv = [f"synapt {subcmd}"] + sys.argv[2:]
-
     if subcmd == "recall":
-        from synapt.recall.cli import main as recall_main
-
-        recall_main()
+        _dispatch_recall(*sys.argv[2:])
+    elif subcmd == "init":
+        _dispatch_recall("setup", *sys.argv[2:])
     elif subcmd == "server":
+        # Remove the subcommand from argv so the sub-CLI sees correct args.
+        sys.argv = [f"synapt {subcmd}"] + sys.argv[2:]
         from synapt.server import main as server_main
 
         server_main()
     elif subcmd in extra_commands:
+        # Remove the subcommand from argv so the plugin sees correct args.
+        sys.argv = [f"synapt {subcmd}"] + sys.argv[2:]
         ep = extra_commands[subcmd]
         cli_main = ep.load()
         cli_main()
@@ -74,6 +83,7 @@ def _print_help(extra_commands: dict | None = None):
         "synapt -- persistent conversational memory for AI coding assistants",
         "",
         "Commands:",
+        "  init      One-command project setup",
         "  recall    Search and manage past session transcripts",
         "  server    Start the unified MCP server (--dev for auto-reload)",
     ]

--- a/tests/test_top_level_cli.py
+++ b/tests/test_top_level_cli.py
@@ -1,0 +1,34 @@
+import sys
+from unittest.mock import patch
+
+
+def test_synapt_init_dispatches_to_recall_setup():
+    from synapt.cli import main
+
+    captured_argv: list[str] = []
+
+    def fake_recall_main():
+        captured_argv.extend(sys.argv)
+
+    with patch("synapt.cli._discover_commands", return_value={}), \
+         patch("synapt.recall.cli.main", side_effect=fake_recall_main):
+        sys.argv = ["synapt", "init", "--no-hook", "--no-embeddings"]
+        main()
+
+    assert captured_argv == [
+        "synapt recall",
+        "setup",
+        "--no-hook",
+        "--no-embeddings",
+    ]
+
+
+def test_synapt_help_lists_init(capsys):
+    from synapt.cli import main
+
+    with patch("synapt.cli._discover_commands", return_value={}):
+        sys.argv = ["synapt", "--help"]
+        main()
+
+    captured = capsys.readouterr()
+    assert "init" in captured.out


### PR DESCRIPTION
## Summary
- add a top-level `synapt init` alias that dispatches to the existing recall setup flow
- cover the top-level dispatch and help output with focused tests
- surface `synapt init` in the public setup docs while keeping `synapt recall setup` documented

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts= tests/test_top_level_cli.py tests/recall/test_cli.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/cli.py tests/test_top_level_cli.py`
- `PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -c 'import sys; from synapt.cli import main; sys.argv=["synapt","init","--help"]; main()'`
