### PR TITLE
Harden the cross-editor demo tape workflow

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -19,6 +19,17 @@ python demo/build_demo_index.py --no-embeddings
 That creates `/tmp/synapt-demo` from CodeMemo `project_03_memory_system` and
 builds a real synapt recall index there.
 
+Probe the three editor CLIs before a full render:
+
+```bash
+python demo/run_cross_editor_probe.py
+```
+
+That runs bounded smoke checks for `claude`, `codex`, and `opencode` in the
+demo project so obvious auth, trust, or startup problems fail fast. The Codex
+probe includes `--skip-git-repo-check` because `/tmp/synapt-demo` is outside a
+git worktree.
+
 Then render the tape:
 
 ```bash
@@ -33,5 +44,14 @@ Outputs:
 Prerequisites:
 
 - `vhs`
+- `ffmpeg`
 - local access to the CodeMemo dataset via `evaluation/codememo/eval.py`
 - editor CLIs used in the tape (`claude`, `codex`, `opencode`)
+
+Notes:
+
+- The tape uses a tighter `recall_quick` prompt and longer sleeps than the
+  first draft because the live editor CLIs can take close to a minute to finish
+  a bounded memory query.
+- If a probe times out, increase `--timeout` before rendering instead of
+  blindly running VHS.

--- a/demo/cross-editor-memory.tape
+++ b/demo/cross-editor-memory.tape
@@ -4,7 +4,8 @@
 # Prerequisites:
 #   1. Build demo project + index: python3 demo/build_demo_index.py
 #      Fast local check: python3 demo/build_demo_index.py --no-embeddings
-#   2. Run: vhs demo/cross-editor-memory.tape
+#   2. Probe editor CLIs: python3 demo/run_cross_editor_probe.py
+#   3. Run: vhs demo/cross-editor-memory.tape
 #
 # Uses CodeMemo project_03 (synapt development sessions) as the data source.
 
@@ -40,9 +41,9 @@ Enter
 Type "echo '🟣 Claude Code'"
 Enter
 Sleep 1s
-Type@80ms "claude -p 'use recall to tell me: what embedding model does this project use and why was it chosen? be brief.'"
+Type@80ms "claude -p 'Use recall_quick only. Answer in one short line: what embedding model does this project use and why was it chosen?'"
 Enter
-Sleep 25s
+Sleep 60s
 
 # === Codex CLI ===
 Type "echo ''"
@@ -50,9 +51,9 @@ Enter
 Type "echo '🟢 Codex CLI (OpenAI)'"
 Enter
 Sleep 1s
-Type@80ms "codex exec 'use recall to tell me: what embedding model does this project use and why was it chosen? be brief.'"
+Type@80ms "codex exec --skip-git-repo-check -m gpt-5.4-mini 'Use recall_quick only. Answer in one short line: what embedding model does this project use and why was it chosen?'"
 Enter
-Sleep 25s
+Sleep 60s
 
 # === OpenCode ===
 Type "echo ''"
@@ -60,9 +61,9 @@ Enter
 Type "echo '🔵 OpenCode'"
 Enter
 Sleep 1s
-Type@80ms "opencode run 'use recall to tell me: what embedding model does this project use and why was it chosen? be brief.'"
+Type@80ms "opencode run 'Use recall_quick only. Answer in one short line: what embedding model does this project use and why was it chosen?'"
 Enter
-Sleep 25s
+Sleep 60s
 
 # Closing
 Type "echo ''"

--- a/demo/run_cross_editor_probe.py
+++ b/demo/run_cross_editor_probe.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Probe the cross-editor demo commands before running the VHS tape.
+
+This gives a bounded smoke test for the three CLIs used in
+demo/cross-editor-memory.tape so render failures show up before a multi-minute
+VHS run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROMPT = (
+    "Use recall_quick only. Answer in one short line: "
+    "what embedding model does this project use and why was it chosen?"
+)
+
+DEFAULT_DEMO_ROOT = Path("/tmp/synapt-demo")
+DEFAULT_TIMEOUT = 60
+VALID_TOOLS = ("claude", "codex", "opencode")
+
+
+def _commands(prompt: str) -> dict[str, list[str]]:
+    return {
+        "claude": ["claude", "-p", prompt],
+        "codex": [
+            "codex",
+            "exec",
+            "--skip-git-repo-check",
+            "-m",
+            "gpt-5.4-mini",
+            prompt,
+        ],
+        "opencode": ["opencode", "run", prompt],
+    }
+
+
+def _snippet(text: str, limit: int = 800) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+def _probe(tool: str, cmd: list[str], cwd: Path, timeout: int) -> int:
+    print(f"== {tool} ==")
+    binary = shutil.which(cmd[0])
+    if not binary:
+        print(f"missing: {cmd[0]}")
+        return 1
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        print(f"timeout after {timeout}s")
+        stdout = exc.stdout if isinstance(exc.stdout, str) else (
+            exc.stdout or b""
+        ).decode("utf-8", "ignore")
+        stderr = exc.stderr if isinstance(exc.stderr, str) else (
+            exc.stderr or b""
+        ).decode("utf-8", "ignore")
+        if stdout.strip():
+            print("stdout:")
+            print(_snippet(stdout))
+        if stderr.strip():
+            print("stderr:")
+            print(_snippet(stderr))
+        return 1
+
+    print(f"rc={proc.returncode}")
+    if proc.stdout.strip():
+        print("stdout:")
+        print(_snippet(proc.stdout))
+    if proc.stderr.strip():
+        print("stderr:")
+        print(_snippet(proc.stderr))
+    return 0 if proc.returncode == 0 else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe the cross-editor demo commands with a bounded timeout.",
+    )
+    parser.add_argument(
+        "--demo-root",
+        type=Path,
+        default=DEFAULT_DEMO_ROOT,
+        help="Demo project directory used by the VHS tape (default: /tmp/synapt-demo)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help="Per-command timeout in seconds (default: 60)",
+    )
+    parser.add_argument(
+        "--tool",
+        action="append",
+        choices=VALID_TOOLS,
+        dest="tools",
+        help="Restrict probing to one or more tools (repeatable).",
+    )
+    args = parser.parse_args()
+
+    demo_root = args.demo_root.expanduser().resolve()
+    if not demo_root.exists():
+        print(f"demo root not found: {demo_root}", file=sys.stderr)
+        print(
+            "Run python demo/build_demo_index.py first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    commands = _commands(PROMPT)
+    selected = args.tools or list(VALID_TOOLS)
+    failures = 0
+    for tool in selected:
+        failures += _probe(tool, commands[tool], demo_root, args.timeout)
+
+    if failures:
+        print(f"\n{failures} probe(s) failed.")
+        return 1
+
+    print("\nAll selected probes completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a bounded cross-editor probe script for the Claude, Codex, and OpenCode demo commands
- fix the Codex tape command to run outside a git worktree with --skip-git-repo-check
- tighten the recall prompt and increase tape sleeps to match real CLI latency
- document the probe-first workflow and ffmpeg requirement in demo/README.md

## Notes
- This hardens the demo path for synapt#41, but does not claim the final GIF/MP4 assets are fully solved yet.
- The probe script exists because the live editor CLIs can fail on trust, auth, or startup long before VHS would make that obvious.

## Testing
- python3 -m py_compile demo/build_demo_index.py demo/run_cross_editor_probe.py
- python3 demo/run_cross_editor_probe.py --help
