### PR TITLE
fix: recall_quick skips embedding loading (#472)

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -88,6 +88,7 @@ MCP_INSTRUCTIONS = (
 _cached_index: TranscriptIndex | None = None
 _cached_mtime: float = 0.0
 _cached_dir: Path | None = None
+_cached_has_embeddings: bool = False
 
 
 def _get_index(use_embeddings: bool = True) -> TranscriptIndex | None:
@@ -108,7 +109,13 @@ def _get_index(use_embeddings: bool = True) -> TranscriptIndex | None:
 
     try:
         mtime = check_path.stat().st_mtime
-        if _cached_index is None or mtime != _cached_mtime or index_dir != _cached_dir:
+        needs_reload = (
+            _cached_index is None
+            or mtime != _cached_mtime
+            or index_dir != _cached_dir
+            or (use_embeddings and not _cached_has_embeddings)
+        )
+        if needs_reload:
             # Close old DB connection before replacing cached index
             if _cached_index is not None and getattr(_cached_index, '_db', None) is not None:
                 with contextlib.suppress(Exception):
@@ -121,6 +128,7 @@ def _get_index(use_embeddings: bool = True) -> TranscriptIndex | None:
                 "Index loaded: %d chunks in %.1fs",
                 len(_cached_index.chunks), _time.monotonic() - _load_t0,
             )
+            _cached_has_embeddings = use_embeddings
             _cached_mtime = mtime
             _cached_dir = index_dir
             # Set current session ID for access tracking (distinct_sessions)
@@ -142,13 +150,14 @@ def _get_index(use_embeddings: bool = True) -> TranscriptIndex | None:
 
 def _invalidate_cache() -> None:
     """Reset cached index so next search reloads from disk."""
-    global _cached_index, _cached_mtime, _cached_dir
+    global _cached_index, _cached_mtime, _cached_dir, _cached_has_embeddings
     if _cached_index is not None and getattr(_cached_index, '_db', None) is not None:
         with contextlib.suppress(Exception):
             _cached_index._db.close()
     _cached_index = None
     _cached_mtime = 0.0
     _cached_dir = None
+    _cached_has_embeddings = False
 
 
 # Clean up the DB connection before Python's module teardown begins.


### PR DESCRIPTION
Reduces cold-start time for recall_quick by skipping SentenceTransformer model loading. Concise depth only needs BM25/FTS5. Generated with Claude Code