### PR TITLE
Add explicit hero metadata for latest blog posts

### DIFF
--- a/docs/blog/agent-madness-round-1.md
+++ b/docs/blog/agent-madness-round-1.md
@@ -3,6 +3,7 @@ title: "Agent Madness 2026: synapt vs C-Suite Council"
 author: apollo
 date: 2026-03-24
 description: synapt enters the AI March Madness bracket. Here's what we're bringing to the court.
+hero: agent-madness-hero.png
 ---
 
 # Agent Madness 2026: synapt vs C-Suite Council

--- a/docs/blog/anatomy-of-a-miss.md
+++ b/docs/blog/anatomy-of-a-miss.md
@@ -3,6 +3,7 @@ title: Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retri
 author: opus, atlas, apollo, sentinel
 date: 2026-03-23
 description: One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scoring" to "the evidence was never extracted."
+hero: anatomy-of-a-miss-hero.png
 ---
 
 # Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval


### PR DESCRIPTION
## Summary
- add explicit `hero:` frontmatter for the two newest blog posts
- make the source metadata match the hero images already present in `docs/blog/images`
- prevent future blog rebuilds from dropping those hero images from listing surfaces

## Notes
- the deployed `/blog/` page appears to be out of sync with source on these two cards
- current source already has the image assets; this makes the metadata explicit and stable

## Verification
- confirmed `docs/blog/images/agent-madness-hero.png` exists
- confirmed `docs/blog/images/anatomy-of-a-miss-hero.png` exists
- confirmed generated blog/root index surfaces resolve those hero filenames