### PR TITLE
fix: increase gpt-5 codememo answer budget

### DIFF
--- a/evaluation/codememo/eval.py
+++ b/evaluation/codememo/eval.py
@@ -552,9 +552,10 @@ def token_f1(prediction: str, ground_truth: str) -> float:
 def generate_answer(question: str, context: str, client, model: str = "gpt-4o-mini") -> str:
     """Generate a short answer using the configured LLM."""
     prompt = ANSWER_PROMPT.format(context=context, question=question)
+    max_tokens = 150 if _is_gpt5_chat_model(model) else 100
     return _api_call_with_retry(
         client, [{"role": "user", "content": prompt}],
-        max_tokens=100, model=model,
+        max_tokens=max_tokens, model=model,
     )
 
 

--- a/tests/evaluation/test_codememo_eval.py
+++ b/tests/evaluation/test_codememo_eval.py
@@ -171,6 +171,23 @@ def test_api_call_uses_gpt5_completion_arg_shape():
     assert "seed" not in call
 
 
+def test_generate_answer_uses_higher_budget_for_gpt5():
+    client = _FakeClient()
+
+    result = codememo_eval.generate_answer(
+        "What version of croniter did we pin?",
+        "We pinned croniter 1.3.8 for recurring task support.",
+        client,
+        model="gpt-5-mini",
+    )
+
+    assert result == "ok"
+    call = client.chat.completions.calls[0]
+    assert call["model"] == "gpt-5-mini"
+    assert call["max_completion_tokens"] == 150
+    assert call["reasoning_effort"] == "minimal"
+
+
 def test_run_evaluation_can_reset_working_memory_between_runs(tmp_path):
     project = _write_project(tmp_path)
     sut = FakeSUT()


### PR DESCRIPTION
Raises GPT-5 CodeMemo answer-generation budget from 100 to 150 completion tokens while keeping reasoning_effort=minimal.\n\nWhy:\n- #287 fixed the GPT-5 param shape and eliminated the all-zero failure mode\n- but some long CodeMemo answer prompts still returned empty visible content at 100 tokens because the model hit length before finishing the answer\n- reproduced on p01_q001; 150 tokens resolves it cleanly\n\nValidation:\n- pytest -q -o addopts='' tests/evaluation/test_codememo_eval.py\n- py_compile evaluation/codememo/eval.py tests/evaluation/test_codememo_eval.py\n- direct generate_answer() repro for p01_q001 now returns a visible answer