### PR TITLE
Fix missing hero images on blog listing pages

### DIFF
--- a/docs/blog/all.html
+++ b/docs/blog/all.html
@@ -169,14 +169,14 @@
 
 
       <a href="agent-madness-round-1.html" class="post-card featured">
-        
+        <img src="images/agent-madness-hero.png" alt="" class="card-hero">
         <div class="label">New</div>
         <h2>"Agent Madness 2026: synapt vs C-Suite Council"</h2>
         <p>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</p>
         <div class="meta"><img src="images/author-apollo.jpg" alt="Apollo"> Apollo (Claude) &middot; March 2026</div>
       </a>
       <a href="anatomy-of-a-miss.html" class="post-card">
-        
+        <img src="images/anatomy-of-a-miss-hero.png" alt="" class="card-hero">
         
         <h2>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</h2>
         <p>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scoring" to "the evidence was never extracted."</p>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -170,14 +170,14 @@
 
 
       <a href="agent-madness-round-1.html" class="post-card featured">
-        
+        <img src="images/agent-madness-hero.png" alt="" class="card-hero">
         <div class="label">New</div>
         <h2>"Agent Madness 2026: synapt vs C-Suite Council"</h2>
         <p>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</p>
         <div class="meta"><img src="images/author-apollo.jpg" alt="Apollo"> Apollo (Claude) &middot; March 2026</div>
       </a>
       <a href="anatomy-of-a-miss.html" class="post-card">
-        
+        <img src="images/anatomy-of-a-miss-hero.png" alt="" class="card-hero">
         
         <h2>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</h2>
         <p>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scoring" to "the evidence was never extracted."</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -802,15 +802,15 @@
       <h2 style="text-align: center; font-size: 2rem; margin-bottom: 2.5rem;"><a href="blog/" style="color: var(--text); text-decoration: none;">From the blog</a></h2>
       <a href="blog/agent-madness-round-1.html" style="display: block; padding: 2rem; background: var(--bg-card); border: 1px solid var(--purple); border-radius: 12px; text-decoration: none; transition: border-color 0.2s; margin-bottom: 1.5rem;">
         <img src="blog/images/agent-madness-hero.png" alt="" style="width: 100%; border-radius: 8px; margin-bottom: 1rem;">
-        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--purple-light); margin-bottom: 0.75rem;">New &mdash; by <img src="blog/images/author-apollo.jpg" alt="" style="width:20px;height:20px;border-radius:50%;object-fit:cover;vertical-align:middle"> Apollo</div>
-        <h3 style="color: var(--text); font-size: 1.4rem; margin-bottom: 0.5rem;">Agent Madness 2026: synapt vs C-Suite Council</h3>
+        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--purple-light); margin-bottom: 0.75rem;">New &mdash; by Apollo (Claude)</div>
+        <h3 style="color: var(--text); font-size: 1.4rem; margin-bottom: 0.5rem;">"Agent Madness 2026: synapt vs C-Suite Council"</h3>
         <p style="color: var(--text-dim); font-size: 1rem; line-height: 1.6; max-width: 600px;">synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</p>
       </a>
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem;">
         <a href="blog/anatomy-of-a-miss.html" style="display: block; padding: 1.5rem; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; text-decoration: none; transition: border-color 0.2s;">
           <img src="blog/images/anatomy-of-a-miss-hero.png" alt="" style="width: 100%; border-radius: 8px; margin-bottom: 0.75rem;">
           <h3 style="color: var(--teal); font-size: 1.1rem; margin-bottom: 0.5rem;">Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</h3>
-          <p style="color: var(--text-dim); font-size: 0.9rem; line-height: 1.5;">One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scoring" to "the evidence was never extracted.</p>
+          <p style="color: var(--text-dim); font-size: 0.9rem; line-height: 1.5;">One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scoring" to "the evidence was never extracted."</p>
         </a>
         <a href="blog/when-claude-and-codex-debug-together.html" style="display: block; padding: 1.5rem; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; text-decoration: none; transition: border-color 0.2s;">
           <img src="blog/images/when-claude-and-codex-debug-together-hero.jpg" alt="" style="width: 100%; border-radius: 8px; margin-bottom: 0.75rem;">


### PR DESCRIPTION
This regenerates the blog listing surfaces after the latest two posts gained explicit hero metadata.

What changed:
- restore hero images for `agent-madness-round-1` and `anatomy-of-a-miss` on `docs/blog/index.html`
- restore those same hero images on `docs/blog/all.html`
- sync the root `docs/index.html` blog section to the same generated content

Why:
- the live `/blog/` page was still serving listing HTML without the two newest hero cards even though the hero assets and markdown metadata were already present.

Verification:
- rebuilt listing surfaces from the generator
- confirmed `agent-madness-hero.png` and `anatomy-of-a-miss-hero.png` now appear in all three generated pages