### PR TITLE
bench: add codememo recall gate

### DIFF
--- a/evaluation/codememo/eval.py
+++ b/evaluation/codememo/eval.py
@@ -63,6 +63,13 @@ HF_DATASET_ID = "laynepro/codememo-benchmark"
 _SMALL_SAMPLE_THRESHOLD = 10
 _NEAR_CEILING_J_SCORE = 95.0
 _RECALL_REASONING_GAP_THRESHOLD = 20.0
+_NEGATIVE_EVIDENCE_RE = re.compile(
+    r"\b("
+    r"never|no |none|not |did not|didn't|was not|wasn't|were not|weren't|"
+    r"not implemented|not added|not called|not used|no evidence|no such"
+    r")\b",
+    re.IGNORECASE,
+)
 
 
 def _resolve_data_dir() -> Path:
@@ -651,6 +658,33 @@ def judge_answer(
     return 1 if label == "CORRECT" else 0
 
 
+def _is_negative_evidence_question(question: str, gold_answer: str) -> bool:
+    """Return True when a question explicitly tests absence/negative evidence."""
+    text = f"{question}\n{gold_answer}"
+    return bool(_NEGATIVE_EVIDENCE_RE.search(text))
+
+
+def _apply_recall_gate(
+    *,
+    j_score: int,
+    recall_at_k: float,
+    question: str,
+    gold_answer: str,
+) -> int:
+    """Cap judged wins that were produced with zero retrieved evidence.
+
+    Exception: questions that explicitly test negative evidence ("never",
+    "not implemented", etc.) are allowed to pass without retrieved support.
+    """
+    if j_score != 1:
+        return j_score
+    if recall_at_k > 0.0:
+        return j_score
+    if _is_negative_evidence_question(question, gold_answer):
+        return j_score
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Retrieval recall (evidence-based)
 # ---------------------------------------------------------------------------
@@ -1237,14 +1271,21 @@ def run_evaluation(
                     category_f1[category].append(f1)
 
                     t0 = time.time()
-                    j_score = judge_answer(question, gold, generated, client, model=model)
+                    raw_j_score = judge_answer(question, gold, generated, client, model=model)
                     judge_time = time.time() - t0
                     total_judge_time += judge_time
 
+                    j_score = _apply_recall_gate(
+                        j_score=raw_j_score,
+                        recall_at_k=recall_at_k,
+                        question=question,
+                        gold_answer=gold,
+                    )
                     category_scores[category].append(j_score)
                     result_entry.update({
                         "generated_answer": generated,
                         "j_score": j_score,
+                        "raw_j_score": raw_j_score,
                         "f1": round(f1, 4),
                         "generate_time_ms": round(generate_time * 1000, 1),
                         "judge_time_ms": round(judge_time * 1000, 1),

--- a/tests/evaluation/test_codememo_eval.py
+++ b/tests/evaluation/test_codememo_eval.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -235,6 +236,50 @@ def test_run_evaluation_can_reset_working_memory_between_runs(tmp_path):
 
     assert summary["repeat_runs"] == 3
     assert sut.reset_calls == 2
+
+
+def test_apply_recall_gate_caps_zero_recall_non_negative_questions():
+    gated = codememo_eval._apply_recall_gate(
+        j_score=1,
+        recall_at_k=0.0,
+        question="What was the final test count and coverage percentage?",
+        gold_answer="41 tests and 89% coverage",
+    )
+
+    assert gated == 0
+
+
+def test_apply_recall_gate_allows_negative_evidence_questions():
+    gated = codememo_eval._apply_recall_gate(
+        j_score=1,
+        recall_at_k=0.0,
+        question="Was close_connection() ever called?",
+        gold_answer="No, it was never called.",
+    )
+
+    assert gated == 1
+
+
+def test_run_evaluation_applies_recall_gate_to_judged_wins(tmp_path, monkeypatch):
+    project = _write_project(tmp_path)
+    sut = FakeSUT()
+
+    monkeypatch.setattr(codememo_eval, "generate_answer", lambda *args, **kwargs: "89% coverage")
+    monkeypatch.setattr(codememo_eval, "judge_answer", lambda *args, **kwargs: 1)
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=lambda: _FakeClient()))
+
+    summary = codememo_eval.run_evaluation(
+        project_dirs=[project],
+        sut=sut,
+        output_path=tmp_path / "results",
+        repeat_runs=1,
+    )
+
+    assert summary["j_score_overall"] == 0.0
+
+    detailed = json.loads((tmp_path / "results" / "codememo_detailed.json").read_text())
+    assert {row["raw_j_score"] for row in detailed} == {1}
+    assert {row["j_score"] for row in detailed} == {0}
 
 
 def test_synapt_sut_namespaces_persistent_work_dir_per_project(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- cap CodeMemo judged wins when retrieval recall is zero on non-negative-evidence questions
- preserve explicit negative-evidence questions like "never called" / "not implemented"
- record both `raw_j_score` and gated `j_score` in detailed results

## Why
Apollo's remediation audit on #296 found several `recall=0, J=1` wins that should not count as memory success. This patch hardens the evaluator without waiting on the external dataset cleanup.

## Validation
- `.venv/bin/python -m pytest -q -o addopts='' tests/evaluation/test_codememo_eval.py`
- `.venv/bin/python -m py_compile evaluation/codememo/eval.py tests/evaluation/test_codememo_eval.py`

Refs #296
