### PR TITLE
fix: resolve relative dates in enrichment prompt

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -111,6 +111,8 @@ def _build_transcript_summary(session_id: str, project_dir: Path) -> str:
 ENRICHMENT_PROMPT = """\
 You are summarizing a session transcript. Extract structured information about what happened.
 
+Session date: {session_date}
+
 Given the following transcript, produce a JSON object with these fields:
 - "focus": A one-sentence description of the session's main topic or goal (max 200 chars)
 - "done": A list of 1-5 concrete things accomplished, discussed, or learned (each max 100 chars)
@@ -119,9 +121,11 @@ Given the following transcript, produce a JSON object with these fields:
 
 Rules:
 - Include specific names, dates, places, numbers, and details — NOT general themes
+- Resolve ALL relative time references to absolute dates using the session date above (e.g. "yesterday" → the actual date, "last week" → the actual date range)
 - Capture people's names, their relationships, possessions, hobbies, and stated preferences
 - BAD: "discussed travel plans" — GOOD: "plans trip to Florida in June with sister Elena"
 - BAD: "talked about hobbies" — GOOD: "signed up for pottery class on July 2nd"
+- BAD: "fixed a bug yesterday" — GOOD: "fixed auth bug on March 14"
 - If the session was short or trivial, use fewer items
 - Output ONLY valid JSON, no markdown fences, no explanation
 
@@ -269,7 +273,17 @@ def enrich_entry(
                 return None
             client = MLXClient(MLXOptions(max_tokens=800))
 
-    prompt = ENRICHMENT_PROMPT.format(transcript=transcript_text)
+    # Derive human-readable session date for relative date resolution
+    session_date = "unknown"
+    if entry.timestamp:
+        try:
+            from datetime import datetime as _dt, timezone as _tz
+            _ts = entry.timestamp.replace("Z", "+00:00")
+            _parsed = _dt.fromisoformat(_ts)
+            session_date = _parsed.strftime("%A, %B %d, %Y")
+        except (ValueError, AttributeError):
+            pass
+    prompt = ENRICHMENT_PROMPT.format(transcript=transcript_text, session_date=session_date)
 
     try:
         response = client.chat(

--- a/tests/recall/test_enrich.py
+++ b/tests/recall/test_enrich.py
@@ -209,12 +209,19 @@ class TestEnrichmentPrompt(unittest.TestCase):
         self.assertIn("{transcript}", ENRICHMENT_PROMPT)
 
     def test_format_with_transcript(self):
-        prompt = ENRICHMENT_PROMPT.format(transcript="[Turn 1] User: hello")
+        prompt = ENRICHMENT_PROMPT.format(
+            transcript="[Turn 1] User: hello",
+            session_date="Monday, March 22, 2026",
+        )
         self.assertIn("[Turn 1] User: hello", prompt)
         self.assertIn("focus", prompt)
         self.assertIn("done", prompt)
         self.assertIn("decisions", prompt)
         self.assertIn("next_steps", prompt)
+        self.assertIn("March 22, 2026", prompt)
+
+    def test_has_session_date_placeholder(self):
+        self.assertIn("{session_date}", ENRICHMENT_PROMPT)
 
 
 class TestIterEnrichableEntries(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Pass session date to the enrichment prompt so the LLM resolves relative time references to absolute dates
- "yesterday" → "March 14", "last week" → actual date range
- Adds new rule + example to the enrichment prompt
- Derives human-readable date from `entry.timestamp`

## Why
Phase B2 of temporal refinements (#464). Knowledge nodes with absolute dates are FTS-searchable via the `date_text` field (weight 3.0). Relative dates like "yesterday" are meaningless outside the session context.

## Test plan
- [x] 49/49 enrichment tests pass
- [x] New test verifies session_date placeholder works
- [x] Backward compatible — unknown date falls back to "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)