### PR TITLE
eval: record LOCOMO search result summaries

### DIFF
--- a/evaluation/locomo_eval.py
+++ b/evaluation/locomo_eval.py
@@ -564,6 +564,21 @@ def retrieve_context(
     return result
 
 
+def attach_search_summary(result_entry: dict, index) -> None:
+    """Attach the last search summary from a RecallIndex-like object."""
+    summary = getattr(index, "_last_search_summary", None)
+    if summary is None:
+        return
+    result_entry.update({
+        "search_intent": summary.intent,
+        "selected_blocks": summary.selected_blocks,
+        "chunk_blocks": summary.chunk_blocks,
+        "knowledge_blocks": summary.knowledge_blocks,
+        "cluster_blocks": summary.cluster_blocks,
+        "effective_max_knowledge": summary.max_knowledge,
+    })
+
+
 # ---------------------------------------------------------------------------
 # Step 4: Generate answer using LLM
 # ---------------------------------------------------------------------------
@@ -1075,6 +1090,7 @@ def run_evaluation(
                 "retrieve_time_ms": round(retrieve_time * 1000, 1),
                 "retrieval_recall": recall_at_k,
             }
+            attach_search_summary(result_entry, indexes[conv_idx])
 
             if not retrieval_only and client:
                 # Generate answer

--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -239,6 +239,18 @@ class SearchDiagnostics:
         return "No results found."
 
 
+@dataclass
+class SearchResultSummary:
+    """Summary of what a successful search emitted."""
+
+    intent: str = ""
+    max_knowledge: int | None = None
+    selected_blocks: int = 0
+    chunk_blocks: int = 0
+    knowledge_blocks: int = 0
+    cluster_blocks: int = 0
+
+
 # ---------------------------------------------------------------------------
 # Transcript parser
 # ---------------------------------------------------------------------------
@@ -995,6 +1007,7 @@ class TranscriptIndex:
 
         # Search diagnostics (populated on empty results for caller inspection)
         self._last_diagnostics: SearchDiagnostics | None = None
+        self._last_search_summary: SearchResultSummary | None = None
         self._last_conflicts: list[tuple[dict, dict]] = []
 
         # Query result cache — avoids re-computing BM25/embedding/RRF for
@@ -1572,6 +1585,7 @@ class TranscriptIndex:
             When empty, ``self._last_diagnostics`` explains why.
         """
         self._last_diagnostics = None
+        self._last_search_summary = None
         self._last_conflicts: list[tuple[dict, dict]] = []
 
         if not self.chunks:
@@ -3150,7 +3164,23 @@ class TranscriptIndex:
             lines.append(conflict_notice)
 
         if len(lines) <= 1:
+            self._last_search_summary = SearchResultSummary(
+                intent=intent,
+                max_knowledge=max_knowledge,
+                selected_blocks=0,
+                chunk_blocks=0,
+                knowledge_blocks=0,
+                cluster_blocks=0,
+            )
             return ""
+        self._last_search_summary = SearchResultSummary(
+            intent=intent,
+            max_knowledge=max_knowledge,
+            selected_blocks=len(emitted_access),
+            chunk_blocks=sum(1 for item in emitted_access if item["item_type"] == "chunk"),
+            knowledge_blocks=sum(1 for item in emitted_access if item["item_type"] == "knowledge"),
+            cluster_blocks=sum(1 for item in emitted_access if item["item_type"] == "cluster"),
+        )
         return "\n".join(lines)
 
     def _access_frequency_boost(

--- a/tests/evaluation/test_locomo_eval.py
+++ b/tests/evaluation/test_locomo_eval.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _load_locomo_eval():
@@ -70,3 +71,26 @@ def test_build_answer_prompt_adds_temporal_guardrails():
     assert "prefer the memory that gives the clearest date evidence" in prompt
     assert "Do NOT default to the header timestamp" in prompt
     assert "The conversations span from 8 May 2023 to 9 June 2023." in prompt
+
+
+def test_attach_search_summary_adds_diagnostic_fields():
+    result = {"question": "When did Caroline give a speech at a school?"}
+    index = SimpleNamespace(
+        _last_search_summary=SimpleNamespace(
+            intent="temporal",
+            selected_blocks=4,
+            chunk_blocks=4,
+            knowledge_blocks=0,
+            cluster_blocks=0,
+            max_knowledge=0,
+        )
+    )
+
+    locomo_eval.attach_search_summary(result, index)
+
+    assert result["search_intent"] == "temporal"
+    assert result["selected_blocks"] == 4
+    assert result["chunk_blocks"] == 4
+    assert result["knowledge_blocks"] == 0
+    assert result["cluster_blocks"] == 0
+    assert result["effective_max_knowledge"] == 0


### PR DESCRIPTION
## Summary
- store a lightweight `_last_search_summary` on `RecallIndex` after successful searches
- thread that search summary into LOCOMO per-question output so detailed results show whether a query emitted chunks, knowledge, or clusters and what effective `max_knowledge` was used
- add focused test coverage for the LOCOMO-side summary attachment helper

## Why
Recent LOCOMO analysis narrowed the main gap to evidence coverage / surfacing, but the current detailed outputs do not tell us whether a miss came back with zero blocks, chunk-only results, or knowledge-enabled results. This patch adds enough observability to stop inferring that from rendered context strings.

## Validation
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m pytest -q -o addopts='' tests/evaluation/test_locomo_eval.py`
- `/Users/layne/Development/synapt-codex/synapt/.venv/bin/python -m py_compile src/synapt/recall/core.py evaluation/locomo_eval.py tests/evaluation/test_locomo_eval.py`
