### PR TITLE
Fix Codex session indexing in recall

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -219,6 +219,7 @@ def _archive_and_build_locked(
     import time as _time
 
     from synapt.recall.archive import archive_transcripts
+    from synapt.recall.codex import archive_codex_transcripts
     from synapt.recall.storage import RecallDB
 
     build_t0 = _time.monotonic()
@@ -234,6 +235,10 @@ def _archive_and_build_locked(
             copied = archive_transcripts(project_dir, src)
             if copied:
                 print(f"  Archived {len(copied)} new transcript(s) from {src}")
+
+    codex_copied = archive_codex_transcripts(project_dir)
+    if codex_copied:
+        print(f"  Archived {len(codex_copied)} Codex transcript(s)")
 
     # Step 2: Determine what to build from — aggregate all worktree archives
     build_sources: list[Path] = []
@@ -315,23 +320,6 @@ def _archive_and_build_locked(
         chatgpt_chunks = parse_chatgpt_archive(archive_path)
         print(f"[build] Parsed {len(chatgpt_chunks)} ChatGPT chunks")
         all_chunks.extend(chatgpt_chunks)
-
-    # Codex CLI transcripts (cross-editor memory)
-    try:
-        from synapt.recall.codex import discover_codex_sessions, list_codex_transcripts, parse_codex_transcript
-        codex_dir = discover_codex_sessions()
-        if codex_dir:
-            codex_files = list_codex_transcripts(codex_dir)
-            if codex_files:
-                codex_chunks = []
-                seen = set()
-                for cf in codex_files:
-                    codex_chunks.extend(parse_codex_transcript(cf, seen_uuids=seen))
-                if codex_chunks:
-                    all_chunks.extend(codex_chunks)
-                    print(f"  Codex: {len(codex_chunks)} chunks from {len(codex_files)} sessions")
-    except Exception as exc:
-        logger.debug("Codex transcript parsing failed: %s", exc)
 
     # Channel messages → searchable chunks
     try:
@@ -1981,6 +1969,16 @@ def cmd_setup(args: argparse.Namespace) -> None:
     step += 1
 
     transcript_dir = project_transcript_dir(project)
+    codex_count = 0
+    try:
+        from synapt.recall.codex import discover_codex_sessions, list_codex_transcripts
+        codex_dir = discover_codex_sessions()
+        if codex_dir:
+            codex_count = len(list_codex_transcripts(codex_dir, project_dir=project))
+            if codex_count:
+                print(f"  Found {codex_count} Codex transcript files")
+    except Exception:
+        codex_count = 0
     if transcript_dir:
         jsonl_count = len(list(transcript_dir.glob("*.jsonl")))
         print(f"  Found {jsonl_count} transcript files at {transcript_dir}")
@@ -1992,9 +1990,9 @@ def cmd_setup(args: argparse.Namespace) -> None:
         if archive_count:
             print(f"  Found {archive_count} archived transcript(s)")
 
-    if not transcript_dir and not (archive_dir.exists() and any(archive_dir.glob("*.jsonl"))):
+    if not transcript_dir and codex_count == 0 and not (archive_dir.exists() and any(archive_dir.glob("*.jsonl"))):
         print(f"  No transcripts found for this project.", file=sys.stderr)
-        print(f"  Start a Claude Code session in this project first,", file=sys.stderr)
+        print(f"  Start a Claude Code or Codex session in this project first,", file=sys.stderr)
         print(f"  or use --sync to pull from HuggingFace.", file=sys.stderr)
         sys.exit(1)
 

--- a/src/synapt/recall/codex.py
+++ b/src/synapt/recall/codex.py
@@ -58,6 +58,8 @@ def _project_roots(project_dir: Path | None = None) -> list[Path]:
 
     grip_root = _find_gripspace_root(actual_dir)
     if grip_root is not None:
+        # Match Claude transcript discovery semantics: in a gripspace we treat
+        # direct child repos as part of the same shared recall surface.
         try:
             children = sorted(grip_root.iterdir())
         except OSError:
@@ -82,7 +84,7 @@ def _session_cwd(path: Path) -> Path | None:
                 except json.JSONDecodeError:
                     continue
                 if entry.get("type") != "session_meta":
-                    continue
+                    return None
                 cwd = entry.get("payload", {}).get("cwd", "")
                 if not cwd:
                     return None

--- a/src/synapt/recall/codex.py
+++ b/src/synapt/recall/codex.py
@@ -22,8 +22,16 @@ import re
 
 from synapt.recall.core import TranscriptChunk, _short_sid, project_archive_dir
 
-# Simple file path regex — matches common code file paths
-_FILE_RE = re.compile(r'(?:^|[\s"\'`])(/[\w./-]+\.\w{1,10})(?:[\s"\'`:,)]|$)')
+# Simple file path regex — matches common Unix and Windows absolute file paths
+_FILE_RE = re.compile(
+    r'(?:^|[\s"\'`])'
+    r'('
+    r'(?:/[^\s"\'`:,)]+?\.\w{1,10})'
+    r'|'
+    r'(?:[A-Za-z]:\\[^\n\r\t"\'`]+?\.\w{1,10})'
+    r')'
+    r'(?=[\s"\'`:,)]|$)'
+)
 
 
 def _extract_file_paths(text: str) -> list[str]:

--- a/src/synapt/recall/codex.py
+++ b/src/synapt/recall/codex.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import re
 
-from synapt.recall.core import TranscriptChunk, _short_sid
+from synapt.recall.core import TranscriptChunk, _short_sid, project_archive_dir
 
 # Simple file path regex — matches common code file paths
 _FILE_RE = re.compile(r'(?:^|[\s"\'`])(/[\w./-]+\.\w{1,10})(?:[\s"\'`:,)]|$)')
@@ -39,13 +39,135 @@ def discover_codex_sessions() -> Path | None:
     return None
 
 
-def list_codex_transcripts(sessions_dir: Path | None = None) -> list[Path]:
-    """List all Codex transcript JSONL files, sorted by name."""
+def _project_roots(project_dir: Path | None = None) -> list[Path]:
+    """Return project roots whose Codex sessions should be indexed."""
+    from synapt.recall.core import _find_gripspace_root, _git_main_worktree_root
+
+    actual_dir = (project_dir or Path.cwd()).resolve()
+    roots: list[Path] = []
+
+    def _add_root(path: Path | None) -> None:
+        if path is None:
+            return
+        resolved = path.resolve()
+        if resolved not in roots:
+            roots.append(resolved)
+
+    _add_root(actual_dir)
+    _add_root(_git_main_worktree_root(actual_dir))
+
+    grip_root = _find_gripspace_root(actual_dir)
+    if grip_root is not None:
+        try:
+            children = sorted(grip_root.iterdir())
+        except OSError:
+            children = []
+        for child in children:
+            if child.is_dir() and (child / ".git").exists():
+                _add_root(child)
+
+    return roots
+
+
+def _session_cwd(path: Path) -> Path | None:
+    """Return the session cwd recorded in a Codex transcript, if present."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") != "session_meta":
+                    continue
+                cwd = entry.get("payload", {}).get("cwd", "")
+                if not cwd:
+                    return None
+                try:
+                    return Path(cwd).resolve()
+                except OSError:
+                    return None
+    except OSError:
+        return None
+    return None
+
+
+def is_codex_transcript(path: Path) -> bool:
+    """True when *path* looks like a Codex CLI transcript."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                return entry.get("type") == "session_meta"
+    except OSError:
+        return False
+    return False
+
+
+def _matches_project(path: Path, project_dir: Path | None = None) -> bool:
+    """True when the Codex transcript belongs to the current project scope."""
+    session_cwd = _session_cwd(path)
+    if session_cwd is None:
+        return False
+
+    for root in _project_roots(project_dir):
+        if session_cwd == root or root in session_cwd.parents:
+            return True
+    return False
+
+
+def list_codex_transcripts(
+    sessions_dir: Path | None = None,
+    project_dir: Path | None = None,
+) -> list[Path]:
+    """List project-relevant Codex transcript JSONL files, sorted by name."""
     if sessions_dir is None:
         sessions_dir = discover_codex_sessions()
     if sessions_dir is None:
         return []
-    return sorted(sessions_dir.rglob("rollout-*.jsonl"))
+
+    files = sorted(sessions_dir.rglob("rollout-*.jsonl"))
+    if project_dir is None:
+        return files
+    return [path for path in files if _matches_project(path, project_dir)]
+
+
+def archive_codex_transcripts(
+    project_dir: Path,
+    sessions_dir: Path | None = None,
+) -> list[Path]:
+    """Copy project-relevant Codex transcripts into the project archive.
+
+    Uses the same size-based semantics as Claude transcript archiving:
+    unchanged files are skipped, grown files overwrite the archive copy,
+    and shrunken sources do not replace larger archived copies.
+    """
+    archive_dir = project_archive_dir(project_dir)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[Path] = []
+    for src_file in list_codex_transcripts(sessions_dir, project_dir=project_dir):
+        dst_file = archive_dir / src_file.name
+        src_size = src_file.stat().st_size
+        if dst_file.exists():
+            dst_size = dst_file.stat().st_size
+            if src_size == dst_size:
+                continue
+            if src_size < dst_size:
+                continue
+        dst_file.write_bytes(src_file.read_bytes())
+        copied.append(dst_file)
+
+    return copied
 
 
 def parse_codex_transcript(

--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -4242,6 +4242,8 @@ def build_index(
         for src in incremental_manifest.get("source_files", []):
             already_indexed[src["name"]] = (src.get("mtime", 0), src.get("size", 0))
 
+    from synapt.recall.codex import is_codex_transcript, parse_codex_transcript
+
     all_chunks: list[TranscriptChunk] = []
     seen_uuids: set[str] = set()
     skipped = 0
@@ -4255,8 +4257,11 @@ def build_index(
                 skipped += 1
                 continue
         try:
-            chunks = parse_transcript(filepath, seen_uuids=seen_uuids,
-                                      subchunk_min_text=subchunk_min_text)
+            if is_codex_transcript(filepath):
+                chunks = parse_codex_transcript(filepath, seen_uuids=seen_uuids)
+            else:
+                chunks = parse_transcript(filepath, seen_uuids=seen_uuids,
+                                          subchunk_min_text=subchunk_min_text)
             all_chunks.extend(chunks)
             parsed_files.append(filepath)
             print(f"  {filepath.name}: {len(chunks)} turns")
@@ -4289,8 +4294,11 @@ def build_index(
                 seen_uuids_reparse: set[str] = set()
                 for filepath in parsed_files:
                     try:
-                        chunks = parse_transcript(filepath, seen_uuids=seen_uuids_reparse,
-                                                  subchunk_min_text=0)
+                        if is_codex_transcript(filepath):
+                            chunks = parse_codex_transcript(filepath, seen_uuids=seen_uuids_reparse)
+                        else:
+                            chunks = parse_transcript(filepath, seen_uuids=seen_uuids_reparse,
+                                                      subchunk_min_text=0)
                         all_chunks.extend(chunks)
                     except Exception:
                         pass

--- a/src/synapt/recall/journal.py
+++ b/src/synapt/recall/journal.py
@@ -333,6 +333,8 @@ def extract_session_id(path: Path | str) -> str:
                     continue
                 try:
                     d = json.loads(line)
+                    if d.get("type") == "session_meta":
+                        return d.get("payload", {}).get("id", "")
                     if d.get("type") == "progress" and d.get("sessionId"):
                         return d["sessionId"]
                 except (json.JSONDecodeError, ValueError):
@@ -360,14 +362,24 @@ def _transcript_sort_key(f: Path) -> tuple:
 def latest_transcript_path(project: Path | None = None) -> str | None:
     """Find the most recently modified transcript file for the project."""
     project = (project or Path.cwd()).resolve()
+    candidates: list[Path] = []
+
     transcript_dir = project_transcript_dir(project)
-    if not transcript_dir:
+    if transcript_dir:
+        candidates.extend(transcript_dir.glob("*.jsonl"))
+
+    try:
+        from synapt.recall.codex import discover_codex_sessions, list_codex_transcripts
+        codex_dir = discover_codex_sessions()
+        if codex_dir:
+            candidates.extend(list_codex_transcripts(codex_dir, project_dir=project))
+    except Exception:
+        pass
+
+    if not candidates:
         return None
-    jsonl_files = sorted(
-        transcript_dir.glob("*.jsonl"),
-        key=_transcript_sort_key,
-        reverse=True,
-    )
+
+    jsonl_files = sorted(candidates, key=_transcript_sort_key, reverse=True)
     return str(jsonl_files[0]) if jsonl_files else None
 
 
@@ -414,21 +426,34 @@ def auto_extract_entry(
     # Parse transcript if available
     if transcript_path and Path(transcript_path).exists():
         files_set: set[str] = set()
-        with open(transcript_path, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    d = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                if d.get("type") == "progress" and not session_id:
-                    session_id = d.get("sessionId", "")
-                if d.get("type") == "assistant":
-                    for block in d.get("message", {}).get("content", []) or []:
-                        if not isinstance(block, dict):
-                            continue
-                        fp = block.get("input", {}).get("file_path", "") if isinstance(block.get("input"), dict) else ""
-                        if fp:
-                            files_set.add(fp)
+        try:
+            from synapt.recall.codex import is_codex_transcript, parse_codex_transcript
+            is_codex = is_codex_transcript(Path(transcript_path))
+        except Exception:
+            is_codex = False
+
+        if is_codex:
+            chunks = parse_codex_transcript(Path(transcript_path))
+            if chunks:
+                session_id = chunks[0].session_id
+            for chunk in chunks:
+                files_set.update(chunk.files_touched)
+        else:
+            with open(transcript_path, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        d = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if d.get("type") == "progress" and not session_id:
+                        session_id = d.get("sessionId", "")
+                    if d.get("type") == "assistant":
+                        for block in d.get("message", {}).get("content", []) or []:
+                            if not isinstance(block, dict):
+                                continue
+                            fp = block.get("input", {}).get("file_path", "") if isinstance(block.get("input"), dict) else ""
+                            if fp:
+                                files_set.add(fp)
         files_modified = _filter_project_files(files_set, project_root=cwd)
 
     # Capture agent identity if channel system is available

--- a/src/synapt/recall/live.py
+++ b/src/synapt/recall/live.py
@@ -77,6 +77,7 @@ def _get_live_chunks(transcript_path: str) -> tuple[str, list[TranscriptChunk]]:
     # TYPE_CHECKING guard already covers type annotations, and the deferred
     # import documents that we only need parse_transcript at call time.
     from synapt.recall.core import parse_transcript
+    from synapt.recall.codex import is_codex_transcript, parse_codex_transcript
 
     try:
         size = Path(transcript_path).stat().st_size
@@ -96,7 +97,11 @@ def _get_live_chunks(transcript_path: str) -> tuple[str, list[TranscriptChunk]]:
         # self-contained and safe for any future caller that lacks one.
         try:
             session_id = extract_session_id(transcript_path)
-            chunks = parse_transcript(Path(transcript_path))
+            path_obj = Path(transcript_path)
+            if is_codex_transcript(path_obj):
+                chunks = parse_codex_transcript(path_obj)
+            else:
+                chunks = parse_transcript(path_obj)
         except Exception:
             return "", []
 

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -480,7 +480,7 @@ def recall_build(incremental: bool = True) -> str:
         _invalidate_cache()
 
     if not final_index or not final_index.chunks:
-        return "No Claude Code transcripts found for this project."
+        return "No Claude Code or Codex transcripts found for this project."
 
     stats = final_index.stats()
     index_dir = project_index_dir(project)
@@ -514,8 +514,8 @@ def recall_setup(no_hook: bool = False) -> str:
 
     if not final_index or not final_index.chunks:
         return (
-            "No Claude Code transcripts found for this project. "
-            "Start a Claude Code session first, then run recall_setup again."
+            "No Claude Code or Codex transcripts found for this project. "
+            "Start a Claude Code or Codex session first, then run recall_setup again."
         )
 
     stats = final_index.stats()

--- a/tests/recall/test_cli.py
+++ b/tests/recall/test_cli.py
@@ -11,6 +11,37 @@ from synapt.recall.core import project_slug, project_index_dir, project_archive_
 from synapt.recall.cli import discover_transcript_dirs, _ensure_gitignore, _install_global_hooks, cmd_rebuild, cmd_sync, main
 
 
+def _write_codex_transcript(path: Path, cwd: Path) -> None:
+    """Write a minimal Codex-format transcript."""
+    entries = [
+        {
+            "timestamp": "2026-03-01T10:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "codex-session-001", "cwd": str(cwd)},
+        },
+        {
+            "timestamp": "2026-03-01T10:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "How does Codex indexing work?"}],
+            },
+        },
+        {
+            "timestamp": "2026-03-01T10:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "It should index project-scoped Codex transcripts."}],
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
 def test_discover_transcript_dirs_finds_dirs(tmp_path):
     """discover_transcript_dirs finds directories with .jsonl files."""
     projects = tmp_path / ".claude" / "projects"
@@ -232,6 +263,38 @@ def test_cmd_setup_orchestrates_all_steps(tmp_path):
     assert ".synapt/" in gitignore.read_text()
 
 
+def test_cmd_setup_with_codex_only_transcripts(tmp_path):
+    """setup succeeds for a Codex-only project with no Claude transcripts."""
+    project_dir = tmp_path / "myproject"
+    project_dir.mkdir()
+
+    codex_sessions = tmp_path / ".codex" / "sessions" / "2026" / "03" / "01"
+    _write_codex_transcript(codex_sessions / "rollout-test.jsonl", project_dir)
+
+    mock_run = MagicMock()
+    mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+    with patch("synapt.recall.core.Path.home", return_value=tmp_path), \
+         patch("synapt.recall.cli.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.journal.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.codex.Path.home", return_value=tmp_path), \
+         patch("synapt.recall.cli.subprocess.run", mock_run), \
+         patch("synapt.recall.cli.shutil.which", return_value="/usr/bin/claude"):
+        from synapt.recall.cli import cmd_setup
+        args = argparse.Namespace(
+            no_embeddings=True,
+            no_hook=False,
+            global_scope=False,
+            sync=None,
+        )
+        cmd_setup(args)
+
+    index_dir = project_index_dir(project_dir)
+    assert (index_dir / "recall.db").exists()
+    archive_dir = project_archive_dir(project_dir)
+    assert (archive_dir / "rollout-test.jsonl").exists()
+
+
 def test_ensure_gitignore_creates_file(tmp_path):
     """_ensure_gitignore creates .gitignore with .synapt/ entry if missing."""
     _ensure_gitignore(tmp_path)
@@ -449,7 +512,30 @@ def test_recall_setup_no_transcripts(tmp_path):
          patch("synapt.recall.cli.Path.cwd", return_value=project_dir):
         result = recall_setup()
 
-    assert "No Claude Code transcripts found" in result
+    assert "No Claude Code or Codex transcripts found" in result
+
+
+def test_recall_setup_mcp_tool_with_codex_only_transcripts(tmp_path):
+    """recall_setup succeeds for a Codex-only project."""
+    from synapt.recall.server import recall_setup
+
+    project_dir = tmp_path / "myproject"
+    project_dir.mkdir()
+
+    codex_sessions = tmp_path / ".codex" / "sessions" / "2026" / "03" / "01"
+    _write_codex_transcript(codex_sessions / "rollout-test.jsonl", project_dir)
+
+    with patch("synapt.recall.core.Path.home", return_value=tmp_path), \
+         patch("synapt.recall.cli.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.server.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.journal.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.codex.Path.home", return_value=tmp_path):
+        result = recall_setup(no_hook=True)
+
+    assert "Setup complete" in result
+    assert "chunks from" in result
+    archive_dir = project_archive_dir(project_dir)
+    assert (archive_dir / "rollout-test.jsonl").exists()
 
 
 def test_main_dispatches_export_command(tmp_path):
@@ -601,3 +687,57 @@ def test_catchup_skips_already_journaled_session(tmp_path):
     entries = read_entries(journal_path, n=10)
     assert len(entries) == 1
     assert entries[0].focus == "Previous work"
+
+
+def test_catchup_writes_journal_for_codex_session(tmp_path):
+    """_catchup_archive_and_journal handles Codex transcripts from the archive source."""
+    from synapt.recall.cli import _catchup_archive_and_journal
+    from synapt.recall.journal import read_entries
+
+    project = tmp_path / "project"
+    project.mkdir()
+    source = tmp_path / "source"
+    source.mkdir()
+
+    transcript = source / "rollout-test.jsonl"
+    local_file = project / "src" / "main.py"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    entries = [
+        {
+            "timestamp": "2026-03-01T10:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": "codex-session-001", "cwd": str(project)},
+        },
+        {
+            "timestamp": "2026-03-01T10:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": f"inspect {local_file}"}],
+            },
+        },
+        {
+            "timestamp": "2026-03-01T10:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": json.dumps({"cmd": f"sed -n 1,20p {local_file}"}),
+                "call_id": "call_1",
+            },
+        },
+    ]
+    with open(transcript, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    with patch("synapt.recall.core.Path.cwd", return_value=project):
+        _catchup_archive_and_journal(project, source)
+
+    archive_dir = project_archive_dir(project)
+    assert (archive_dir / "rollout-test.jsonl").exists()
+
+    journal_path = project_worktree_dir(project) / "journal.jsonl"
+    entries = read_entries(journal_path, n=1)
+    assert len(entries) == 1
+    assert entries[0].session_id == "codex-session-001"

--- a/tests/recall/test_codex.py
+++ b/tests/recall/test_codex.py
@@ -8,8 +8,12 @@ from pathlib import Path
 from synapt.recall.codex import (
     parse_codex_transcript,
     list_codex_transcripts,
+    archive_codex_transcripts,
+    is_codex_transcript,
     _extract_file_paths,
 )
+from synapt.recall.core import build_index
+from synapt.recall.journal import auto_extract_entry, extract_session_id
 
 
 def _write_codex_transcript(tmpdir: str, entries: list[dict], name: str = "rollout-test.jsonl") -> Path:
@@ -199,6 +203,26 @@ class TestParseCodexTranscript(unittest.TestCase):
         self.assertEqual(len(chunks), 1)
         self.assertIn("via event_msg", chunks[0].user_text)
 
+    def test_journal_helpers_support_codex_transcript(self):
+        local_file = str(Path(self.tmpdir) / "example.py")
+        entries = [
+            {"timestamp": "2026-03-01T10:00:00Z", "type": "session_meta",
+             "payload": {"id": "journal-codex-session", "cwd": self.tmpdir}},
+            {"timestamp": "2026-03-01T10:00:01Z", "type": "response_item",
+             "payload": {"role": "user", "content": [
+                 {"type": "input_text", "text": f"inspect {local_file}"}
+             ]}},
+            {"timestamp": "2026-03-01T10:00:02Z", "type": "response_item",
+             "payload": {"type": "function_call", "name": "exec_command",
+                          "arguments": json.dumps({"cmd": f"sed -n 1,20p {local_file}"}), "call_id": "call_1"}},
+        ]
+        path = _write_codex_transcript(self.tmpdir, entries, name="rollout-journal.jsonl")
+
+        self.assertEqual(extract_session_id(path), "journal-codex-session")
+        entry = auto_extract_entry(transcript_path=path, cwd=self.tmpdir)
+        self.assertEqual(entry.session_id, "journal-codex-session")
+        self.assertIn("example.py", entry.files_modified)
+
 
 class TestListCodexTranscripts(unittest.TestCase):
     """Test transcript discovery."""
@@ -219,6 +243,78 @@ class TestListCodexTranscripts(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         found = list_codex_transcripts(Path(tmpdir))
         self.assertEqual(found, [])
+
+    def test_filters_to_project_scope(self):
+        tmpdir = tempfile.mkdtemp()
+        sessions = Path(tmpdir) / "2026" / "03" / "01"
+        sessions.mkdir(parents=True)
+
+        project_root = Path(tmpdir) / "project"
+        project_root.mkdir()
+        other_root = Path(tmpdir) / "other-project"
+        other_root.mkdir()
+
+        matching = _write_codex_transcript(
+            str(sessions),
+            [{"type": "session_meta", "payload": {"id": "match", "cwd": str(project_root / "subdir")}}],
+            name="rollout-match.jsonl",
+        )
+        _write_codex_transcript(
+            str(sessions),
+            [{"type": "session_meta", "payload": {"id": "miss", "cwd": str(other_root)}}],
+            name="rollout-miss.jsonl",
+        )
+
+        found = list_codex_transcripts(Path(tmpdir), project_dir=project_root)
+        self.assertEqual(found, [matching])
+
+    def test_archive_codex_transcripts_filters_to_project(self):
+        tmpdir = tempfile.mkdtemp()
+        sessions = Path(tmpdir) / "2026" / "03" / "01"
+        sessions.mkdir(parents=True)
+
+        project_root = Path(tmpdir) / "project"
+        project_root.mkdir()
+        archive_root = project_root / ".synapt" / "recall" / "worktrees" / "project" / "transcripts"
+        archive_root.mkdir(parents=True)
+        other_root = Path(tmpdir) / "other-project"
+        other_root.mkdir()
+
+        matching = _write_codex_transcript(
+            str(sessions),
+            [{"type": "session_meta", "payload": {"id": "match", "cwd": str(project_root)}}],
+            name="rollout-match.jsonl",
+        )
+        _write_codex_transcript(
+            str(sessions),
+            [{"type": "session_meta", "payload": {"id": "miss", "cwd": str(other_root)}}],
+            name="rollout-miss.jsonl",
+        )
+
+        copied = archive_codex_transcripts(project_root, sessions_dir=Path(tmpdir))
+        self.assertEqual([p.name for p in copied], [matching.name])
+        self.assertTrue((archive_root / matching.name).exists())
+
+    def test_build_index_parses_codex_archived_file(self):
+        tmpdir = tempfile.mkdtemp()
+        entries = [
+            {"timestamp": "2026-03-01T10:00:00Z", "type": "session_meta",
+             "payload": {"id": "build-codex-session", "cwd": tmpdir}},
+            {"timestamp": "2026-03-01T10:00:01Z", "type": "response_item",
+             "payload": {"role": "user", "content": [
+                 {"type": "input_text", "text": "question from codex"}
+             ]}},
+            {"timestamp": "2026-03-01T10:00:02Z", "type": "response_item",
+             "payload": {"role": "assistant", "content": [
+                 {"type": "output_text", "text": "answer from codex"}
+             ]}},
+        ]
+        path = _write_codex_transcript(tmpdir, entries, name="rollout-build.jsonl")
+
+        self.assertTrue(is_codex_transcript(path))
+        index = build_index(Path(tmpdir), use_embeddings=False)
+        self.assertEqual(len(index.chunks), 1)
+        self.assertIn("question from codex", index.chunks[0].user_text)
 
 
 class TestExtractFilePaths(unittest.TestCase):

--- a/tests/recall/test_codex.py
+++ b/tests/recall/test_codex.py
@@ -325,6 +325,11 @@ class TestExtractFilePaths(unittest.TestCase):
         self.assertIn("/src/main.py", paths)
         self.assertIn("/tmp/test.js", paths)
 
+    def test_extracts_windows_absolute_paths(self):
+        paths = _extract_file_paths(r'editing C:\repo\main.py and D:\tmp\test.js')
+        self.assertIn(r"C:\repo\main.py", paths)
+        self.assertIn(r"D:\tmp\test.js", paths)
+
     def test_no_false_positives_on_plain_text(self):
         paths = _extract_file_paths("hello world this is a test")
         self.assertEqual(paths, [])


### PR DESCRIPTION
## Summary
- make Codex transcript discovery project-scoped instead of global
- archive Codex sessions into the normal recall transcript archive and parse them through the normal build path
- add Codex support to journal/live/setup flows and extend CLI/server messages accordingly
- add regression coverage for Codex-only setup/build/catch-up paths

## Verification
- `PYTHONPATH=src pytest -q tests/recall/test_codex.py tests/recall/test_cli.py -q`
- manual smoke test: Codex-only `recall_setup(no_hook=True)` succeeds, archives the transcript, and builds the index