### PR TITLE
bench: flag codememo saturation in eval summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ First benchmark specifically testing coding session memory — 158 questions acr
 
 Synapt leads by **+14.51pp overall**. The biggest gaps are in convention (+37pp), factual (+24pp), and debug (+22pp) — categories that depend on raw evidence preservation. Synapt runs entirely locally; Mem0 requires OpenAI API calls for memory extraction, embedding, and search.
 
+For current regression tracking, prefer **all-project CodeMemo runs** over
+single-project best slices. On `project_01_cli_tool`, some categories are now
+approaching ceiling on strong systems, so isolated `100.0` scores are useful as
+regression checks but less useful as headline evidence on their own.
+
 ## How search works
 
 Synapt runs three retrieval paths and merges them:

--- a/evaluation/BENCHMARKS.md
+++ b/evaluation/BENCHMARKS.md
@@ -30,6 +30,34 @@ claims to have run at a specific ref.
 
 ## Current Results
 
+### CodeMemo interpretation notes (2026-03-22)
+
+Use **all-project CodeMemo runs** for headline comparisons when possible. The
+`project_01_cli_tool` slice is still useful for regression testing, but some
+categories on strong current systems are approaching ceiling and are no longer
+very discriminative on their own.
+
+Recent normalized reruns on `gpt-5-mini`:
+
+| Ref | Scope | Mode | Model | Overall |
+|-----|-------|------|-------|---------|
+| v0.6.1 | `project_01_cli_tool` | full-pipeline | gpt-5-mini | 76.0 |
+| v0.6.2 | all 3 projects | recalldb | gpt-5-mini | 71.9 |
+| v0.7.5 | `project_01_cli_tool` | recalldb | gpt-5-mini | 82.0 |
+| latest `main` (`5b3f58a`) | `project_01_cli_tool` | recalldb | gpt-5-mini | 84.0 |
+
+Important caveats:
+
+- The earlier `96.0%` `v0.7.5` result was on `gpt-4o-mini` and is still valid
+  for that standard methodology, but it is **not** directly comparable to the
+  normalized `gpt-5-mini` reruns above.
+- On `project_01`, the strongest current systems are partially saturated in a
+  few categories. Treat isolated `100.0` values over `7-8` questions as a sign
+  to inspect category-level headroom, not as proof that the whole benchmark is
+  exhausted.
+- The evaluator now emits `validity_notes` and `category_diagnostics` in
+  `codememo_summary.json` to make this visible in run artifacts.
+
 ### CodeMemo v0.6.2 — Synapt vs Mem0 (2026-03-14)
 
 First apples-to-apples comparison of coding memory systems on the CodeMemo benchmark. Same 158 questions, same gpt-4o-mini judge, same transcript data — only the memory system differs.

--- a/evaluation/codememo/eval.py
+++ b/evaluation/codememo/eval.py
@@ -60,6 +60,9 @@ _LOCAL_DATA = CODEMEMO_DIR / "data"
 
 # HuggingFace dataset ID — auto-downloaded if no local data/ directory exists
 HF_DATASET_ID = "laynepro/codememo-benchmark"
+_SMALL_SAMPLE_THRESHOLD = 10
+_NEAR_CEILING_J_SCORE = 95.0
+_RECALL_REASONING_GAP_THRESHOLD = 20.0
 
 
 def _resolve_data_dir() -> Path:
@@ -178,6 +181,73 @@ def _audit_finish(start_ts: str, summary: dict, outcome: str = "SUCCESS") -> Non
     _audit_log(entry)
     j = summary.get("j_score_overall", "?")
     print(f"  [audit] Logged {outcome} — J-Score: {j}%")
+
+
+def _add_validity_metadata(summary: dict) -> dict:
+    """Attach benchmark-validity diagnostics to a CodeMemo summary."""
+    category_diagnostics: dict[str, dict] = {}
+    validity_notes: list[str] = []
+    near_ceiling: list[tuple[str, float, int]] = []
+    reasoning_gap: list[tuple[str, float, float]] = []
+
+    max_chunks = summary.get("max_chunks", 20)
+    for cat in sorted(ALL_CATEGORIES):
+        name = CATEGORY_NAMES[cat]
+        n = summary.get(f"n_{name}")
+        j_score = summary.get(f"j_score_{name}")
+        recall = summary.get(f"recall@{max_chunks}_{name}")
+
+        if n is None and j_score is None and recall is None:
+            continue
+
+        entry: dict[str, int | float | bool] = {}
+        if n is not None:
+            entry["questions"] = n
+            entry["small_sample"] = n < _SMALL_SAMPLE_THRESHOLD
+        if j_score is not None:
+            entry["j_score"] = j_score
+            entry["headroom"] = round(max(0.0, 100.0 - j_score), 2)
+            entry["near_ceiling"] = j_score >= _NEAR_CEILING_J_SCORE
+        if recall is not None:
+            entry["recall_at_k"] = recall
+        if j_score is not None and recall is not None:
+            gap = round(j_score - recall, 2)
+            entry["reasoning_gap"] = gap
+            entry["high_reasoning_gap"] = gap >= _RECALL_REASONING_GAP_THRESHOLD
+        category_diagnostics[name] = entry
+
+        if (
+            n is not None
+            and j_score is not None
+            and j_score >= _NEAR_CEILING_J_SCORE
+        ):
+            near_ceiling.append((name, j_score, n))
+        if (
+            j_score is not None
+            and recall is not None
+            and j_score >= _NEAR_CEILING_J_SCORE
+            and (j_score - recall) >= _RECALL_REASONING_GAP_THRESHOLD
+        ):
+            reasoning_gap.append((name, j_score, recall))
+
+    if len(summary.get("projects", [])) == 1:
+        validity_notes.append(
+            "Single-project slice; prefer all-project CodeMemo runs for headline claims."
+        )
+    for name, j_score, n in near_ceiling:
+        validity_notes.append(
+            f"Category '{name}' is near ceiling on this slice ({j_score:.2f}% over {n} questions)."
+        )
+    for name, j_score, recall in reasoning_gap:
+        validity_notes.append(
+            f"Category '{name}' has near-ceiling J-score ({j_score:.2f}%) despite lower retrieval recall ({recall:.2f}%), so answer-model or judge effects may be masking retrieval weakness."
+        )
+
+    if category_diagnostics:
+        summary["category_diagnostics"] = category_diagnostics
+    if validity_notes:
+        summary["validity_notes"] = validity_notes
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -1248,6 +1318,7 @@ def run_evaluation(
                     )
                 deltas.append(delta)
             summary["run_deltas"] = deltas
+    summary = _add_validity_metadata(summary)
 
     # Print summary
     print("\n" + "=" * 60)
@@ -1255,6 +1326,10 @@ def run_evaluation(
     print("=" * 60)
     for k, v in summary.items():
         print(f"  {k}: {v}")
+    if summary.get("validity_notes"):
+        print("  benchmark_validity:")
+        for note in summary["validity_notes"]:
+            print(f"    - {note}")
     print("=" * 60)
 
     # Save results

--- a/tests/evaluation/test_codememo_eval.py
+++ b/tests/evaluation/test_codememo_eval.py
@@ -188,6 +188,38 @@ def test_generate_answer_uses_higher_budget_for_gpt5():
     assert call["reasoning_effort"] == "minimal"
 
 
+def test_add_validity_metadata_flags_slice_ceiling_and_reasoning_gap():
+    summary = {
+        "projects": ["project_01_cli_tool"],
+        "max_chunks": 20,
+        "n_temporal": 8,
+        "j_score_temporal": 100.0,
+        "recall@20_temporal": 56.25,
+        "n_convention": 7,
+        "j_score_convention": 100.0,
+        "recall@20_convention": 85.71,
+        "n_debug": 9,
+        "j_score_debug": 66.67,
+        "recall@20_debug": 53.7,
+    }
+
+    annotated = codememo_eval._add_validity_metadata(summary)
+
+    diagnostics = annotated["category_diagnostics"]
+    assert diagnostics["temporal"]["near_ceiling"] is True
+    assert diagnostics["temporal"]["small_sample"] is True
+    assert diagnostics["temporal"]["headroom"] == 0.0
+    assert diagnostics["temporal"]["high_reasoning_gap"] is True
+    assert diagnostics["debug"]["near_ceiling"] is False
+    assert diagnostics["debug"]["high_reasoning_gap"] is False
+
+    notes = annotated["validity_notes"]
+    assert any("Single-project slice" in note for note in notes)
+    assert any("Category 'temporal' is near ceiling" in note for note in notes)
+    assert any("Category 'convention' is near ceiling" in note for note in notes)
+    assert any("may be masking retrieval weakness" in note for note in notes)
+
+
 def test_run_evaluation_can_reset_working_memory_between_runs(tmp_path):
     project = _write_project(tmp_path)
     sut = FakeSUT()


### PR DESCRIPTION
## Summary
- add CodeMemo validity notes and category diagnostics to eval summaries
- flag single-project best-slice ceiling risk and large retrieval-vs-J-score gaps
- document that all-project runs are the preferred CodeMemo headline surface

## Validation
- /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/evaluation/test_codememo_eval.py
- /Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile evaluation/codememo/eval.py