### PR TITLE
fix(recall): disable snippet extraction by default (#344)

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3412,7 +3412,10 @@ class TranscriptIndex:
 
         # Query-aware snippet extraction: prefer assistant text (where
         # evidence lives) over user text (which just echoes the question).
-        if query:
+        # Disabled by default — saves only 3.4% tokens but clips evidence
+        # that retrieval scoring and answer generation need. See #344.
+        # Enable with SYNAPT_ENABLE_SNIPPETS=1 for token-constrained use.
+        if query and os.environ.get("SYNAPT_ENABLE_SNIPPETS"):
             asst = chunk.assistant_text or ""
             user = chunk.user_text or ""
             # Try assistant text first — that's the evidence source

--- a/tests/recall/test_core.py
+++ b/tests/recall/test_core.py
@@ -2160,8 +2160,9 @@ def test_find_query_span_multi_sentence_window():
     assert "migration" in snippet
 
 
-def test_format_chunk_block_with_query_snippets():
-    """_format_chunk_block emits focused snippet when query matches a subspan."""
+def test_format_chunk_block_with_query_snippets(monkeypatch):
+    """_format_chunk_block emits focused snippet when SYNAPT_ENABLE_SNIPPETS=1."""
+    monkeypatch.setenv("SYNAPT_ENABLE_SNIPPETS", "1")
     chunks = [
         TranscriptChunk(
             id="s001:t0",
@@ -2203,12 +2204,13 @@ def test_format_chunk_block_with_query_snippets():
     assert "Assistant:" in block_without_query
 
 
-def test_format_chunk_block_prefers_assistant_over_user():
+def test_format_chunk_block_prefers_assistant_over_user(monkeypatch):
     """Snippet extraction prefers assistant text over user question.
 
     Regression test for Atlas's review: concatenated user+assistant scoring
     would anchor on the user question and clip the actual answer evidence.
     """
+    monkeypatch.setenv("SYNAPT_ENABLE_SNIPPETS", "1")
     chunks = [
         TranscriptChunk(
             id="s001:t0",


### PR DESCRIPTION
## Summary
Bisect confirmed #340's snippet extraction causes LOCOMO regression by clipping evidence from formatted output. Token savings only 3.4% — not worth the evidence loss.

| Config | open-domain | single-hop | Avg Context |
|--------|-------------|------------|-------------|
| v0.7.8 baseline | 56.31% | 13.64% | — |
| v0.8.0 snippets ON | 51.35% | 4.55% | 8,603 chars |
| **v0.8.0 snippets OFF** | **58.11%** | **13.64%** | 8,903 chars |

Snippets now opt-in via `SYNAPT_ENABLE_SNIPPETS=1`.

## Test plan
- [x] 128 core tests pass
- [x] Conv3 8B eval confirms regression recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)