### PR TITLE
feat(recall): improve offset resolution coverage (#336 Gap 2)

### DIFF
--- a/src/synapt/recall/consolidate.py
+++ b/src/synapt/recall/consolidate.py
@@ -1879,7 +1879,7 @@ def _find_best_span(node_text: str, chunk_text: str, margin: int = 30) -> tuple[
                 best_begin = scored[i][0]
                 best_end = scored[i + window - 1][1]
 
-    if best_score < 2:
+    if best_score < 1:
         return None
 
     # Add margin for context
@@ -1892,7 +1892,7 @@ def resolve_source_offsets(
     project_dir: Path | None = None,
     *,
     max_offsets_per_node: int = 3,
-    min_overlap: int = 3,
+    min_overlap: int = 2,
 ) -> int:
     """Resolve source_offsets for knowledge nodes by finding sentence spans.
 
@@ -1900,6 +1900,11 @@ def resolve_source_offsets(
     within transcript chunks from its source_sessions.  Stores character
     offsets (begin, end) so retrieval can extract precise snippets instead
     of formatting entire turns.
+
+    When a node already has ``source_turns`` (from ``resolve_source_turns``),
+    those turns are used as direct candidates — skipping the token-overlap
+    scan entirely.  This improves coverage for short or abstract nodes that
+    would otherwise fail the overlap threshold.
 
     Returns the number of nodes updated.
     """
@@ -1910,11 +1915,46 @@ def resolve_source_offsets(
     kn_path, session_chunks, nodes, db = loaded
     pending_updates: dict[str, dict] = {}
 
+    # Build a turn lookup: (session_id, turn_index) → full text
+    _turn_text: dict[tuple[str, int], str] = {}
+    for sid, chunks_list in session_chunks.items():
+        for tidx, text, _toks in chunks_list:
+            _turn_text[(sid, tidx)] = text
+
     try:
         for node in nodes:
             if node.source_offsets:
                 continue  # Already resolved
 
+            # Fast path: use source_turns as direct candidates when available.
+            # source_turns are already the best-matching turns from
+            # resolve_source_turns(), so we skip the token overlap scan.
+            if node.source_turns:
+                offsets: list[dict] = []
+                for turn_ref in node.source_turns[:max_offsets_per_node]:
+                    # Parse "session_id:turn_index" format
+                    parts = turn_ref.rsplit(":", 1)
+                    if len(parts) != 2:
+                        continue
+                    sid, tidx_str = parts
+                    try:
+                        tidx = int(tidx_str)
+                    except ValueError:
+                        continue
+                    text = _turn_text.get((sid, tidx), "")
+                    if not text:
+                        continue
+                    span = _find_best_span(node.content, text)
+                    if span:
+                        offsets.append({
+                            "s": sid, "t": tidx,
+                            "b": span[0], "e": span[1],
+                        })
+                if offsets:
+                    pending_updates[node.id] = {"source_offsets": offsets}
+                    continue
+
+            # Fallback: scan source_sessions by token overlap
             if not node.source_sessions:
                 continue
 
@@ -1922,7 +1962,6 @@ def resolve_source_offsets(
             if len(node_toks) < 2:
                 continue
 
-            # Score chunks by token overlap, keep top candidates
             candidates: list[tuple[str, int, str, int]] = []
             for sid in node.source_sessions:
                 for tidx, text, chunk_toks in session_chunks.get(sid, []):
@@ -1935,7 +1974,7 @@ def resolve_source_offsets(
 
             candidates.sort(key=lambda x: x[3], reverse=True)
 
-            offsets: list[dict] = []
+            offsets = []
             for sid, tidx, text, _ in candidates[:max_offsets_per_node]:
                 span = _find_best_span(node.content, text)
                 if span:

--- a/tests/recall/test_consolidate.py
+++ b/tests/recall/test_consolidate.py
@@ -1653,5 +1653,42 @@ def test_extract_collections_can_be_disabled(tmp_path, monkeypatch):
     assert extract_collections(tmp_path) == 0
 
 
+# ---------------------------------------------------------------------------
+# Tests: _find_best_span threshold and offset resolution coverage
+# ---------------------------------------------------------------------------
+
+def test_find_best_span_single_keyword_match():
+    """_find_best_span now resolves with a single keyword overlap."""
+    from synapt.recall.consolidate import _find_best_span
+
+    node_text = "adoption"
+    chunk_text = (
+        "We talked about the weather. "
+        "She mentioned her adoption plans were moving forward. "
+        "Then we discussed dinner."
+    )
+    span = _find_best_span(node_text, chunk_text)
+    assert span is not None
+    begin, end = span
+    snippet = chunk_text[begin:end]
+    assert "adoption" in snippet
+
+
+def test_find_best_span_no_overlap_returns_none():
+    """_find_best_span returns None when there is zero keyword overlap."""
+    from synapt.recall.consolidate import _find_best_span
+
+    span = _find_best_span("kubernetes", "We had lunch and discussed movies.")
+    assert span is None
+
+
+def test_find_best_span_empty_inputs():
+    """_find_best_span returns None for empty inputs."""
+    from synapt.recall.consolidate import _find_best_span
+
+    assert _find_best_span("", "some text") is None
+    assert _find_best_span("query", "") is None
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- **source_turns fast path**: `resolve_source_offsets()` now uses existing `source_turns` as direct candidates, skipping the token-overlap scan for nodes that already have turn refs
- **Lower min_overlap**: 3 → 2 for fallback scan, catching nodes with fewer matching keywords
- **Lower span threshold**: `_find_best_span()` threshold 2 → 1, allowing single-keyword sentence matches (pre-filtered by chunk-level overlap)

These three changes increase how many knowledge nodes get precise `source_offsets`, which feeds into the snippet extraction from Gap 1 (#340).

## Changes
| File | Change |
|------|--------|
| `src/synapt/recall/consolidate.py` | source_turns fast path + lower thresholds |
| `tests/recall/test_consolidate.py` | 3 new tests for `_find_best_span` threshold |

## Test plan
- [x] 131 consolidation tests pass
- [x] 128 core tests pass (259 total)
- [ ] Manual: verify offset coverage increase on a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)