### PR TITLE
fix: revert blanket personal-content specificity skip

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -2545,13 +2545,7 @@ class TranscriptIndex:
                     if conf < 0.4:
                         effective_boost = 1.0
                     else:
-                        if (
-                            _env_flag("SYNAPT_DISABLE_SPECIFICITY_SCORING")
-                            or (
-                                getattr(getattr(self, "_adaptive", None), "content_type", None)
-                                == "personal"
-                            )
-                        ):
+                        if _env_flag("SYNAPT_DISABLE_SPECIFICITY_SCORING"):
                             specificity = 1.0
                         else:
                             from synapt.recall.consolidate import _lacks_specificity


### PR DESCRIPTION
## Summary
- Reverts the content-profile-based specificity bypass from PR #299
- Keeps `SYNAPT_DISABLE_SPECIFICITY_SCORING` env flag for targeted ablations
- One-line change: removes the `or (content_type == "personal")` branch from knowledge node specificity scoring

## Evidence
LOCOMO v9 (1400/1540 questions, treated as final) scored **72.1%** — the worst full run since v0.7.4 (71.5%). The blanket specificity skip was the only config difference vs v7 (74.6%), which remains the best LOCOMO config.

The miss taxonomy showed scoring changes (including specificity) can only address 5% of misses (the "displaced" bucket). The blanket skip actively hurt multi-hop (-5.4pp vs v7) and open-domain (-5.2pp) while single-hop gains washed out on later conversations.

## Test plan
- [x] Existing tests pass (no test coverage for the removed branch — it was a conditional bypass)
- [x] CodeMemo unaffected (uses code content profile, not personal)
- [x] `SYNAPT_DISABLE_SPECIFICITY_SCORING` env flag still works for ablations

🤖 Generated with [Claude Code](https://claude.com/claude-code)