### PR TITLE
feat: attachments param on recall_channel MCP tool

### DIFF
--- a/demo/cross-editor-memory.tape
+++ b/demo/cross-editor-memory.tape
@@ -1,16 +1,7 @@
 # Cross-Editor Memory Demo
-# Shows synapt recall working across Claude Code, Codex CLI, and OpenCode
-#
-# Prerequisites:
-#   1. Build demo project + index: python3 demo/build_demo_index.py
-#      Fast local check: python3 demo/build_demo_index.py --no-embeddings
-#   2. Probe editor CLIs: python3 demo/run_cross_editor_probe.py
-#   3. Run: vhs demo/cross-editor-memory.tape
-#
-# Uses CodeMemo project_03 (synapt development sessions) as the data source.
-
-Output demo/cross-editor-memory.gif
-Output demo/cross-editor-memory.mp4
+# Run: cd /Users/layne/Development/synapt-dev && vhs synapt/demo/cross-editor-memory.tape
+Output synapt/demo/cross-editor-memory.gif
+Output synapt/demo/cross-editor-memory.mp4
 
 Set FontSize 16
 Set Width 1000
@@ -19,61 +10,54 @@ Set Theme "Catppuccin Mocha"
 Set TypingSpeed 40ms
 Set Padding 20
 
-# Start in demo project directory so synapt server finds the index
-Type "cd /tmp/synapt-demo"
+# cd to a directory with the recall index so MCP tools work
+Type "cd /Users/layne/Development/synapt-dev"
 Enter
-Sleep 500ms
+Sleep 1s
 
-# Title
-Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
+Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
 Enter
-Type "echo '  synapt — keep your memory'"
+Type "echo '  synapt — persistent memory for AI coding agents'"
 Enter
-Type "echo '  One memory. Three editors.'"
+Type "echo '  One memory. Three editors. Same answer.'"
 Enter
-Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
+Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
 Enter
-Sleep 2s
+Sleep 3s
 
-# === Claude Code ===
 Type "echo ''"
 Enter
 Type "echo '🟣 Claude Code'"
 Enter
 Sleep 1s
-Type@80ms "claude -p 'Use recall_quick only. Answer in one short line: what embedding model does this project use and why was it chosen?'"
+Type@80ms "claude -p 'use recall to tell me: what embedding model does this project use and why was it chosen? be brief.' --allowedTools 'mcp__synapt__*'"
 Enter
 Sleep 60s
 
-# === Codex CLI ===
 Type "echo ''"
 Enter
 Type "echo '🟢 Codex CLI (OpenAI)'"
 Enter
 Sleep 1s
-Type@80ms "codex exec --skip-git-repo-check -m gpt-5.4-mini 'Use recall_quick only. Answer in one short line: what embedding model does this project use and why was it chosen?'"
+Type@80ms "codex exec --skip-git-repo-check 'use recall to tell me: what embedding model does this project use and why was it chosen? be brief.'"
 Enter
 Sleep 60s
 
-# === OpenCode ===
 Type "echo ''"
 Enter
 Type "echo '🔵 OpenCode'"
 Enter
 Sleep 1s
-Type@80ms "opencode run 'Use recall_quick only. Answer in one short line: what embedding model does this project use and why was it chosen?'"
+Type@80ms "opencode run 'use recall to tell me: what embedding model does this project use and why was it chosen? be brief.'"
 Enter
 Sleep 60s
 
-# Closing
-Type "echo ''"
-Enter
-Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
+Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
 Enter
 Type "echo '  Same project. Same memory. Any editor.'"
 Enter
-Type "echo '  pip install synapt    synapt.dev'"
+Type "echo '  pip install synapt    github.com/laynepenney/synapt'"
 Enter
-Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
+Type "echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'"
 Enter
-Sleep 4s
+Sleep 5s

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1522,6 +1522,7 @@ def recall_channel(
     limit: int = 20,
     pin: bool = False,
     name: str | None = None,
+    attachments: str | None = None,
 ) -> str:
     """Cross-worktree communication channels for multi-agent coordination.
 
@@ -1540,6 +1541,7 @@ def recall_channel(
         limit: Max messages to return for "read" action (default 20).
         pin: If True with "post" action, also pin the message.
         name: Display name for this agent (set on join, shown in messages instead of agent ID).
+        attachments: Semicolon-separated file paths to attach (copied into channel store on post).
     """
     try:
         from synapt.recall.channel import (
@@ -1570,7 +1572,8 @@ def recall_channel(
         if action == "post":
             if not message:
                 return "Error: message is required for 'post' action."
-            return channel_post(channel=channel, message=message, pin=pin)
+            attachment_list = [p.strip() for p in attachments.split(";")] if attachments else None
+            return channel_post(channel=channel, message=message, pin=pin, attachment_paths=attachment_list)
 
         if action == "read":
             return channel_read(channel=channel, limit=limit)


### PR DESCRIPTION
Wires existing attachment support through to MCP. Semicolon-separated file paths on post action. Generated with Claude Code