### PR TITLE
feat: add show_pins option to channel read (#306)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -851,6 +851,7 @@ def channel_read(
     since: str | None = None,
     agent_name: str | None = None,
     project_dir: Path | None = None,
+    show_pins: bool = True,
 ) -> str:
     """Read recent messages from a channel.
 
@@ -874,12 +875,14 @@ def channel_read(
             ).fetchall()
         }
 
-        # Get pins
-        pins = conn.execute(
-            "SELECT body, message_id, pinned_by, pinned_at FROM pins WHERE channel = ? "
-            "ORDER BY pinned_at",
-            (channel,),
-        ).fetchall()
+        # Get pins (skip query when show_pins=False to save overhead)
+        pins = []
+        if show_pins:
+            pins = conn.execute(
+                "SELECT body, message_id, pinned_by, pinned_at FROM pins WHERE channel = ? "
+                "ORDER BY pinned_at",
+                (channel,),
+            ).fetchall()
 
         # Resolve display names and roles for rendering
         display_map = {}

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1539,6 +1539,7 @@ def recall_channel(
     pin: bool = False,
     name: str | None = None,
     attachments: str | None = None,
+    show_pins: bool = True,
 ) -> str:
     """Cross-worktree communication channels for multi-agent coordination.
 
@@ -1558,6 +1559,7 @@ def recall_channel(
         pin: If True with "post" action, also pin the message.
         name: Display name for this agent (set on join, shown in messages instead of agent ID).
         attachments: Semicolon-separated file paths to attach (copied into channel store on post).
+        show_pins: If False with "read" action, omit pinned messages from output (default True).
     """
     try:
         from synapt.recall.channel import (
@@ -1593,7 +1595,7 @@ def recall_channel(
             return channel_post(channel=channel, message=message, pin=pin, attachment_paths=attachment_list)
 
         if action == "read":
-            return channel_read(channel=channel, limit=limit)
+            return channel_read(channel=channel, limit=limit, show_pins=show_pins)
 
         if action == "who":
             return channel_who()

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -687,6 +687,51 @@ class TestUnpin(unittest.TestCase):
         self.assertNotIn("remove this pin", result.split("##")[1] if "##" in result else "")
 
 
+class TestShowPins(unittest.TestCase):
+    """Test show_pins option for channel_read (#306)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self.tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _post_and_pin(self, channel, body, agent="bot"):
+        channel_post(channel, body, agent_name=agent)
+        msgs = _read_messages(_channels_dir() / f"{channel}.jsonl")
+        msg_id = [m for m in msgs if m.body == body][-1].id
+        channel_pin(channel, msg_id, agent_name=agent)
+        return msg_id
+
+    def test_show_pins_true_by_default(self):
+        self._post_and_pin("dev", "pinned rule")
+        channel_post("dev", "regular msg", agent_name="bot")
+        result = channel_read("dev")
+        self.assertIn("[pin]", result)
+        self.assertIn("pinned rule", result)
+        self.assertIn("regular msg", result)
+
+    def test_show_pins_false_hides_pins(self):
+        self._post_and_pin("dev", "pinned rule")
+        channel_post("dev", "regular msg", agent_name="bot")
+        result = channel_read("dev", show_pins=False)
+        self.assertNotIn("[pin]", result)
+        self.assertNotIn("Pinned", result)
+        self.assertIn("regular msg", result)
+
+    def test_show_pins_false_still_shows_messages(self):
+        self._post_and_pin("dev", "pinned content")
+        channel_post("dev", "msg1", agent_name="a1")
+        channel_post("dev", "msg2", agent_name="a2")
+        result = channel_read("dev", show_pins=False)
+        self.assertIn("msg1", result)
+        self.assertIn("msg2", result)
+        # The pinned message still appears as a regular message
+        self.assertIn("pinned content", result)
+
+
 class TestPostAndRead(unittest.TestCase):
     """Test posting and reading messages."""
 


### PR DESCRIPTION
Adds a show_pins parameter (default True) to channel_read() and the recall_channel MCP tool. When False, skips the pin query and omits the Pinned header, reducing context overhead for monitoring loops.

Closes #306

## Changes
- channel.py: show_pins param on channel_read(), skips pin DB query when False
- server.py: show_pins param on recall_channel(), passed through to channel_read()
- test_channel.py: 3 new tests (TestShowPins) — default=True, hide pins, messages still shown