### PR TITLE
fix: prevent template-variable hallucination in enrichment output (#317)

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -190,6 +190,7 @@ Rules:
 - BAD: "discussed travel plans" — GOOD: "plans trip to Florida in June with sister Elena"
 - BAD: "talked about hobbies" — GOOD: "signed up for pottery class on July 2nd"
 - BAD: "fixed a bug yesterday" — GOOD: "fixed auth bug on March 14"
+- NEVER output template variables like {{yesterday}}, {{last_friday}}, or {{today}} — always write the actual resolved date
 {personal_rules}- If the session was short or trivial, use fewer items
 - Output ONLY valid JSON, no markdown fences, no explanation
 


### PR DESCRIPTION
## Summary
- One-line prompt reinforcement in `ENRICHMENT_PROMPT` to prevent the 3B model from emitting literal brace-wrapped template tokens (`{yesterday}`, `{last_friday}`) instead of resolved dates
- Observed in overlap=0 multi-window enrichment: 39 brace-token occurrences in temp journal, 0 in all earlier runs (baseline, overlap=1K, raw)

## Evidence
- Opus traced source: not in LOCOMO dataset (0), not in enrichment code (0), not in earlier run artifacts (0) — purely a 3B model behavior triggered by shorter/cleaner window context
- Temporal regression in overlap=0 (-2.7pp vs baseline) may be partially caused by unresolved dates in enriched facts

## Test plan
- [x] `pytest tests/recall/test_enrich.py` — 70/70 pass
- [x] Prompt-only change, no code path modifications
- [x] Personal and code enrichment both include the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)