### PR TITLE
fix: default multi-window overlap to 0 (#307 P3 Phase 1)

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -47,7 +48,7 @@ _ENRICHMENT_FIELD_MAP = {
     "next steps": "next_steps",
 }
 MAX_TRANSCRIPT_CHARS = 6000  # ~1.5K tokens — fits in 3B context budget
-MULTI_WINDOW_OVERLAP = 1000  # chars of overlap between adjacent windows
+MULTI_WINDOW_OVERLAP = int(os.environ.get("SYNAPT_MW_OVERLAP", "0"))  # default 0; set via env for ablation
 
 
 def _find_transcript(session_id: str, project_dir: Path) -> Path | None:
@@ -141,7 +142,6 @@ def _dedup_facts(items: list[str], threshold: float = 0.8) -> list[str]:
 
 def _multi_window_enabled() -> bool:
     """Check if multi-window enrichment is enabled via env var."""
-    import os
     return os.environ.get("SYNAPT_MULTI_WINDOW_ENRICH", "0") == "1"
 
 


### PR DESCRIPTION
Phase 1 diagnostic for #307 P3 multi-window regression.

The first multi-window ablation showed knowledge nodes collapsed from 25→11 due to repetitive extraction across overlapping windows. This defaults overlap to 0 to test whether overlap is the specific trigger.

## Change
- `MULTI_WINDOW_OVERLAP` now reads from `SYNAPT_MW_OVERLAP` env var, default 0
- `os` import moved to module level

## Next
Rerun conv0 full-pipeline with `SYNAPT_MULTI_WINDOW_ENRICH=1` (overlap now 0).
If knowledge nodes recover, overlap was the trigger.
If still flat, Phase 2 (prior-context injection) is needed.

All 70 tests pass.