### PR TITLE
feat: multi-window enrichment for personal content (#307 P3)

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -47,6 +47,7 @@ _ENRICHMENT_FIELD_MAP = {
     "next steps": "next_steps",
 }
 MAX_TRANSCRIPT_CHARS = 6000  # ~1.5K tokens — fits in 3B context budget
+MULTI_WINDOW_OVERLAP = 1000  # chars of overlap between adjacent windows
 
 
 def _find_transcript(session_id: str, project_dir: Path) -> Path | None:
@@ -95,6 +96,55 @@ def _build_summary_from_chunks(
     return text
 
 
+def _split_windows(
+    text: str,
+    window_size: int = MAX_TRANSCRIPT_CHARS,
+    overlap: int = MULTI_WINDOW_OVERLAP,
+) -> list[str]:
+    """Split text into overlapping windows for multi-window enrichment.
+
+    Returns a list of text windows. If text fits in one window, returns [text].
+    """
+    if len(text) <= window_size:
+        return [text]
+
+    windows = []
+    start = 0
+    step = window_size - overlap
+    while start < len(text):
+        end = min(start + window_size, len(text))
+        windows.append(text[start:end])
+        if end >= len(text):
+            break
+        start += step
+    return windows
+
+
+def _dedup_facts(items: list[str], threshold: float = 0.8) -> list[str]:
+    """Deduplicate a list of fact strings using fuzzy matching.
+
+    Keeps the first occurrence of each near-duplicate group.
+    """
+    from difflib import SequenceMatcher
+
+    unique: list[str] = []
+    for item in items:
+        is_dup = False
+        for existing in unique:
+            if SequenceMatcher(None, item.lower(), existing.lower()).ratio() > threshold:
+                is_dup = True
+                break
+        if not is_dup:
+            unique.append(item)
+    return unique
+
+
+def _multi_window_enabled() -> bool:
+    """Check if multi-window enrichment is enabled via env var."""
+    import os
+    return os.environ.get("SYNAPT_MULTI_WINDOW_ENRICH", "0") == "1"
+
+
 def _build_transcript_summary(session_id: str, project_dir: Path) -> str:
     """Build a condensed text representation of a transcript for the LLM."""
     path = _find_transcript(session_id, project_dir)
@@ -106,6 +156,20 @@ def _build_transcript_summary(session_id: str, project_dir: Path) -> str:
         return ""
 
     return _build_summary_from_chunks(chunks)
+
+
+def _build_full_transcript_text(session_id: str, project_dir: Path) -> str:
+    """Build full (non-truncated) transcript text for multi-window enrichment."""
+    path = _find_transcript(session_id, project_dir)
+    if not path:
+        return ""
+
+    chunks = parse_transcript(path)
+    if not chunks:
+        return ""
+
+    # Use a very large limit to avoid truncation
+    return _build_summary_from_chunks(chunks, max_chars=10_000_000)
 
 
 ENRICHMENT_PROMPT = """\
@@ -282,6 +346,56 @@ def _detect_content_type(transcript_text: str) -> str:
     return profile.content_type
 
 
+def _enrich_single_window(
+    transcript_text: str,
+    session_date: str,
+    content_type: str,
+    limits: dict,
+    client: "MLXClient",
+    model: str,
+    adapter_path: str = "",
+) -> dict | None:
+    """Run enrichment on a single transcript window. Returns parsed dict or None."""
+    prompt = ENRICHMENT_PROMPT.format(
+        transcript=transcript_text,
+        session_date=session_date,
+        done_limit=f"1-{limits['done']}",
+        decisions_limit=f"0-{limits['decisions']}",
+        next_steps_limit=f"0-{limits['next_steps']}",
+        personal_rules=_PERSONAL_RULES if content_type == "personal" else "",
+    )
+
+    try:
+        response = client.chat(
+            model=model,
+            messages=[Message(role="user", content=prompt)],
+            temperature=0.1,
+            adapter_path=adapter_path or None,
+        )
+    except Exception as exc:
+        logger.warning("LLM inference failed: %s", exc)
+        return None
+
+    return _parse_llm_response(response)
+
+
+def _merge_enrichment_results(results: list[dict]) -> dict:
+    """Merge enrichment results from multiple windows with dedup."""
+    merged: dict = {"focus": "", "done": [], "decisions": [], "next_steps": []}
+
+    for r in results:
+        if not merged["focus"] and r.get("focus"):
+            merged["focus"] = r["focus"]
+        for key in ("done", "decisions", "next_steps"):
+            merged[key].extend(r.get(key, []))
+
+    # Dedup each list
+    for key in ("done", "decisions", "next_steps"):
+        merged[key] = _dedup_facts([str(item) for item in merged[key] if item])
+
+    return merged
+
+
 def enrich_entry(
     entry: JournalEntry,
     project_dir: Path,
@@ -294,6 +408,9 @@ def enrich_entry(
 
     Uses the model router to select the best backend (decoder-only preferred
     for JSON schema compliance). Falls back to MLX decoder if router unavailable.
+
+    When SYNAPT_MULTI_WINDOW_ENRICH=1 and content is personal, runs enrichment
+    on overlapping 6K-char windows to avoid truncation of long conversations.
 
     Args:
         client: Reusable model client instance. Created via router if not provided.
@@ -333,31 +450,53 @@ def enrich_entry(
             session_date = _parsed.strftime("%A, %B %d, %Y")
         except (ValueError, AttributeError):
             pass
-    prompt = ENRICHMENT_PROMPT.format(
-        transcript=transcript_text,
-        session_date=session_date,
-        done_limit=f"1-{limits['done']}",
-        decisions_limit=f"0-{limits['decisions']}",
-        next_steps_limit=f"0-{limits['next_steps']}",
-        personal_rules=_PERSONAL_RULES if content_type == "personal" else "",
+
+    # Multi-window enrichment for personal content when enabled
+    use_multi_window = (
+        _multi_window_enabled()
+        and content_type == "personal"
+        and len(transcript_text) > MAX_TRANSCRIPT_CHARS
     )
 
-    try:
-        response = client.chat(
-            model=model,
-            messages=[Message(role="user", content=prompt)],
-            temperature=0.1,
-            adapter_path=adapter_path or None,
-        )
-    except Exception as exc:
-        logger.warning("LLM inference failed: %s", exc)
-        return None
+    if use_multi_window:
+        # Get full (non-truncated) transcript text
+        full_text = _build_full_transcript_text(entry.session_id, project_dir)
+        if not full_text:
+            full_text = transcript_text
 
-    parsed = _parse_llm_response(response)
+        windows = _split_windows(full_text)
+        logger.info(
+            "Multi-window enrichment: %d windows for session %s (%d chars)",
+            len(windows), entry.session_id, len(full_text),
+        )
+
+        window_results = []
+        for i, window in enumerate(windows):
+            parsed = _enrich_single_window(
+                window, session_date, content_type, limits,
+                client, model, adapter_path,
+            )
+            if parsed:
+                window_results.append(parsed)
+            else:
+                logger.warning(
+                    "Window %d/%d failed for session %s",
+                    i + 1, len(windows), entry.session_id,
+                )
+
+        if not window_results:
+            return None
+
+        parsed = _merge_enrichment_results(window_results)
+    else:
+        parsed = _enrich_single_window(
+            transcript_text, session_date, content_type, limits,
+            client, model, adapter_path,
+        )
+
     if not parsed:
         logger.warning(
-            "Failed to parse LLM response for session %s: %.200s",
-            entry.session_id, response,
+            "Failed to parse enrichment for session %s", entry.session_id,
         )
         return None
 

--- a/tests/recall/test_enrich.py
+++ b/tests/recall/test_enrich.py
@@ -1,6 +1,7 @@
 """Tests for journal enrichment pipeline."""
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -14,12 +15,16 @@ from synapt.recall.enrich import (
     _backfill_stubs,
     _build_summary_from_chunks,
     _build_transcript_summary,
+    _dedup_facts,
     _detect_content_type,
     _get_fact_limits,
     _has_conversation,
+    _merge_enrichment_results,
+    _multi_window_enabled,
     _parse_enrichment_text,
     _parse_llm_response,
     _segment_transcript,
+    _split_windows,
     enrich_entry,
     enrich_transcript_segments,
     iter_enrichable_entries,
@@ -309,6 +314,79 @@ class TestContentAwareFactLimits(unittest.TestCase):
         # No strong signals either way
         text = "[Turn 1] User: hello\n[Turn 1] Assistant: hi there"
         self.assertEqual(_detect_content_type(text), "mixed")
+
+
+class TestMultiWindowEnrichment(unittest.TestCase):
+    """Test multi-window enrichment for personal content (#307 P3)."""
+
+    def test_split_windows_short_text(self):
+        """Text shorter than window size returns single window."""
+        windows = _split_windows("short text", window_size=6000)
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0], "short text")
+
+    def test_split_windows_long_text(self):
+        """Long text splits into overlapping windows."""
+        text = "a" * 15000
+        windows = _split_windows(text, window_size=6000, overlap=1000)
+        self.assertGreater(len(windows), 1)
+        # Each window should be <= window_size
+        for w in windows:
+            self.assertLessEqual(len(w), 6000)
+        # Windows should overlap
+        self.assertTrue(windows[0][-1000:] == windows[1][:1000])
+
+    def test_split_windows_covers_all_text(self):
+        """All characters from original text appear in at least one window."""
+        text = "".join(str(i % 10) for i in range(20000))
+        windows = _split_windows(text, window_size=6000, overlap=1000)
+        # Reconstruct: every char position should be covered
+        covered = set()
+        start = 0
+        step = 6000 - 1000
+        for i, w in enumerate(windows):
+            offset = i * step
+            for j in range(len(w)):
+                covered.add(offset + j)
+        # All positions should be covered
+        self.assertEqual(len(covered), len(text))
+
+    def test_dedup_facts_removes_near_duplicates(self):
+        items = [
+            "Caroline started painting in 2022",
+            "Caroline began painting in 2022",
+            "Melanie signed up for pottery class",
+        ]
+        result = _dedup_facts(items, threshold=0.8)
+        self.assertEqual(len(result), 2)
+        self.assertIn("Caroline started painting in 2022", result)
+        self.assertIn("Melanie signed up for pottery class", result)
+
+    def test_dedup_facts_keeps_distinct(self):
+        items = ["fact one", "fact two", "fact three"]
+        result = _dedup_facts(items)
+        self.assertEqual(len(result), 3)
+
+    def test_merge_enrichment_results(self):
+        results = [
+            {"focus": "Window 1 focus", "done": ["a", "b"], "decisions": ["d1"], "next_steps": []},
+            {"focus": "Window 2 focus", "done": ["c", "a"], "decisions": ["d2"], "next_steps": ["n1"]},
+        ]
+        merged = _merge_enrichment_results(results)
+        self.assertEqual(merged["focus"], "Window 1 focus")  # first non-empty wins
+        # "a" appears twice but should be deduped
+        self.assertIn("a", merged["done"])
+        self.assertIn("b", merged["done"])
+        self.assertIn("c", merged["done"])
+        self.assertEqual(len(merged["decisions"]), 2)
+        self.assertEqual(len(merged["next_steps"]), 1)
+
+    def test_multi_window_disabled_by_default(self):
+        self.assertFalse(_multi_window_enabled())
+
+    @patch.dict("os.environ", {"SYNAPT_MULTI_WINDOW_ENRICH": "1"})
+    def test_multi_window_enabled_by_env(self):
+        self.assertTrue(_multi_window_enabled())
 
 
 class TestIterEnrichableEntries(unittest.TestCase):


### PR DESCRIPTION
Addresses the dominant LOCOMO failure mode: 74% of absent-evidence misses have gold evidence beyond the 6K truncation point.

## What it does
When `SYNAPT_MULTI_WINDOW_ENRICH=1` and content is personal, runs enrichment on overlapping 6K-char windows (1K overlap) instead of truncating at 6K. Results are merged across windows with fuzzy dedup.

## Evidence
- Conv 0 transcript: 62,977 chars, 90.5% discarded by 6K cap
- 35/47 absent-evidence misses have gold evidence BEYOND 6K
- Median evidence position: 18,604 chars (3x the threshold)
- Temporal (81%), Open-domain (83%), Single-hop (100%) most affected

## Implementation
- `_split_windows()`: overlapping 6K windows with 1K overlap
- `_dedup_facts()`: fuzzy string dedup (difflib ratio > 0.8)
- `_merge_enrichment_results()`: combines facts across windows
- `_enrich_single_window()`: extracted from enrich_entry for reuse
- `_build_full_transcript_text()`: non-truncated transcript retrieval

## Safety
- Disabled by default (`SYNAPT_MULTI_WINDOW_ENRICH=0`)
- Personal-content only — code/mixed sessions unchanged
- Same pattern as BM25 floor (#314) — env-gated for ablation

## Tests
8 new tests: window splitting, dedup, merging, env gating. All 70 pass.

Partial fix for #307