### PR TITLE
fix: clear all shards on rebuild to prevent chunk duplication

### DIFF
--- a/src/synapt/recall/sharded_db.py
+++ b/src/synapt/recall/sharded_db.py
@@ -122,7 +122,8 @@ class ShardedRecallDB:
         """Save chunks to the appropriate database.
 
         In monolithic mode, delegates directly to the single DB.
-        In sharded mode, saves to the active (last) shard. If the active
+        In sharded mode, clears ALL shards first (to prevent duplication on
+        full rebuilds), then saves to the active (last) shard. If the active
         shard exceeds SHARD_CHUNK_THRESHOLD, a new shard is created.
         """
         if not self._data_dbs:
@@ -137,7 +138,27 @@ class ShardedRecallDB:
             next_shard_index,
         )
 
-        # Save to the last (active) shard
+        # Clear ALL non-active shards before writing. RecallDB.save_chunks()
+        # only wipes the single DB it's called on, so without this step a
+        # full rebuild leaves stale duplicates in every earlier shard.
+        for db in self._data_dbs[:-1]:
+            try:
+                db._conn.execute("DROP TRIGGER IF EXISTS chunks_ad")
+                db._conn.execute("DELETE FROM chunks")
+                db._conn.execute("INSERT INTO chunks_fts(chunks_fts) VALUES ('delete-all')")
+                db._conn.execute(
+                    "CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN "
+                    "  INSERT INTO chunks_fts(chunks_fts, rowid, user_text, assistant_text, "
+                    "    tools_used, files_touched, tool_content, date_text) "
+                    "  VALUES ('delete', old.rowid, old.user_text, old.assistant_text, "
+                    "    old.tools_used, old.files_touched, old.tool_content, old.date_text); "
+                    "END;"
+                )
+                db._conn.commit()
+            except Exception:
+                logger.warning("Failed to clear shard %s", db._path, exc_info=True)
+
+        # Save to the last (active) shard (this also clears it internally)
         active_db = self._data_dbs[-1]
         active_db.save_chunks(chunks)
 

--- a/tests/recall/test_sharded_db.py
+++ b/tests/recall/test_sharded_db.py
@@ -125,6 +125,52 @@ class TestShardedRecallDBSharded(unittest.TestCase):
         db.save_chunks([])
         db.close()
 
+    def test_save_chunks_clears_all_shards_on_rebuild(self):
+        """Full save_chunks clears stale data from ALL shards, not just active."""
+        from synapt.recall.core import TranscriptChunk
+        RecallDB(self.index_dir / "index.db").close()
+        RecallDB(self.index_dir / "data_001.db").close()
+        RecallDB(self.index_dir / "data_002.db").close()
+        db = ShardedRecallDB.open(self.index_dir)
+        self.assertEqual(db.shard_count, 2)
+
+        # Seed shard 1 with old data
+        old_chunk = TranscriptChunk(
+            id="old:t0", session_id="s1", timestamp="2025-01-01T00:00:00Z",
+            turn_index=0, user_text="old", assistant_text="stale",
+        )
+        db._data_dbs[0].save_chunks([old_chunk])
+        count_before = db._data_dbs[0]._conn.execute(
+            "SELECT COUNT(*) FROM chunks"
+        ).fetchone()[0]
+        self.assertEqual(count_before, 1)
+
+        # Now do a full rebuild save (like rescrub does)
+        new_chunk = TranscriptChunk(
+            id="new:t0", session_id="s2", timestamp="2025-06-01T00:00:00Z",
+            turn_index=0, user_text="new", assistant_text="fresh",
+        )
+        db.save_chunks([new_chunk])
+
+        # Shard 1 should be cleared (the bug: it kept the old chunk)
+        count_shard1 = db._data_dbs[0]._conn.execute(
+            "SELECT COUNT(*) FROM chunks"
+        ).fetchone()[0]
+        self.assertEqual(count_shard1, 0, "Old shard should be cleared on rebuild")
+
+        # Active shard should have the new chunk
+        count_active = db._data_dbs[-1]._conn.execute(
+            "SELECT COUNT(*) FROM chunks"
+        ).fetchone()[0]
+        self.assertEqual(count_active, 1)
+
+        # FTS search should only find the new chunk, not the old one
+        results = db.fts_search("stale")
+        self.assertEqual(len(results), 0, "Stale data should not appear in FTS")
+        results = db.fts_search("fresh")
+        self.assertEqual(len(results), 1)
+        db.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ShardedRecallDB.save_chunks() only cleared the active (last) shard before writing, leaving stale duplicates in all previous shards on full rebuilds
- Production impact: 30 shards with 782K duplicate chunks (from 40K unique), 2.2GB index dir, 30x search fan-out
- Fix: clear all non-active shards before writing, matching RecallDB's delete-and-reinsert semantics
- Regression test: verifies old shard data is cleared and FTS doesn't return stale results

## Test plan
- [x] `pytest tests/recall/test_sharded_db.py` — 11/11 passing (including new rebuild test)
- [ ] Manual: split a DB, rebuild, verify no duplication across shards


🤖 Generated with [Claude Code](https://claude.com/claude-code)