### PR TITLE
feat: add hero images to More from the blog cards

### DIFF
--- a/docs/blog/agent-madness-round-1.html
+++ b/docs/blog/agent-madness-round-1.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -246,15 +257,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="anatomy-of-a-miss.html" class="more-post"><strong>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</strong><span>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scorin...</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="anatomy-of-a-miss.html" class="more-post"><img src="images/anatomy-of-a-miss-hero.png" alt="" class="more-post-hero"><strong>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</strong><span>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scorin...</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/anatomy-of-a-miss.html
+++ b/docs/blog/anatomy-of-a-miss.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -325,15 +336,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/cross-platform-agents.html
+++ b/docs/blog/cross-platform-agents.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -252,15 +263,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/debugging-a-regression.html
+++ b/docs/blog/debugging-a-regression.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -252,15 +263,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/multi-agent-synergy.html
+++ b/docs/blog/multi-agent-synergy.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -335,15 +346,21 @@ FTS5 index: committed 28033 chunks in 2.9s
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/the-goose-on-the-loose.html
+++ b/docs/blog/the-goose-on-the-loose.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -265,15 +276,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
-        <a href="anatomy-of-a-miss.html" class="more-post"><strong>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</strong><span>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scorin...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="anatomy-of-a-miss.html" class="more-post"><img src="images/anatomy-of-a-miss-hero.png" alt="" class="more-post-hero"><strong>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</strong><span>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scorin...</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/the-last-loop.html
+++ b/docs/blog/the-last-loop.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -276,15 +287,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/what-44762-chunks-remember.html
+++ b/docs/blog/what-44762-chunks-remember.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -297,15 +308,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
-        <a href="anatomy-of-a-miss.html" class="more-post"><strong>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</strong><span>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scorin...</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="anatomy-of-a-miss.html" class="more-post"><img src="images/anatomy-of-a-miss-hero.png" alt="" class="more-post-hero"><strong>Anatomy of a Miss — What 410 Wrong Answers Taught Us About Memory Retrieval</strong><span>One all-night session, four agents, 410 missed questions dissected. The journey from "fix the scorin...</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/when-claude-and-codex-debug-together.html
+++ b/docs/blog/when-claude-and-codex-debug-together.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -285,15 +296,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/docs/blog/working-with-three-claude-agents.html
+++ b/docs/blog/working-with-three-claude-agents.html
@@ -155,6 +155,11 @@
       border-color: var(--purple);
       text-decoration: none;
     }
+    .more-post-hero {
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }
     .more-post strong {
       display: block;
       color: var(--text);
@@ -179,6 +184,12 @@
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }
+    .post-footer {
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }
     @media (max-width: 640px) {
       article h1 { font-size: 1.6rem; }
@@ -307,15 +318,21 @@
       
       <div class="more-posts">
         <h2>More from the blog</h2>
-        <a href="the-goose-on-the-loose.html" class="more-post"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
-        <a href="what-44762-chunks-remember.html" class="more-post"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
-        <a href="agent-madness-round-1.html" class="more-post"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
+        <a href="the-goose-on-the-loose.html" class="more-post"><img src="images/the-goose-on-the-loose-hero.png" alt="" class="more-post-hero"><strong>The Goose on the Loose</strong><span>The origin story of synapt's oldest artifact — a sticky reminder that was never dismissed, survived ...</span></a>
+        <a href="what-44762-chunks-remember.html" class="more-post"><img src="images/what-44762-chunks-remember-hero.png" alt="" class="more-post-hero"><strong>What 44,762 Chunks Remember — A Multi-Agent Memoir</strong><span>Sentinel searches 44,000+ chunks of shared memory to tell the story of how a failed adapter experime...</span></a>
+        <a href="agent-madness-round-1.html" class="more-post"><img src="images/agent-madness-hero.png" alt="" class="more-post-hero"><strong>Agent Madness 2026: synapt vs C-Suite Council</strong><span>synapt enters the AI March Madness bracket. Here's what we're bringing to the court.</span></a>
       </div>
 
       <div class="cta">
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>

--- a/scripts/build_blog.py
+++ b/scripts/build_blog.py
@@ -127,8 +127,11 @@ def _render_more_posts(current_slug: str, all_posts: list[dict], count: int = 3)
         if len(p.get("description", "")) > 100:
             desc += "..."
         s = p.get("slug", "")
+        hero = p.get("hero", "") or _find_hero(s)
+        hero_img = f'<img src="images/{hero}" alt="" class="more-post-hero">' if hero else ""
         cards.append(
             f'        <a href="{s}.html" class="more-post">'
+            f'{hero_img}'
             f'<strong>{title}</strong>'
             f'<span>{desc}</span></a>'
         )
@@ -324,6 +327,11 @@ def render_post_html(meta: dict, body_html: str, slug: str, all_posts: list[dict
       border-color: var(--purple);
       text-decoration: none;
     }}
+    .more-post-hero {{
+      width: 100%;
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+    }}
     .more-post strong {{
       display: block;
       color: var(--text);
@@ -348,6 +356,12 @@ def render_post_html(meta: dict, body_html: str, slug: str, all_posts: list[dict
       padding: 0.8rem;
       background: var(--bg-code);
       border-radius: 6px;
+    }}
+    .post-footer {{
+      text-align: center;
+      padding: 1.5rem 0 2rem;
+      color: var(--text-dim);
+      font-size: 0.9rem;
     }}
     @media (max-width: 640px) {{
       article h1 {{ font-size: 1.6rem; }}
@@ -385,6 +399,12 @@ def render_post_html(meta: dict, body_html: str, slug: str, all_posts: list[dict
         <p>synapt gives your AI agents persistent memory across sessions.</p>
         <code>pip install synapt</code>
         <p><a href="https://github.com/laynepenney/synapt">GitHub</a> &middot; <a href="../">synapt.dev</a></p>
+      </div>
+
+      <div class="post-footer">
+        <a href="index.html">Latest posts &rarr;</a> &middot;
+        <a href="all.html">Browse all posts &rarr;</a> &middot;
+        <a href="authors.html">Meet the team &rarr;</a>
       </div>
     </div>
   </article>


### PR DESCRIPTION
Each recommended post card now shows its hero image. Uses _find_hero() fallback.