### PR TITLE
Add chunk date text for temporal search

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -72,6 +72,42 @@ def atomic_json_write(data: dict | list, path: Path, indent: int = 2) -> None:
         raise
 
 
+def _build_date_text(timestamp: str) -> str:
+    """Expand an ISO-ish timestamp into date terms useful for FTS/BM25."""
+    if not timestamp:
+        return ""
+    try:
+        dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+    day_num = str(dt.day)
+    day_padded = dt.strftime("%d")
+    month_full = dt.strftime("%B")
+    month_abbrev = dt.strftime("%b")
+    weekday = dt.strftime("%A")
+    year = dt.strftime("%Y")
+    month_num = dt.strftime("%m")
+    iso_date = dt.strftime("%Y-%m-%d")
+    return " ".join(
+        [
+            year,
+            f"{year}-{month_num}",
+            iso_date,
+            month_full,
+            month_abbrev,
+            day_num,
+            day_padded,
+            weekday,
+            f"{month_full} {year}",
+            f"{month_abbrev} {year}",
+            f"{weekday} {month_full} {day_num} {year}",
+        ]
+    )
+
+
 # Near-duplicate Jaccard threshold for result deduplication.
 # 0.75 keeps only near-identical chunks from consuming retrieval slots.
 # Lower values (0.6) aggressively remove "similar" chunks that contain
@@ -102,12 +138,15 @@ class TranscriptChunk:
     tools_used: list[str] = field(default_factory=list)
     files_touched: list[str] = field(default_factory=list)
     tool_content: str = ""  # Summarized tool inputs + results
+    date_text: str = ""  # Timestamp expanded into FTS-friendly calendar text
     transcript_path: str = ""  # Path to source transcript file
     byte_offset: int = -1  # Byte position where this turn starts in raw JSONL
     byte_length: int = 0  # Total bytes of raw JSONL entries for this turn
     text: str = ""  # Combined searchable text (built at init)
 
     def __post_init__(self):
+        if not self.date_text:
+            self.date_text = _build_date_text(self.timestamp)
         if not self.text:
             self.text = self._build_text()
 
@@ -123,6 +162,8 @@ class TranscriptChunk:
             parts.append(" ".join(self.tools_used))
         if self.files_touched:
             parts.append(" ".join(self.files_touched))
+        if self.date_text:
+            parts.append(self.date_text)
         return "\n".join(parts)
 
     def to_dict(self) -> dict:
@@ -136,6 +177,7 @@ class TranscriptChunk:
             "tools_used": self.tools_used,
             "files_touched": self.files_touched,
             "tool_content": self.tool_content,
+            "date_text": self.date_text,
             "transcript_path": self.transcript_path,
             "byte_offset": self.byte_offset,
             "byte_length": self.byte_length,
@@ -153,6 +195,7 @@ class TranscriptChunk:
             tools_used=d.get("tools_used", []),
             files_touched=d.get("files_touched", []),
             tool_content=d.get("tool_content", ""),
+            date_text=d.get("date_text", ""),
             transcript_path=d.get("transcript_path", ""),
             byte_offset=d.get("byte_offset", -1),
             byte_length=d.get("byte_length", 0),

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -38,8 +38,8 @@ _EMBEDDING_FMT = f"{EMBEDDING_DIM}f"
 _EMBEDDING_BYTES = struct.calcsize(_EMBEDDING_FMT)
 
 # FTS5 column weights for bm25():
-#   user_text, assistant_text, tools_used, files_touched, tool_content
-_FTS_WEIGHTS = "1.0, 1.5, 2.0, 2.0, 1.5"
+#   user_text, assistant_text, tools_used, files_touched, tool_content, date_text
+_FTS_WEIGHTS = "1.0, 1.5, 2.0, 2.0, 1.5, 3.0"
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS metadata (
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS chunks (
     tools_used TEXT NOT NULL DEFAULT '',
     files_touched TEXT NOT NULL DEFAULT '',
     tool_content TEXT NOT NULL DEFAULT '',
+    date_text TEXT NOT NULL DEFAULT '',
     transcript_path TEXT NOT NULL DEFAULT '',
     byte_offset INTEGER NOT NULL DEFAULT -1,
     byte_length INTEGER NOT NULL DEFAULT 0,
@@ -207,7 +208,7 @@ CREATE TABLE IF NOT EXISTS access_log_archive (
 # doesn't work for virtual tables — we check first).
 _FTS_TABLE_SQL = """\
 CREATE VIRTUAL TABLE chunks_fts USING fts5(
-    user_text, assistant_text, tools_used, files_touched, tool_content,
+    user_text, assistant_text, tools_used, files_touched, tool_content, date_text,
     content=chunks,
     content_rowid=rowid,
     tokenize="porter unicode61 tokenchars '._'"
@@ -218,20 +219,20 @@ CREATE VIRTUAL TABLE chunks_fts USING fts5(
 # (e.g., after a crash during save_chunks drops chunks_ad).
 _FTS_TRIGGERS_SQL = """\
 CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
-    INSERT INTO chunks_fts(rowid, user_text, assistant_text, tools_used, files_touched, tool_content)
-    VALUES (new.rowid, new.user_text, new.assistant_text, new.tools_used, new.files_touched, new.tool_content);
+    INSERT INTO chunks_fts(rowid, user_text, assistant_text, tools_used, files_touched, tool_content, date_text)
+    VALUES (new.rowid, new.user_text, new.assistant_text, new.tools_used, new.files_touched, new.tool_content, new.date_text);
 END;
 
 CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
-    INSERT INTO chunks_fts(chunks_fts, rowid, user_text, assistant_text, tools_used, files_touched, tool_content)
-    VALUES ('delete', old.rowid, old.user_text, old.assistant_text, old.tools_used, old.files_touched, old.tool_content);
+    INSERT INTO chunks_fts(chunks_fts, rowid, user_text, assistant_text, tools_used, files_touched, tool_content, date_text)
+    VALUES ('delete', old.rowid, old.user_text, old.assistant_text, old.tools_used, old.files_touched, old.tool_content, old.date_text);
 END;
 
-CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE OF user_text, assistant_text, tools_used, files_touched, tool_content ON chunks BEGIN
-    INSERT INTO chunks_fts(chunks_fts, rowid, user_text, assistant_text, tools_used, files_touched, tool_content)
-    VALUES ('delete', old.rowid, old.user_text, old.assistant_text, old.tools_used, old.files_touched, old.tool_content);
-    INSERT INTO chunks_fts(rowid, user_text, assistant_text, tools_used, files_touched, tool_content)
-    VALUES (new.rowid, new.user_text, new.assistant_text, new.tools_used, new.files_touched, new.tool_content);
+CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE OF user_text, assistant_text, tools_used, files_touched, tool_content, date_text ON chunks BEGIN
+    INSERT INTO chunks_fts(chunks_fts, rowid, user_text, assistant_text, tools_used, files_touched, tool_content, date_text)
+    VALUES ('delete', old.rowid, old.user_text, old.assistant_text, old.tools_used, old.files_touched, old.tool_content, old.date_text);
+    INSERT INTO chunks_fts(rowid, user_text, assistant_text, tools_used, files_touched, tool_content, date_text)
+    VALUES (new.rowid, new.user_text, new.assistant_text, new.tools_used, new.files_touched, new.tool_content, new.date_text);
 END;
 """
 
@@ -508,6 +509,7 @@ class RecallDB:
         }
         new_cols = {
             "tool_content": "TEXT NOT NULL DEFAULT ''",
+            "date_text": "TEXT NOT NULL DEFAULT ''",
             "transcript_path": "TEXT NOT NULL DEFAULT ''",
             "byte_offset": "INTEGER NOT NULL DEFAULT -1",
             "byte_length": "INTEGER NOT NULL DEFAULT 0",
@@ -792,9 +794,9 @@ class RecallDB:
         cur.execute(
             "CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN "
             "  INSERT INTO chunks_fts(chunks_fts, rowid, user_text, assistant_text, "
-            "    tools_used, files_touched, tool_content) "
+            "    tools_used, files_touched, tool_content, date_text) "
             "  VALUES ('delete', old.rowid, old.user_text, old.assistant_text, "
-            "    old.tools_used, old.files_touched, old.tool_content); "
+            "    old.tools_used, old.files_touched, old.tool_content, old.date_text); "
             "END;"
         )
 
@@ -808,9 +810,9 @@ class RecallDB:
             cur.execute(
                 "INSERT INTO chunks "
                 "(id, session_id, timestamp, turn_index, user_text, assistant_text, "
-                " tools_used, files_touched, tool_content, "
+                " tools_used, files_touched, tool_content, date_text, "
                 " transcript_path, byte_offset, byte_length, embedding) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     chunk.id,
                     chunk.session_id,
@@ -821,6 +823,7 @@ class RecallDB:
                     json.dumps(chunk.tools_used),
                     json.dumps(chunk.files_touched),
                     chunk.tool_content,
+                    chunk.date_text,
                     chunk.transcript_path,
                     chunk.byte_offset,
                     chunk.byte_length,
@@ -847,7 +850,7 @@ class RecallDB:
         rows = self._conn.execute(
             "SELECT id, session_id, timestamp, turn_index, "
             "user_text, assistant_text, tools_used, files_touched, "
-            "tool_content, transcript_path, byte_offset, byte_length "
+            "tool_content, date_text, transcript_path, byte_offset, byte_length "
             "FROM chunks ORDER BY rowid"
         ).fetchall()
 
@@ -863,6 +866,7 @@ class RecallDB:
                 tools_used=json.loads(r["tools_used"]) if r["tools_used"] else [],
                 files_touched=json.loads(r["files_touched"]) if r["files_touched"] else [],
                 tool_content=r["tool_content"] or "",
+                date_text=r["date_text"] or "",
                 transcript_path=r["transcript_path"] or "",
                 byte_offset=r["byte_offset"] if r["byte_offset"] is not None else -1,
                 byte_length=r["byte_length"] if r["byte_length"] is not None else 0,

--- a/tests/recall/test_storage.py
+++ b/tests/recall/test_storage.py
@@ -165,6 +165,7 @@ class TestChunksCRUD:
         assert got.assistant_text == orig.assistant_text
         assert got.tools_used == orig.tools_used
         assert got.files_touched == orig.files_touched
+        assert got.date_text == orig.date_text
 
     def test_save_replaces_existing(self, db, sample_chunks):
         db.save_chunks(sample_chunks)
@@ -258,8 +259,12 @@ class TestFTSSearch:
         # Should find via tool_content (not in user_text or assistant_text)
         results = db.fts_search("AssertionError")
         assert len(results) > 0
-        results2 = db.fts_search("pytest")
-        assert len(results2) > 0
+
+    def test_search_date_text(self, db, sample_chunks):
+        """FTS5 indexes expanded calendar text for month/year queries."""
+        db.save_chunks(sample_chunks)
+        results = db.fts_search("march 2026")
+        assert len(results) > 0
 
     def test_search_files_with_dots(self, db, sample_chunks):
         """FTS5 with tokenchars '._' handles filenames with dots."""
@@ -340,10 +345,16 @@ class TestFTSMigration:
             "SELECT sql FROM sqlite_master WHERE type='table' AND name='chunks_fts'"
         ).fetchone()
         assert "porter" in row[0].lower()
+        assert "date_text" in row[0].lower()
 
         # Critical: verify existing data is searchable after migration
         results = db.fts_search("authentication")
         assert len(results) > 0, "FTS migration lost existing data"
+        cols = {
+            r[1]
+            for r in db._conn.execute("PRAGMA table_info(chunks)").fetchall()
+        }
+        assert "date_text" in cols
         db.close()
 
     def test_migration_detects_tokenchars_change(self, tmp_path):


### PR DESCRIPTION
## Summary
- add chunk-level date_text derived from timestamps in TranscriptChunk
- store date_text in the chunks table and index it in chunks_fts with a higher BM25 weight
- migrate older chunk tables to include date_text and recreate FTS when the schema changes
- add storage tests covering round-trip persistence, month/year FTS matching, and old-DB migration

## Notes
- This is the public repo slice of Phase B from synapt-private#464.
- It does not include enrichment-side relative date resolution or consolidation-side valid_from derivation yet.

## Testing
- python3 -m py_compile src/synapt/recall/core.py src/synapt/recall/storage.py tests/recall/test_storage.py
- PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/recall/test_storage.py
- PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/recall/test_core.py
