### PR TITLE
fix: derive knowledge valid_from from source timestamps

### DIFF
--- a/src/synapt/recall/consolidate.py
+++ b/src/synapt/recall/consolidate.py
@@ -353,6 +353,24 @@ def _validate_iso_date(value: str | None) -> str | None:
         return None
 
 
+def _cluster_valid_from(cluster: list[JournalEntry]) -> str | None:
+    """Return the earliest parseable journal timestamp in *cluster*."""
+    earliest: tuple[datetime, str] | None = None
+    for entry in cluster:
+        if not entry.timestamp:
+            continue
+        try:
+            dt = datetime.fromisoformat(entry.timestamp.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.astimezone(timezone.utc)
+        if earliest is None or dt < earliest[0]:
+            earliest = (dt, entry.timestamp)
+    return earliest[1] if earliest is not None else None
+
+
 def _is_generic_node(content: str) -> bool:
     """Return True if content matches a known generic advice pattern."""
     for pattern in _GENERIC_PATTERNS:
@@ -1115,6 +1133,7 @@ def _apply_consolidation_result(
                     knowledge_path,
                 )
                 result.nodes_contradicted += 1
+                cluster_valid_from = _cluster_valid_from(cluster)
                 now = datetime.now(timezone.utc).isoformat()
                 new_node = KnowledgeNode.create(
                     content=content,
@@ -1123,7 +1142,7 @@ def _apply_consolidation_result(
                     confidence=compute_confidence(len(cluster_sessions)),
                     tags=tags,
                 )
-                new_node.valid_from = now
+                new_node.valid_from = cluster_valid_from or now
                 update_node(target.id, {"superseded_by": new_node.id}, knowledge_path)
                 append_node(new_node, knowledge_path)
                 result.nodes_created += 1
@@ -1220,7 +1239,12 @@ def _apply_consolidation_result(
             else:
                 llm_valid_from = _validate_iso_date(raw_node.get("valid_from"))
                 llm_valid_until = _validate_iso_date(raw_node.get("valid_until"))
-            new_node.valid_from = llm_valid_from or datetime.now(timezone.utc).isoformat()
+            cluster_valid_from = _cluster_valid_from(cluster)
+            new_node.valid_from = (
+                llm_valid_from
+                or cluster_valid_from
+                or datetime.now(timezone.utc).isoformat()
+            )
             if llm_valid_until:
                 new_node.valid_until = llm_valid_until
             append_node(new_node, knowledge_path)

--- a/tests/recall/test_consolidate.py
+++ b/tests/recall/test_consolidate.py
@@ -470,8 +470,21 @@ class TestApplyConsolidation(unittest.TestCase):
         nodes = read_nodes(self.kn_path)
         self.assertEqual(len(nodes), 1)
         self.assertIsNone(nodes[0].valid_until)
-        self.assertIsNotNone(nodes[0].valid_from)
-        self.assertFalse(nodes[0].valid_from.startswith("2026-04-01"))
+        self.assertEqual(nodes[0].valid_from, "2026-03-01T00:00:00")
+
+    def test_create_action_defaults_valid_from_to_earliest_cluster_timestamp(self):
+        parsed = {
+            "nodes": [{
+                "action": "create",
+                "content": "Release flag flipped after PR #42 landed in /src/flags.py",
+                "category": "workflow",
+            }]
+        }
+        result = _apply_consolidation_result(parsed, [], self.cluster, self.kn_path)
+        self.assertEqual(result.nodes_created, 1)
+        nodes = read_nodes(self.kn_path)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].valid_from, "2026-03-01T00:00:00")
 
 
 class TestIsGenericNode(unittest.TestCase):


### PR DESCRIPTION
## Summary
- derive knowledge `valid_from` from the earliest parseable journal timestamp in the source cluster when the LLM does not provide a temporal bound
- keep wall-clock `now` only as the final fallback when cluster timestamps are unavailable
- add focused consolidate coverage for the new source-derived fallback

## Why
LOCOMO v6 narrowed the remaining regression to temporal and single-hop behavior. One concrete temporal flaw in current main is that newly consolidated knowledge defaults `valid_from` to wall-clock time, which can misdate facts extracted from older sessions and weaken temporal filtering/ranking later.

## Validation
- `PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/recall/test_consolidate.py`
- `PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/consolidate.py tests/recall/test_consolidate.py`
