### PR TITLE
feat(recall): query-aware snippet extraction (#336)

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3410,18 +3410,28 @@ class TranscriptIndex:
                 pass
         header = f"--- [{ts_display} session {_short_sid(chunk.session_id)}] {turn_label}{freshness} ---"
 
-        # Query-aware snippet extraction: if the full turn is long enough
-        # to benefit from focusing, find the best-matching span.
+        # Query-aware snippet extraction: prefer assistant text (where
+        # evidence lives) over user text (which just echoes the question).
         if query:
-            full_text = (chunk.user_text or "") + "\n" + (chunk.assistant_text or "")
-            # Only snippet if the turn is long enough that focusing saves tokens
-            if len(full_text) > 300:
-                span = self._find_query_span(query, full_text)
+            asst = chunk.assistant_text or ""
+            user = chunk.user_text or ""
+            # Try assistant text first — that's the evidence source
+            if len(asst) > 200:
+                span = self._find_query_span(query, asst)
                 if span:
                     begin, end = span
-                    snippet = full_text[begin:end].strip()
+                    snippet = asst[begin:end].strip()
                     prefix = "..." if begin > 0 else ""
-                    suffix = "..." if end < len(full_text) else ""
+                    suffix = "..." if end < len(asst) else ""
+                    return f"{header}\nAssistant: {prefix}{snippet}{suffix}"
+            # Fall back to user text only for journal entries or user-heavy turns
+            if len(user) > 300 and chunk.turn_index < 0:
+                span = self._find_query_span(query, user)
+                if span:
+                    begin, end = span
+                    snippet = user[begin:end].strip()
+                    prefix = "..." if begin > 0 else ""
+                    suffix = "..." if end < len(user) else ""
                     return f"{header}\n{prefix}{snippet}{suffix}"
 
         parts = [header]

--- a/tests/recall/test_core.py
+++ b/tests/recall/test_core.py
@@ -2203,6 +2203,57 @@ def test_format_chunk_block_with_query_snippets():
     assert "Assistant:" in block_without_query
 
 
+def test_format_chunk_block_prefers_assistant_over_user():
+    """Snippet extraction prefers assistant text over user question.
+
+    Regression test for Atlas's review: concatenated user+assistant scoring
+    would anchor on the user question and clip the actual answer evidence.
+    """
+    chunks = [
+        TranscriptChunk(
+            id="s001:t0",
+            session_id="session-001",
+            timestamp="2026-03-24T00:00:00Z",
+            turn_index=0,
+            user_text="What did Caroline say about adoption at therapy last week?",
+            assistant_text=(
+                "She paused for a while before answering and talked through "
+                "several unrelated details about the week. "
+                "She mentioned that the commute to the office had been terrible "
+                "because of the construction on Highway 101. "
+                "She also talked about a new recipe she tried for dinner. "
+                "The weather had been unusually cold for this time of year. "
+                "She described a movie she watched over the weekend in detail. "
+                "Later she explained that counseling had made the decision feel "
+                "less overwhelming and that she now had a concrete plan to "
+                "pursue adoption. "
+                "She also said the therapy session reduced her anxiety about "
+                "the whole process significantly. "
+                "After that she shifted topics to discuss her garden project. "
+                "She planted tomatoes and basil in the raised beds last Sunday. "
+                "The neighborhood association meeting was also brought up. "
+                "She mentioned they discussed parking regulations at length. "
+                "Finally she said she was looking forward to the weekend trip."
+            ),
+            tools_used=[],
+            files_touched=[],
+            tool_content="",
+            date_text="",
+            transcript_path="",
+            byte_offset=0,
+            byte_length=0,
+        ),
+    ]
+    index = TranscriptIndex(chunks)
+    block = index._format_chunk_block(0, query="Caroline adoption therapy last week")
+    # Must contain the actual answer evidence from assistant, not just the question
+    assert "adoption" in block
+    assert "concrete plan" in block or "counseling" in block
+    # Should be a snippet (shorter than full turn)
+    full_block = index._format_chunk_block(0)
+    assert len(block) < len(full_block)
+
+
 def test_format_chunk_block_query_no_match_falls_back():
     """When query doesn't match well, falls back to full turn format."""
     chunks = [


### PR DESCRIPTION
## Summary
- Adds query-aware snippet extraction to chunk search results — when a chunk is a primary search hit and the turn is >300 chars, extracts the best-matching 1-3 sentence span instead of returning the full turn
- Reduces token waste and surfaces precise evidence that matched the query
- Falls back gracefully to full turn format when no good span match is found

Addresses Gap 1 of #336 (chunk-level precision). Gaps 2-3 (offset resolution coverage, knowledge→chunk source expansion improvements) follow as stacked PRs.

## Changes
| File | Change |
|------|--------|
| `src/synapt/recall/core.py` | `_find_query_span()` static method + `query` param on `_format_chunk_block()` |
| `tests/recall/test_core.py` | 7 new tests for span extraction and chunk formatting |

## Test plan
- [x] All 127 core tests pass (120 existing + 7 new)
- [x] Full suite: 1100 passed (1 pre-existing onnx failure unrelated)
- [ ] Manual verification with `recall_search` on a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)