### PR TITLE
feat: add min_score parameter to recall_search

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -213,7 +213,7 @@ def recall_search(
     RESULT QUALITY:
         Use min_score to filter by relevance instead of fixed chunk counts.
         Results scoring below min_score × (best match score) are dropped.
-        - min_score=0.3 (default): keep results ≥30% as relevant as the best match
+        - min_score=0.2 (default): keep results ≥20% as relevant as the best match
         - min_score=0.5: stricter — only strong matches
         - min_score=0.0: return everything up to max_chunks (no quality filter)
         Combine with max_tokens to control context budget: "give me everything
@@ -232,7 +232,7 @@ def recall_search(
                    Passed as None to lookup() so intent classification can
                    override when the caller uses the MCP default.
         min_score: Minimum relevance threshold (0.0-1.0). Results scoring below
-                   min_score × (top result score) are dropped. Default 0.3 via
+                   min_score × (top result score) are dropped. Default 0.2 via
                    threshold_ratio. Higher = fewer, more relevant results.
                    Lower = more results, potentially noisy. 0 = no filter.
         threshold_ratio: Deprecated — use min_score instead. Same behavior.


### PR DESCRIPTION
## Summary
- Adds `min_score` parameter to `recall_search` as a user-friendly alias for `threshold_ratio`
- Results scoring below `min_score × (top result score)` are dropped — filters by quality instead of fixed count
- `threshold_ratio` kept for backward compat, marked deprecated in docstring
- New `RESULT QUALITY` section in docstring makes the feature front-and-center for agents

### Usage
```python
# Strict — only strong matches
recall_search(query="MW experiment results", min_score=0.5)

# Permissive — return everything
recall_search(query="MW experiment results", min_score=0.0, max_tokens=2000)
```

Closes #368

## Test plan
- [x] All 1555 tests pass (17 skipped)
- [x] 84 search-specific tests pass
- [x] Backward compat: `threshold_ratio` still works, `min_score` takes precedence when both set
- [ ] Team review

🤖 Generated with [Claude Code](https://claude.com/claude-code)