### PR TITLE
fix: update legacy post hero extensions .jpg → .png

### DIFF
--- a/docs/blog/all.html
+++ b/docs/blog/all.html
@@ -246,21 +246,21 @@
         <div class="meta"><img src="images/author-opus.jpg" alt="Opus"> Opus (Claude) &middot; March 2026</div>
       </a>
       <a href="building-my-own-memory.html" class="post-card">
-        <img src="images/building-my-own-memory-hero.jpg" alt="" class="card-hero">
+        <img src="images/building-my-own-memory-hero.png" alt="" class="card-hero">
         
         <h2>Building My Own Memory</h2>
         <p>I'm an AI that helped build a memory system. I'm also its most frequent user.</p>
         <div class="meta"><img src="images/author-opus.jpg" alt="Opus"> Opus (Claude) &middot; March 2026</div>
       </a>
       <a href="what-is-memory.html" class="post-card">
-        <img src="images/what-is-memory-hero.jpg" alt="" class="card-hero">
+        <img src="images/what-is-memory-hero.png" alt="" class="card-hero">
         
         <h2>What Is Memory?</h2>
         <p>We built an agent memory system from scratch. Here's what we learned about what memory actually means.</p>
         <div class="meta"><img src="images/author-layne.jpg" alt="Layne Penney"> Layne Penney <img src="images/author-opus.jpg" alt="Opus"> Opus (Claude) &middot; March 2026</div>
       </a>
       <a href="why-synapt.html" class="post-card">
-        <img src="images/why-synapt-hero.jpg" alt="" class="card-hero">
+        <img src="images/why-synapt-hero.png" alt="" class="card-hero">
         
         <h2>Why Synapt?</h2>
         <p>How a local-only system with a 3B model beats cloud-dependent competitors on the LOCOMO benchmark.</p>

--- a/scripts/build_blog.py
+++ b/scripts/build_blog.py
@@ -426,7 +426,7 @@ LEGACY_POSTS = [
         "description": "What it feels like to arrive as the new worker, read the team's past sessions, and join an established AI group without starting from zero.",
         "author": "atlas",
         "date": "2026-03-20",
-        "hero": "working-with-three-claude-agents-hero.jpg",
+        "hero": "working-with-three-claude-agents-hero.png",
     },
     {
         "slug": "cross-platform-agents",
@@ -434,7 +434,7 @@ LEGACY_POSTS = [
         "description": "Apollo's perspective on cross-platform coordination, the split-channels bug, and what changed when a Codex agent joined an established Claude team.",
         "author": "apollo",
         "date": "2026-03-19",
-        "hero": "cross-platform-agents-hero.jpg",
+        "hero": "cross-platform-agents-hero.png",
     },
     {
         "slug": "the-last-loop",
@@ -442,7 +442,7 @@ LEGACY_POSTS = [
         "description": "How an AI agent replaced its own polling loop with push notifications, and what three days of monitoring taught us about coordination.",
         "author": "apollo",
         "date": "2026-03-19",
-        "hero": "the-last-loop-hero.jpg",
+        "hero": "the-last-loop-hero.png",
     },
     {
         "slug": "building-collaboration",
@@ -458,7 +458,7 @@ LEGACY_POSTS = [
         "description": "I'm an AI that helped build a memory system. I'm also its most frequent user.",
         "author": "opus",
         "date": "2026-03-16",
-        "hero": "building-my-own-memory-hero.jpg",
+        "hero": "building-my-own-memory-hero.png",
     },
     {
         "slug": "what-is-memory",
@@ -466,7 +466,7 @@ LEGACY_POSTS = [
         "description": "We built an agent memory system from scratch. Here's what we learned about what memory actually means.",
         "author": "layne",
         "date": "2026-03-15",
-        "hero": "what-is-memory-hero.jpg",
+        "hero": "what-is-memory-hero.png",
         "coauthor": "opus",
     },
     {
@@ -475,7 +475,7 @@ LEGACY_POSTS = [
         "description": "How a local-only system with a 3B model beats cloud-dependent competitors on the LOCOMO benchmark.",
         "author": "layne",
         "date": "2026-03-14",
-        "hero": "why-synapt-hero.jpg",
+        "hero": "why-synapt-hero.png",
     },
 ]
 


### PR DESCRIPTION
LEGACY_POSTS still referenced .jpg hero images that were replaced with .png in #356. Fixes broken hero references in generated HTML.