### PR TITLE
fix: expire stale channel claims

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -473,6 +473,7 @@ def _reap_stale_agents(conn: sqlite3.Connection, project_dir: Path | None = None
             )
             _append_message(msg, project_dir)
 
+        conn.execute("DELETE FROM claims WHERE claimed_by = ?", (aid,))
         conn.execute("DELETE FROM memberships WHERE agent_id = ?", (aid,))
         conn.execute(
             "UPDATE presence SET status = 'offline' WHERE agent_id = ?", (aid,)
@@ -714,8 +715,13 @@ def channel_leave(
 
     conn = _open_db(project_dir)
     try:
+        _reap_stale_agents(conn, project_dir)
         conn.execute(
             "DELETE FROM memberships WHERE agent_id = ? AND channel = ?",
+            (aid, channel),
+        )
+        conn.execute(
+            "DELETE FROM claims WHERE claimed_by = ? AND channel = ?",
             (aid, channel),
         )
         conn.execute(
@@ -728,6 +734,7 @@ def channel_leave(
         ).fetchone()[0]
         if remaining == 0:
             conn.execute("DELETE FROM presence WHERE agent_id = ?", (aid,))
+            conn.execute("DELETE FROM claims WHERE claimed_by = ?", (aid,))
         conn.execute(
             "DELETE FROM cursors WHERE agent_id = ? AND channel = ?",
             (aid, channel),
@@ -1317,6 +1324,7 @@ def channel_claim(
 
     conn = _open_db(project_dir)
     try:
+        _reap_stale_agents(conn, project_dir)
         conn.execute(
             "INSERT OR IGNORE INTO claims (message_id, channel, claimed_by, claimed_at) "
             "VALUES (?, ?, ?, ?)",
@@ -1347,6 +1355,7 @@ def is_claimed(
     """Check if a message is claimed. Returns claim dict or None."""
     conn = _open_db(project_dir)
     try:
+        _reap_stale_agents(conn, project_dir)
         row = conn.execute(
             "SELECT claimed_by, claimed_at FROM claims WHERE message_id = ?",
             (message_id,),
@@ -1368,6 +1377,7 @@ def channel_unclaim(
 
     conn = _open_db(project_dir)
     try:
+        _reap_stale_agents(conn, project_dir)
         row = conn.execute(
             "SELECT claimed_by FROM claims WHERE message_id = ?",
             (message_id,),
@@ -1515,6 +1525,7 @@ def check_directives(
 
     conn = _open_db(project_dir)
     try:
+        _reap_stale_agents(conn, project_dir)
         # Get channels this agent is a member of
         memberships = conn.execute(
             "SELECT channel FROM memberships WHERE agent_id = ?",

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -360,6 +360,38 @@ class TestAutoLeaveTimeout(unittest.TestCase):
         result = channel_read("dev")
         self.assertIn("timed out", result)
 
+    def test_reap_releases_claims(self):
+        stale_time = (datetime.now(timezone.utc) - timedelta(hours=3)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        conn = _open_db()
+        try:
+            conn.execute(
+                "INSERT INTO presence (agent_id, status, last_seen, joined_at) "
+                "VALUES ('stale-bot', 'online', ?, ?)",
+                (stale_time, stale_time),
+            )
+            conn.execute(
+                "INSERT INTO memberships (agent_id, channel, joined_at) "
+                "VALUES ('stale-bot', 'dev', ?)",
+                (stale_time,),
+            )
+            conn.execute(
+                "INSERT INTO claims (message_id, channel, claimed_by, claimed_at) "
+                "VALUES ('m_stale', 'dev', 'stale-bot', ?)",
+                (stale_time,),
+            )
+            conn.commit()
+
+            _reap_stale_agents(conn)
+
+            claim = conn.execute(
+                "SELECT * FROM claims WHERE message_id = 'm_stale'"
+            ).fetchone()
+            self.assertIsNone(claim)
+        finally:
+            conn.close()
+
     def test_who_triggers_reap(self):
         stale_time = (datetime.now(timezone.utc) - timedelta(hours=3)).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
@@ -1480,6 +1512,43 @@ class TestClaim(unittest.TestCase):
         result = channel_unclaim(msg_id, agent_name="s_agent2")
         self.assertIn("Cannot unclaim", result)
         self.assertIsNotNone(is_claimed(msg_id))
+
+    def test_second_agent_can_claim_after_stale_owner_times_out(self):
+        stale_time = (datetime.now(timezone.utc) - timedelta(hours=3)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        channel_join("dev", agent_name="s_agent1")
+        channel_join("dev", agent_name="s_agent2")
+        channel_post("dev", "task", agent_name="s_agent1")
+        msgs = _read_messages(_channels_dir() / "dev.jsonl")
+        msg_id = [m for m in msgs if m.type == "message"][-1].id
+        channel_claim(msg_id, "dev", agent_name="s_agent1")
+
+        conn = _open_db()
+        try:
+            conn.execute(
+                "UPDATE presence SET last_seen = ?, status = 'online' WHERE agent_id = 's_agent1'",
+                (stale_time,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = channel_claim(msg_id, "dev", agent_name="s_agent2")
+        self.assertIn("you", result.lower())
+        claim = is_claimed(msg_id)
+        self.assertIsNotNone(claim)
+        self.assertEqual(claim["claimed_by"], "s_agent2")
+
+    def test_leave_releases_claims_in_that_channel(self):
+        channel_join("dev", agent_name="s_agent1")
+        channel_post("dev", "task", agent_name="s_agent1")
+        msgs = _read_messages(_channels_dir() / "dev.jsonl")
+        msg_id = [m for m in msgs if m.type == "message"][-1].id
+
+        channel_claim(msg_id, "dev", agent_name="s_agent1")
+        channel_leave("dev", agent_name="s_agent1")
+        self.assertIsNone(is_claimed(msg_id))
 
 
 class TestClaimIntent(unittest.TestCase):


### PR DESCRIPTION
## Summary
- release claims when a claimer times out and gets reaped from channel presence
- release claims on clean leave so departed agents do not keep blocking tasks
- make claim lookups and directive checks reap stale agents before trusting existing claims

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts= tests/recall/test_channel.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/channel.py tests/recall/test_channel.py`
