### PR TITLE
fix: keep personal dedup conservative

### DIFF
--- a/src/synapt/recall/content_profile.py
+++ b/src/synapt/recall/content_profile.py
@@ -157,7 +157,7 @@ class AdaptiveParams:
     garbled_filter_enabled: bool = True
 
     # Retrieval
-    dedup_jaccard: float = 0.75
+    dedup_jaccard: float = 0.6
     max_knowledge_default: int | None = None   # None = no cap
     knowledge_boost_adjust: float = 0.0        # Added to intent-based boost
 
@@ -187,7 +187,7 @@ def adaptive_params(profile: ContentProfile) -> AdaptiveParams:
             specificity_threshold=10000,    # Effectively disabled
             generic_filter_enabled=False,   # Personal facts look "generic" to code filters
             garbled_filter_enabled=True,    # Still catch LLM artifacts
-            dedup_jaccard=0.75,             # Personal content is more diverse
+            dedup_jaccard=0.6,              # Preserve distinct personal evidence chunks
             max_knowledge_default=0,        # Disable knowledge in retrieval — raw chunks only
             knowledge_boost_adjust=0.0,     # N/A with max_knowledge=0
         )

--- a/tests/recall/test_content_profile.py
+++ b/tests/recall/test_content_profile.py
@@ -1,0 +1,22 @@
+from synapt.recall.content_profile import ContentProfile, adaptive_params
+
+
+def test_adaptive_params_keep_code_dedup_high():
+    params = adaptive_params(ContentProfile(total_chunks=10, _type="code"))
+
+    assert params.dedup_jaccard == 0.8
+    assert params.max_knowledge_default is None
+
+
+def test_adaptive_params_keep_personal_dedup_conservative():
+    params = adaptive_params(ContentProfile(total_chunks=10, _type="personal"))
+
+    assert params.dedup_jaccard == 0.6
+    assert params.max_knowledge_default == 0
+
+
+def test_adaptive_params_keep_mixed_profile_defaults():
+    params = adaptive_params(ContentProfile(total_chunks=10, _type="mixed"))
+
+    assert params.dedup_jaccard == 0.75
+    assert params.max_knowledge_default == 5


### PR DESCRIPTION
## Summary\n- revert adaptive personal-content dedup from 0.75 back to 0.6\n- keep higher dedup for code content where repetitive chunks are expected\n- add focused tests covering code, personal, and mixed adaptive params\n\n## Why\nLOCOMO is personal-content heavy, and the v0.7.6 adaptive change from 0.6 -> 0.75 matches the observed regression exactly: the k=3 / 0.75 run dropped to 71.2% while the older 0.6 behavior was 73.1%. This keeps the code-side improvement path without over-deduplicating personal evidence.\n\n## Validation\n- ........................................................................ [ 62%]
...........................................                              [100%]
115 passed in 8.84s\n- 