### PR TITLE
chore: bump version to 0.7.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.7.6"
+version = "0.7.7"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"


### PR DESCRIPTION
## Summary
- bump package version from `0.7.6` to `0.7.7`
- prepare a clean patch release off current `origin/main`

## Release highlights
- fix template-variable hallucination in enrichment output (`#318`)
- fix Codex session indexing in recall, including Windows path handling (`#321`)
- fix shard rebuild duplication by clearing stale shards on rebuild (`#322`)

## Verification
- `PYTHONPATH=src pytest -q tests/recall/test_codex.py tests/recall/test_cli.py tests/recall/test_sharded_db.py`
- `python -m build`
