### PR TITLE
feat: add channel unpin support (#303)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1181,6 +1181,30 @@ def channel_pin(
     return f"Pinned [{message_id}] in #{channel}: {body}"
 
 
+def channel_unpin(
+    channel: str,
+    message_id: str,
+    agent_name: str | None = None,
+    project_dir: Path | None = None,
+) -> str:
+    """Unpin a message by its message_id."""
+    conn = _open_db(project_dir)
+    try:
+        row = conn.execute(
+            "SELECT id, body FROM pins WHERE channel = ? AND message_id = ?",
+            (channel, message_id),
+        ).fetchone()
+        if not row:
+            return f"No pin found for [{message_id}] in #{channel}."
+        conn.execute("DELETE FROM pins WHERE id = ?", (row["id"],))
+        conn.commit()
+    finally:
+        conn.close()
+
+    body_preview = row["body"][:80] + "..." if len(row["body"]) > 80 else row["body"]
+    return f"Unpinned [{message_id}] from #{channel}: {body_preview}"
+
+
 # ---------------------------------------------------------------------------
 # New operations: directive, mute, kick, broadcast, list
 # ---------------------------------------------------------------------------

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1571,6 +1571,7 @@ def recall_channel(
             channel_unread,
             channel_unread_read,
             channel_pin,
+            channel_unpin,
             channel_directive,
             channel_mute,
             channel_unmute,
@@ -1607,6 +1608,11 @@ def recall_channel(
             if not message:
                 return "Error: message_id is required for 'pin' action."
             return channel_pin(channel=channel, message_id=message)
+
+        if action == "unpin":
+            if not message:
+                return "Error: message_id is required for 'unpin' action."
+            return channel_unpin(channel=channel, message_id=message)
 
         if action == "directive":
             if not message:

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -28,6 +28,7 @@ from synapt.recall.channel import (
     channel_unread,
     channel_unread_read,
     channel_pin,
+    channel_unpin,
     channel_directive,
     channel_mute,
     channel_unmute,
@@ -636,6 +637,54 @@ class TestPins(unittest.TestCase):
         result = channel_read("dev")
         self.assertIn("rule 1", result)
         self.assertIn("rule 2", result)
+
+
+class TestUnpin(unittest.TestCase):
+    """Test unpin functionality (#303)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self.tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _post_and_get_id(self, channel, message):
+        channel_join(channel, agent_name="s_admin")
+        channel_post(channel, message, agent_name="s_admin")
+        path = _channels_dir() / f"{channel}.jsonl"
+        msgs = _read_messages(path)
+        return msgs[-1].id
+
+    def test_unpin_removes_pin(self):
+        msg_id = self._post_and_get_id("dev", "pinned content")
+        channel_pin("dev", msg_id, agent_name="s_admin")
+        result = channel_read("dev", agent_name="s_admin")
+        self.assertIn("[pin]", result)
+
+        unpin_result = channel_unpin("dev", msg_id)
+        self.assertIn("Unpinned", unpin_result)
+
+        result_after = channel_read("dev", agent_name="s_admin")
+        self.assertNotIn("[pin]", result_after)
+
+    def test_unpin_nonexistent(self):
+        channel_join("dev", agent_name="s_admin")
+        result = channel_unpin("dev", "m_doesnotexist")
+        self.assertIn("No pin found", result)
+
+    def test_unpin_one_of_multiple(self):
+        id1 = self._post_and_get_id("dev", "keep this pin")
+        id2 = self._post_and_get_id("dev", "remove this pin")
+        channel_pin("dev", id1, agent_name="s_admin")
+        channel_pin("dev", id2, agent_name="s_admin")
+
+        channel_unpin("dev", id2)
+
+        result = channel_read("dev", agent_name="s_admin")
+        self.assertIn("keep this pin", result)
+        self.assertNotIn("remove this pin", result.split("##")[1] if "##" in result else "")
 
 
 class TestPostAndRead(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `channel_unpin()` function to remove pins by message_id
- Expose via MCP server as `recall_channel(action="unpin", message=<msg_id>)`
- 3 focused tests covering: remove pin, nonexistent pin, selective unpin

## Why
Layne requested pin cleanup (#303). The channel system had `pin` but no `unpin`, so stale pins accumulated with no way to remove them.

## Test plan
- [x] 137/137 channel tests pass (134 existing + 3 new)
- [x] Verified pin is removed from SQLite and no longer shows in channel_read

🤖 Generated with [Claude Code](https://claude.com/claude-code)