### PR TITLE
fix: apply temporal windows to knowledge search

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -593,6 +593,32 @@ def _parse_chunk_timestamp(timestamp: str) -> datetime | None:
     return dt.astimezone(timezone.utc)
 
 
+def _knowledge_overlaps_temporal_window(
+    node: dict,
+    after: str | None = None,
+    before: str | None = None,
+) -> tuple[bool, bool]:
+    """Return whether a knowledge node overlaps a query window.
+
+    Returns ``(overlaps, has_temporal_bounds)``. Nodes without parseable
+    ``valid_from``/``valid_until`` remain eligible as timeless fallback
+    context, but do not receive a temporal overlap boost.
+    """
+    valid_from = _parse_chunk_timestamp(node.get("valid_from", ""))
+    valid_until = _parse_chunk_timestamp(node.get("valid_until", ""))
+    if valid_from is None and valid_until is None:
+        return True, False
+
+    query_after = _parse_chunk_timestamp(after or "")
+    query_before = _parse_chunk_timestamp(before or "")
+
+    if query_before is not None and valid_from is not None and valid_from >= query_before:
+        return False, True
+    if query_after is not None and valid_until is not None and valid_until < query_after:
+        return False, True
+    return True, True
+
+
 def _format_timestamp_display(timestamp: str, intent: str = "") -> str:
     """Render chunk timestamps in a query-appropriate display format."""
     if not timestamp:
@@ -1636,7 +1662,7 @@ class TranscriptIndex:
         if max_sessions is not None:
             result = self._progressive_lookup(
                 query, query_tokens, max_chunks, max_tokens, max_sessions,
-                date_filter, half_life, threshold_ratio, depth,
+                date_filter, after, before, half_life, threshold_ratio, depth,
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=_knowledge_boost,
                 now=now, max_knowledge=max_knowledge,
@@ -1645,6 +1671,7 @@ class TranscriptIndex:
         else:
             result = self._global_lookup(
                 query, query_tokens, max_chunks, max_tokens, date_filter,
+                after, before,
                 half_life, threshold_ratio, depth, include_archived,
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=_knowledge_boost,
@@ -1667,6 +1694,8 @@ class TranscriptIndex:
         max_chunks: int,
         max_tokens: int,
         date_filter: set[int] | None = None,
+        after: str | None = None,
+        before: str | None = None,
         half_life: float = 30.0,
         threshold_ratio: float = 0.2,
         depth: str = "full",
@@ -1684,6 +1713,7 @@ class TranscriptIndex:
         if self._db and self._rowid_to_idx:
             return self._global_lookup_fts(
                 query, max_chunks, max_tokens, date_filter,
+                after, before,
                 half_life, threshold_ratio, depth, include_archived,
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=knowledge_boost,
@@ -1702,6 +1732,8 @@ class TranscriptIndex:
         max_chunks: int,
         max_tokens: int,
         date_filter: set[int] | None,
+        after: str | None,
+        before: str | None,
         half_life: float,
         threshold_ratio: float,
         depth: str = "full",
@@ -1724,6 +1756,7 @@ class TranscriptIndex:
             query, max_chunks, include_historical=include_historical,
             knowledge_boost=knowledge_boost, emb_weight=emb_weight,
             query_entities=query_entities, intent=intent,
+            after=after, before=before,
         )
 
         # Apply min_confidence filter (grep-style noise reduction)
@@ -2146,6 +2179,8 @@ class TranscriptIndex:
         max_tokens: int,
         max_sessions: int,
         date_filter: set[int] | None = None,
+        after: str | None = None,
+        before: str | None = None,
         half_life: float = 30.0,
         threshold_ratio: float = 0.2,
         depth: str = "full",
@@ -2162,7 +2197,7 @@ class TranscriptIndex:
             self._search_knowledge(
                 query, max_chunks, include_historical=include_historical,
                 knowledge_boost=knowledge_boost, emb_weight=emb_weight,
-                intent=intent,
+                intent=intent, after=after, before=before,
             )
             if self._db else []
         )
@@ -2379,6 +2414,8 @@ class TranscriptIndex:
         emb_weight: float = 1.0,
         query_entities: set[str] | None = None,
         intent: str = "",
+        after: str | None = None,
+        before: str | None = None,
     ) -> list[dict]:
         """Search knowledge nodes via FTS5 + embedding hybrid.
 
@@ -2475,12 +2512,21 @@ class TranscriptIndex:
                     valid_until
                     and not include_historical
                     and not _env_flag("SYNAPT_DISABLE_KNOWLEDGE_EXPIRY")
+                    and not (intent == "temporal" and (after or before))
                 ):
                     try:
                         if valid_until[:10] < now_iso:
                             continue  # Expired — skip
                     except (TypeError, IndexError):
                         pass  # Invalid date format — don't filter
+                temporal_overlap = True
+                has_temporal_bounds = False
+                if intent == "temporal" and (after or before):
+                    temporal_overlap, has_temporal_bounds = (
+                        _knowledge_overlaps_temporal_window(node, after, before)
+                    )
+                    if not temporal_overlap:
+                        continue
                 node_content = node.get("content", "")
                 node_tokens = set(_tokenize(node_content))
                 token_overlap = len(query_tokens & node_tokens) >= min_matches
@@ -2522,11 +2568,19 @@ class TranscriptIndex:
                     aligned_cats = _CAT_INTENT_MAP.get(intent, set())
                     if node_cat in aligned_cats:
                         effective_boost *= 1.5
+                    if (
+                        intent == "temporal"
+                        and temporal_overlap
+                        and has_temporal_bounds
+                    ):
+                        effective_boost *= 1.2
                     raw_score = score_map.get(rowid, 0.0)
                     node["base_score"] = raw_score
                     node["score"] = raw_score * effective_boost
                     results.append(node)
                     seen_ids.add(node_id)
+
+            results.sort(key=lambda n: n.get("score", 0.0), reverse=True)
 
             # Confidence-based dedup: when multiple nodes share a lineage
             # (i.e. one superseded another), keep the highest-confidence one

--- a/tests/recall/test_core.py
+++ b/tests/recall/test_core.py
@@ -1740,6 +1740,93 @@ def test_search_knowledge_expiry_can_be_disabled(monkeypatch):
     assert any(r["content"] == expired["content"] for r in results)
 
 
+def test_search_knowledge_temporal_filters_non_overlapping_windows():
+    """Temporal queries should drop knowledge nodes outside the query window."""
+    from synapt.recall.core import TranscriptIndex
+    from unittest.mock import MagicMock
+
+    index = TranscriptIndex(make_test_chunks())
+
+    overlapping = {
+        "id": "node-1",
+        "content": "Caroline was using the old deploy flow in early March 2026",
+        "category": "fact",
+        "confidence": 0.8,
+        "source_sessions": ["sess1"],
+        "updated_at": "2026-03-05",
+        "valid_from": "2026-03-01",
+        "valid_until": "2026-03-10",
+    }
+    outside_window = {
+        "id": "node-2",
+        "content": "Caroline switched to the new deploy flow in April 2026",
+        "category": "fact",
+        "confidence": 0.8,
+        "source_sessions": ["sess2"],
+        "updated_at": "2026-04-02",
+        "valid_from": "2026-04-01",
+        "valid_until": "2026-04-30",
+    }
+
+    mock_db = MagicMock()
+    mock_db.knowledge_fts_search.return_value = [(2, 3.0), (1, 2.9)]
+    mock_db.knowledge_by_rowid.return_value = {1: overlapping, 2: outside_window}
+    index._db = mock_db
+
+    results = index._search_knowledge(
+        "What deploy flow was Caroline using in early March?",
+        intent="temporal",
+        after="2026-03-01",
+        before="2026-03-15",
+    )
+
+    assert len(results) == 1
+    assert results[0]["content"] == overlapping["content"]
+
+
+def test_search_knowledge_temporal_overlap_boosts_bounded_nodes():
+    """Overlapping temporal nodes should outrank timeless fallback nodes."""
+    from synapt.recall.core import TranscriptIndex
+    from unittest.mock import MagicMock
+
+    index = TranscriptIndex(make_test_chunks())
+
+    timeless = {
+        "id": "node-1",
+        "content": "Caroline deployed through the old pipeline",
+        "category": "fact",
+        "confidence": 0.8,
+        "source_sessions": ["sess1"],
+        "updated_at": "2026-03-05",
+    }
+    overlapping = {
+        "id": "node-2",
+        "content": "Caroline deployed through the old pipeline in March 2026",
+        "category": "fact",
+        "confidence": 0.8,
+        "source_sessions": ["sess2"],
+        "updated_at": "2026-03-05",
+        "valid_from": "2026-03-01",
+        "valid_until": "2026-03-31",
+    }
+
+    mock_db = MagicMock()
+    mock_db.knowledge_fts_search.return_value = [(1, 3.0), (2, 3.0)]
+    mock_db.knowledge_by_rowid.return_value = {1: timeless, 2: overlapping}
+    index._db = mock_db
+
+    results = index._search_knowledge(
+        "Which pipeline was Caroline using in March?",
+        intent="temporal",
+        after="2026-03-01",
+        before="2026-04-01",
+    )
+
+    assert len(results) == 2
+    assert results[0]["content"] == overlapping["content"]
+    assert results[0]["score"] > results[1]["score"]
+
+
 def test_expand_cross_session_can_be_disabled(monkeypatch):
     """Cross-link ablation flag should skip expansion entirely."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
- pass temporal after/before windows through the knowledge search path
- keep temporal queries from dropping historical knowledge nodes just because valid_until is in the past relative to wall-clock now
- mildly boost knowledge nodes whose validity window overlaps the requested temporal window, with focused coverage

## Validation
- PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/recall/test_core.py
- PYTHONPATH=src /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/core.py tests/recall/test_core.py