### PR TITLE
feat: surface channel read truncation details

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -658,6 +658,13 @@ def _read_messages(
     return messages
 
 
+def _estimate_token_count(text: str) -> int:
+    """Approximate token count using the project's standard 4 chars/token heuristic."""
+    if not text:
+        return 0
+    return max(1, (len(text) + 3) // 4)
+
+
 def _read_last_timestamp(path: Path) -> str | None:
     """Read the timestamp of the last message in a JSONL file.
 
@@ -903,7 +910,7 @@ def channel_read(
         max    -- pins, full messages, all metadata (IDs, claims, attachments)
         high   -- pins, full messages, message IDs only
         medium -- full messages, IDs, claims, attachments; pins follow show_pins
-        low    -- no pins, truncated messages (200 chars), no IDs
+        low    -- no pins, truncated messages (200 chars), with refs for truncated messages
         min    -- no pins, one-line per message, skip join/leave noise
     """
     _detail = detail.lower()
@@ -1002,10 +1009,12 @@ def channel_read(
     own_display = display_map.get(aid)
     if own_display:
         self_names.add(own_display.casefold())
+    truncated_messages: list[tuple[str, int]] = []
     for msg in messages:
         ts = msg.timestamp[:16]
         display = msg.from_display or display_map.get(msg.from_agent, msg.from_agent)
         mid = f" [{msg.id}]" if msg.id and _show_ids else ""
+        inline_mid = mid
         # Role marker — human messages get a distinct prefix
         is_human = role_map.get(msg.from_agent) == "human"
         role_tag = " [human]" if is_human else ""
@@ -1025,22 +1034,77 @@ def channel_read(
             for mention in _extract_mentions(body)
         )
         actionable = (msg.type == "directive" and msg.to in (aid, "*")) or mentions_self
+        truncation_tag = ""
         if _truncate and not actionable and len(body) > _truncate:
-            body = body[:_truncate] + "..."
+            omitted_tokens = _estimate_token_count(body[_truncate:])
+            truncated_messages.append((msg.id or "(no-id)", omitted_tokens))
+            body = body[:_truncate].rstrip() + "..."
+            if msg.id and not _show_ids:
+                inline_mid = f" [{msg.id}]"
+            truncation_tag = f" [truncated ~{omitted_tokens} tok omitted]"
         if _one_line:
             body = body.replace("\n", " ").strip()
         if msg.type in ("join", "leave"):
             if _one_line:
                 continue
-            lines.append(f"  {ts}{mid}  -- {body}")
+            lines.append(f"  {ts}{inline_mid}  -- {body}{truncation_tag}")
         elif msg.type == "directive":
             target = f" @{msg.to}" if msg.to else ""
             prefix = "[DIRECTIVE]" if msg.to in (aid, "*") else "[directive]"
-            lines.append(f"  {ts}{mid}  {prefix}{target} {display}{role_tag}: {body}{attachment_tag}{claim_tag}")
+            lines.append(
+                f"  {ts}{inline_mid}  {prefix}{target} {display}{role_tag}: "
+                f"{body}{truncation_tag}{attachment_tag}{claim_tag}"
+            )
         else:
-            lines.append(f"  {ts}{mid}  {display}{role_tag}: {body}{attachment_tag}{claim_tag}")
+            lines.append(
+                f"  {ts}{inline_mid}  {display}{role_tag}: "
+                f"{body}{truncation_tag}{attachment_tag}{claim_tag}"
+            )
+
+    if truncated_messages:
+        total_omitted = sum(tokens for _, tokens in truncated_messages)
+        refs = ", ".join(f"{message_id} (~{tokens} tok)" for message_id, tokens in truncated_messages)
+        lines.insert(
+            len(lines) if not lines else lines.index(f"## #{channel} ({len(messages)} messages)") + 1,
+            (
+                f"  truncated {len(truncated_messages)} message(s), "
+                f"~{total_omitted} tok omitted total: {refs}. "
+                "Use action='read_message' with message=<id> to inspect the full body."
+            ),
+        )
 
     return "\n".join(lines)
+
+
+def channel_read_message(
+    message_id: str,
+    channel: str = "dev",
+    project_dir: Path | None = None,
+) -> str:
+    """Read a specific channel message by id."""
+    path = _channel_path(channel, project_dir)
+    if not path.exists():
+        return f"Channel #{channel} has no messages yet."
+
+    for msg in _read_messages(path):
+        if msg.id != message_id:
+            continue
+
+        display = msg.from_display or msg.from_agent
+        lines = [f"## #{channel} [{msg.id}]", f"Timestamp: {msg.timestamp}", f"Type: {msg.type}"]
+        if display and display != msg.from_agent:
+            lines.append(f"From: {display} ({msg.from_agent})")
+        else:
+            lines.append(f"From: {display}")
+        if msg.to:
+            lines.append(f"To: {msg.to}")
+        if msg.attachments:
+            lines.append(f"Attachments: {', '.join(msg.attachments)}")
+        lines.append("")
+        lines.append(msg.body or "(empty body)")
+        return "\n".join(lines)
+
+    return f"Message {message_id} not found in #{channel}."
 
 
 def channel_who(project_dir: Path | None = None) -> str:

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -83,7 +83,6 @@ MCP_INSTRUCTIONS = (
     "- recall_channel has a `detail` parameter: max/high/medium/low/min.\n"
     "- Use detail='low' or 'min' for monitoring loops and periodic polling.\n"
     "- Use detail='high' or 'max' only when you need the full picture (e.g. catching up after being away).\n"
-    "- 'unread' action defaults to detail='low' (no pins, trimmed metadata). This is intentional.\n"
     "- Pins are large — they contain full benchmark tables. Read them once at session start with detail='high', then poll with 'low'.\n"
     "- Prefer pin=False for routine posts. Reserve pins for durable reference material."
 )
@@ -1669,11 +1668,11 @@ def recall_channel(
     State (presence, cursors, pins) is stored in SQLite.
 
     Args:
-        action: "join", "leave", "post", "read", "who", "heartbeat", "unread",
+        action: "join", "leave", "post", "read", "read_message", "who", "heartbeat", "unread",
                 "pin", "directive", "mute", "unmute", "kick", "broadcast",
                 "list", "search", "rename", "claim", "unclaim", "intent".
         channel: Channel name (default "dev"). Any name works -- created on first post.
-        message: Message body (required for "post", "directive", "broadcast" actions).
+        message: Message body (required for "post", "directive", "broadcast") or message_id for "read_message"/pin actions.
         to: Target agent for "directive" action.
         target: Agent to mute/unmute/kick (agent_id, display name, or griptree name).
         limit: Max messages to return for "read" action (default 20).
@@ -1686,7 +1685,7 @@ def recall_channel(
             "max"    — all pins, full messages, all metadata (IDs, claims, attachments)
             "high"   — all pins, full messages, message IDs only
             "medium" — full messages, IDs, claims, attachments; pins follow show_pins (default for "read")
-            "low"    — no pins, truncated messages (200 chars), no IDs
+            "low"    — no pins, truncated messages (200 chars), with refs for truncated messages
             "min"    — no pins, one-line per message, skip join/leave noise
             Use "low" or "min" for monitoring loops to save context budget.
 
@@ -1701,6 +1700,7 @@ def recall_channel(
             channel_leave,
             channel_post,
             channel_read,
+            channel_read_message,
             channel_rename,
             channel_who,
             channel_heartbeat,
@@ -1730,6 +1730,11 @@ def recall_channel(
 
         if action == "read":
             return channel_read(channel=channel, limit=limit, show_pins=show_pins, detail=detail)
+
+        if action == "read_message":
+            if not message:
+                return "Error: message_id is required for 'read_message' action."
+            return channel_read_message(channel=channel, message_id=message)
 
         if action == "who":
             return channel_who()

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from synapt.recall.channel import (
     ChannelMessage,
+    _channel_path,
     _channels_dir,
     _db_path,
     _open_db,
@@ -23,6 +24,7 @@ from synapt.recall.channel import (
     channel_leave,
     channel_post,
     channel_read,
+    channel_read_message,
     channel_who,
     channel_heartbeat,
     channel_unread,
@@ -1364,11 +1366,15 @@ class TestReadDetailLevels(unittest.TestCase):
         channel_join("dev", agent_name="reader", display_name="Apollo")
         long_message = ("x" * 220) + " tail"
         channel_post("dev", long_message, agent_name="writer")
+        message_id = _read_messages(_channel_path("dev"))[-1].id
 
         result = channel_read("dev", agent_name="reader", detail="low")
 
         self.assertIn("...", result)
         self.assertNotIn("tail", result)
+        self.assertIn(message_id, result)
+        self.assertIn("truncated 1 message(s)", result)
+        self.assertIn("tok omitted", result)
 
     def test_low_preserves_long_message_that_mentions_reader(self):
         channel_join("dev", agent_name="reader", display_name="Apollo")
@@ -1389,6 +1395,31 @@ class TestReadDetailLevels(unittest.TestCase):
 
         self.assertIn("urgent follow-up", result)
         self.assertNotIn("...", result)
+
+    def test_low_summary_lists_only_truncated_messages(self):
+        channel_join("dev", agent_name="reader", display_name="Apollo")
+        channel_post("dev", "short message", agent_name="writer")
+        channel_post("dev", ("x" * 220) + " tail", agent_name="writer")
+        messages = _read_messages(_channel_path("dev"))
+        short_id = messages[-2].id
+        long_id = messages[-1].id
+
+        result = channel_read("dev", agent_name="reader", detail="low")
+
+        self.assertIn(long_id, result)
+        self.assertNotIn(short_id, result)
+
+    def test_read_message_returns_full_body_by_id(self):
+        channel_join("dev", agent_name="reader", display_name="Apollo")
+        long_message = ("x" * 220) + " tail"
+        channel_post("dev", long_message, agent_name="writer")
+        message_id = _read_messages(_channel_path("dev"))[-1].id
+
+        result = channel_read_message(message_id, channel="dev")
+
+        self.assertIn(f"[{message_id}]", result)
+        self.assertIn(long_message, result)
+        self.assertIn("Type: message", result)
 
 
 class TestMuteUnmute(unittest.TestCase):


### PR DESCRIPTION
## Summary
- show explicit truncation summaries for low/min channel reads, including message ids and approximate omitted token counts
- keep truncated message ids visible so operators can follow up on exactly what was clipped
- add a `read_message` channel action to expand a specific message by id

## Testing
- `PYTHONPATH=src pytest tests/recall/test_channel.py -q`
