### PR TITLE
eval: harden temporal LOCOMO answer prompt

### DIFF
--- a/evaluation/locomo_eval.py
+++ b/evaluation/locomo_eval.py
@@ -655,12 +655,20 @@ that anchor point:
    - "recently" or "the other day" → within the week before the timestamp
 4. You MUST answer with a specific date, month, or year — NEVER use relative \
 references like "last week" or "recently" in your answer
-5. If the event is described as happening relative to the conversation time, \
+5. The conversation timestamp is ONLY an anchor for resolving relative phrases. \
+It is NOT automatically the date of the event itself. If someone is recalling an \
+earlier event, do not answer with the conversation date unless the text clearly \
+says the event happened that same day.
+6. If the event is described as happening relative to the conversation time, \
 SHOW YOUR REASONING: state the anchor timestamp, the relative expression, \
 and the computed date
-6. If multiple memories mention the same event, use the one where the event \
-was first discussed — that timestamp is closest to when it actually happened
-7. Answer with specific details from the memories. Be precise — include \
+7. If multiple memories mention the same event, prefer the memory that gives the \
+clearest date evidence for WHEN it happened, not merely the latest conversation \
+where it was discussed.
+8. If no relative phrase is present, look for an explicit absolute date, month, \
+year, season, holiday, birthday, or "during X" reference in the memory text. Do \
+NOT default to the header timestamp just because the event is mentioned there.
+9. Answer with specific details from the memories. Be precise — include \
 exact dates, names, and facts. Be complete but concise — use 2-3 sentences \
 if needed to show your date reasoning.
 
@@ -691,32 +699,30 @@ def _api_call_with_retry(client, messages, max_tokens=50, retries=3, model="gpt-
             raise RuntimeError(f"API call failed after {retries} retries: {e}") from e
 
 
+def build_answer_prompt(question: str, context: str, category: int = 0, date_range: str = "") -> str:
+    """Build the category-appropriate answer prompt for LOCOMO."""
+    dr_text = f"\nThe conversations span from {date_range}." if date_range else ""
+    if category == 1:
+        return MULTIHOP_ANSWER_PROMPT.format(
+            context=context, question=question, date_range=dr_text,
+        )
+    if category == 2:
+        return TEMPORAL_ANSWER_PROMPT.format(
+            context=context, question=question, date_range=dr_text,
+        )
+    return ANSWER_PROMPT.format(
+        context=context, question=question, date_range=dr_text,
+    )
+
+
 def generate_answer(
     question: str, context: str, client,
     category: int = 0, date_range: str = "",
 ) -> str:
-    """Generate a short answer using gpt-4o-mini.
-
-    Uses category-specific prompts:
-    - Category 1 (multi-hop): MULTIHOP_ANSWER_PROMPT — emphasizes aggregation
-    - Category 2 (temporal): TEMPORAL_ANSWER_PROMPT — emphasizes date computation
-    - All others: ANSWER_PROMPT — general memory retrieval
-
-    Injects session date range into all prompts when available.
-    """
-    dr_text = f"\nThe conversations span from {date_range}." if date_range else ""
-    if category == 1:
-        prompt = MULTIHOP_ANSWER_PROMPT.format(
-            context=context, question=question, date_range=dr_text,
-        )
-    elif category == 2:
-        prompt = TEMPORAL_ANSWER_PROMPT.format(
-            context=context, question=question, date_range=dr_text,
-        )
-    else:
-        prompt = ANSWER_PROMPT.format(
-            context=context, question=question, date_range=dr_text,
-        )
+    """Generate a short answer using gpt-4o-mini."""
+    prompt = build_answer_prompt(
+        question, context, category=category, date_range=date_range,
+    )
     return _api_call_with_retry(
         client, [{"role": "user", "content": prompt}], max_tokens=100,
     )

--- a/tests/evaluation/test_locomo_eval.py
+++ b/tests/evaluation/test_locomo_eval.py
@@ -55,3 +55,18 @@ def test_build_question_pairs_reverses_within_each_conversation():
         (1, "q1b"),
         (1, "q1a"),
     ]
+
+
+def test_build_answer_prompt_adds_temporal_guardrails():
+    prompt = locomo_eval.build_answer_prompt(
+        question="When did Caroline give a speech at a school?",
+        context="memory block",
+        category=2,
+        date_range="8 May 2023 to 9 June 2023",
+    )
+
+    assert "ONLY an anchor for resolving relative phrases" in prompt
+    assert "do not answer with the conversation date" in prompt
+    assert "prefer the memory that gives the clearest date evidence" in prompt
+    assert "Do NOT default to the header timestamp" in prompt
+    assert "The conversations span from 8 May 2023 to 9 June 2023." in prompt


### PR DESCRIPTION
## Summary
- harden the LOCOMO temporal answer prompt so the conversation header timestamp is treated as an anchor for relative phrases, not automatically the event date
- refactor prompt construction into `build_answer_prompt()` so the temporal guardrails are directly testable
- add focused regression coverage for the new temporal prompt instructions

## Why
Recent LOCOMO miss analysis found a meaningful `retrieval_recall = 1.0 but wrong answer` bucket in temporal questions. The sampled failures consistently overused the memory block header timestamp as the event date even when the conversation was discussing an earlier event. This patch adds explicit prompt guardrails against that failure mode.

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/evaluation/test_locomo_eval.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile evaluation/locomo_eval.py tests/evaluation/test_locomo_eval.py`
