### PR TITLE
feat: personal-content enrichment P1+P2 (#307)

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -126,16 +126,20 @@ Rules:
 - BAD: "discussed travel plans" — GOOD: "plans trip to Florida in June with sister Elena"
 - BAD: "talked about hobbies" — GOOD: "signed up for pottery class on July 2nd"
 - BAD: "fixed a bug yesterday" — GOOD: "fixed auth bug on March 14"
-- For personal conversations: capture opinions, emotional reactions, hypothetical plans, social relationships, and recurring topics
-- BAD: "talked about feelings" — GOOD: "Sarah is frustrated with her job at the bank and considering applying to grad school"
-- Capture possessions, pets, addresses, workplace details, and family relationships
-- If the session was short or trivial, use fewer items
+{personal_rules}- If the session was short or trivial, use fewer items
 - Output ONLY valid JSON, no markdown fences, no explanation
 
 Transcript:
 {transcript}
 
 JSON:"""
+
+# Additional extraction rules injected only for personal-content sessions.
+_PERSONAL_RULES = """\
+- Capture opinions, emotional reactions, hypothetical plans, social relationships, and recurring topics
+- BAD: "talked about feelings" — GOOD: "Sarah is frustrated with her job at the bank and considering applying to grad school"
+- Capture possessions, pets, addresses, workplace details, and family relationships
+"""
 
 
 # Content-profile-aware fact limits for enrichment output clamping.
@@ -335,6 +339,7 @@ def enrich_entry(
         done_limit=f"1-{limits['done']}",
         decisions_limit=f"0-{limits['decisions']}",
         next_steps_limit=f"0-{limits['next_steps']}",
+        personal_rules=_PERSONAL_RULES if content_type == "personal" else "",
     )
 
     try:

--- a/tests/recall/test_enrich.py
+++ b/tests/recall/test_enrich.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from synapt.recall.enrich import (
     ENRICHMENT_PROMPT,
+    _PERSONAL_RULES,
     TranscriptSegment,
     _FACT_LIMITS,
     _backfill_stubs,
@@ -218,6 +219,7 @@ class TestEnrichmentPrompt(unittest.TestCase):
             done_limit="1-5",
             decisions_limit="0-3",
             next_steps_limit="0-3",
+            personal_rules="",
         )
         self.assertIn("[Turn 1] User: hello", prompt)
         self.assertIn("focus", prompt)
@@ -234,10 +236,42 @@ class TestEnrichmentPrompt(unittest.TestCase):
         self.assertIn("{decisions_limit}", ENRICHMENT_PROMPT)
         self.assertIn("{next_steps_limit}", ENRICHMENT_PROMPT)
 
-    def test_personal_extraction_rules_in_prompt(self):
-        self.assertIn("emotional reactions", ENRICHMENT_PROMPT)
-        self.assertIn("social relationships", ENRICHMENT_PROMPT)
-        self.assertIn("possessions, pets, addresses", ENRICHMENT_PROMPT)
+    def test_has_personal_rules_placeholder(self):
+        self.assertIn("{personal_rules}", ENRICHMENT_PROMPT)
+
+    def test_personal_rules_not_in_base_prompt(self):
+        """Personal extraction rules should NOT be unconditionally in the prompt."""
+        self.assertNotIn("emotional reactions", ENRICHMENT_PROMPT)
+
+    def test_personal_rules_in_personal_addendum(self):
+        """Personal extraction rules should be in _PERSONAL_RULES."""
+        self.assertIn("emotional reactions", _PERSONAL_RULES)
+        self.assertIn("social relationships", _PERSONAL_RULES)
+        self.assertIn("possessions, pets, addresses", _PERSONAL_RULES)
+
+    def test_personal_rules_injected_for_personal_content(self):
+        """When content_type is personal, rules appear in formatted prompt."""
+        prompt = ENRICHMENT_PROMPT.format(
+            transcript="test",
+            session_date="Monday, March 22, 2026",
+            done_limit="1-15",
+            decisions_limit="0-5",
+            next_steps_limit="0-5",
+            personal_rules=_PERSONAL_RULES,
+        )
+        self.assertIn("emotional reactions", prompt)
+
+    def test_personal_rules_absent_for_code_content(self):
+        """When content_type is code, personal rules are NOT in prompt."""
+        prompt = ENRICHMENT_PROMPT.format(
+            transcript="test",
+            session_date="Monday, March 22, 2026",
+            done_limit="1-5",
+            decisions_limit="0-3",
+            next_steps_limit="0-3",
+            personal_rules="",
+        )
+        self.assertNotIn("emotional reactions", prompt)
 
 
 class TestContentAwareFactLimits(unittest.TestCase):


### PR DESCRIPTION
Implements priorities 1 and 2 from the enrichment patch manifest (#307) to improve LOCOMO personal-conversation coverage.

## P1: Content-profile-aware fact budget
- Personal content: `done` 1-15, `decisions` 0-5, `next_steps` 0-5
- Code/mixed: unchanged (5/3/3)
- Limits applied in both the prompt (guiding LLM) and output clamping
- Lightweight content-type detection via heuristics on transcript text

## P2: Personal-content extraction rules
- Added to enrichment prompt: opinions, emotional reactions, hypothetical plans, social relationships, recurring topics
- BAD/GOOD examples for personal content specificity
- Capture possessions, pets, addresses, workplace details, family relationships

## Tests
- 10 new tests: fact limit values, content detection (personal/code/mixed), prompt placeholders, extraction rule presence
- All 58 enrichment tests pass

## What's NOT included (per Atlas's scope)
- P3 (multi-chunk enrichment windows) — medium risk, deferred
- P4 (max_knowledge for personal content) — deferred

Partial fix for #307