### PR TITLE
chore: bump version to 0.7.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.7.7"
+version = "0.7.8"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"


### PR DESCRIPTION
## Summary
- Version bump from 0.7.7 to 0.7.8
- Release scope: 8B enrichment model upgrade, shard fix, Codex indexing, template fix, blog tooling
- MW enrichment evaluated and parked after conv3 gate failure (-9.09pp single-hop regression)

## Test plan
- [x] `./scripts/bump-version.sh patch` updated both files
- [ ] CI passes
- [ ] After merge: tag v0.7.8, publish workflow runs


🤖 Generated with [Claude Code](https://claude.com/claude-code)