### PR TITLE
fix: prevent template-variable hallucination in enrichment output (#317)

### DIFF
--- a/src/synapt/recall/enrich.py
+++ b/src/synapt/recall/enrich.py
@@ -186,6 +186,7 @@ Given the following transcript, produce a JSON object with these fields:
 Rules:
 - Include specific names, dates, places, numbers, and details — NOT general themes
 - Resolve ALL relative time references to absolute dates using the session date above (e.g. "yesterday" → the actual date, "last week" → the actual date range)
+- NEVER output template variables like {{yesterday}}, {{last_friday}}, or {{today}} — always write the actual resolved date
 - Capture people's names, their relationships, possessions, hobbies, and stated preferences
 - BAD: "discussed travel plans" — GOOD: "plans trip to Florida in June with sister Elena"
 - BAD: "talked about hobbies" — GOOD: "signed up for pottery class on July 2nd"


### PR DESCRIPTION
## Summary
- reinforce the enrichment prompt to forbid brace-wrapped template variables for relative dates
- keep the change prompt-only so the overlap=0 multi-window follow-up stays narrowly scoped
- preserve the current overlap=0 retrieval/code path while targeting the remaining temporal residue

## Validation
- ......................................................................   [100%]
70 passed in 0.08s
- 

## Context
Overlap=0 multi-window enrichment improved knowledge diversity and single-hop recall on LOCOMO conv0, but temporal remained down 2.7pp. The temp journal also showed brace-wrapped tokens like  and  that were absent in baseline and overlap=1K runs. This patch hardens the prompt against that specific failure mode before the next follow-up measurement run.