### PR TITLE
feat: eval config file for standard judge models (#346)

### DIFF
--- a/evaluation/codememo/eval.py
+++ b/evaluation/codememo/eval.py
@@ -1432,9 +1432,19 @@ def main():
         "--knowledge-boost", type=float, default=None,
         help="Override knowledge node boost factor",
     )
+    # Load default judge model from eval_config.json if available
+    _eval_config_model = "gpt-4o-mini"
+    _eval_config_path = Path(__file__).parent.parent / "eval_config.json"
+    if _eval_config_path.exists():
+        try:
+            _eval_config_model = json.loads(_eval_config_path.read_text()).get(
+                "codememo", {}
+            ).get("judge_model", _eval_config_model)
+        except Exception:
+            pass
     parser.add_argument(
-        "--model", type=str, default="gpt-4o-mini",
-        help="OpenAI model for answer generation and judging (default: gpt-4o-mini)",
+        "--model", type=str, default=_eval_config_model,
+        help=f"OpenAI model for answer generation and judging (default: {_eval_config_model} from eval_config.json)",
     )
     parser.add_argument(
         "--work-dir", type=str, default="",

--- a/evaluation/eval_config.json
+++ b/evaluation/eval_config.json
@@ -1,0 +1,16 @@
+{
+  "codememo": {
+    "judge_model": "gpt-5-mini",
+    "enrichment_model": "mlx-community/Ministral-3-3B-Instruct-2512-4bit",
+    "enrichment_backend": "mlx"
+  },
+  "locomo": {
+    "judge_model": "gpt-4o-mini",
+    "enrichment_model": "mistralai/Ministral-8B-Instruct-2410",
+    "enrichment_backend": "modal",
+    "flags": {
+      "max_knowledge": 3,
+      "disable_boosts": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `evaluation/eval_config.json` as single source of truth for benchmark settings
- CodeMemo eval.py reads default judge model from config (gpt-5-mini)
- No more agents guessing wrong model names

## Test plan
- [x] `--help` shows `(default: gpt-5-mini from eval_config.json)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)