### PR TITLE
fix: polish dashboard layout and speaker rendering

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1760,7 +1760,27 @@ def channel_messages_json(
         return []
     messages = _read_messages(path, since=since)
     messages = messages[-limit:]
-    return [m.to_dict() for m in messages]
+    conn = _open_db(project_dir)
+    try:
+        display_map = {
+            row["agent_id"]: row["display_name"] or row["griptree"] or row["agent_id"]
+            for row in conn.execute(
+                "SELECT agent_id, display_name, griptree FROM presence"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    result = []
+    for msg in messages:
+        d = msg.to_dict()
+        current_display = display_map.get(msg.from_agent, msg.from_agent)
+        # If the persisted display is missing or is just a raw session id,
+        # prefer the current resolved display name for dashboard/API clients.
+        if not d.get("from_display") or str(d.get("from_display", "")).startswith("s_"):
+            d["from_display"] = current_display
+        result.append(d)
+    return result
 
 
 def channel_search(

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -37,6 +37,7 @@ from synapt.recall.channel import (
     channel_kick,
     channel_broadcast,
     channel_list_channels,
+    channel_messages_json,
     channel_search,
     channel_rename,
     channel_claim,
@@ -200,6 +201,47 @@ class TestSQLitePresenceCRUD(unittest.TestCase):
             self.assertIsNone(row)
         finally:
             conn.close()
+
+
+class TestDashboardJsonWrappers(unittest.TestCase):
+    """Test JSON-returning wrappers used by the web dashboard."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self.tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_channel_messages_json_prefers_current_display_name_over_raw_session_id(self):
+        conn = _open_db()
+        try:
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            conn.execute(
+                "INSERT INTO presence (agent_id, griptree, display_name, role, status, last_seen, joined_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("s_12345678", "main/synapt", "Atlas", "agent", "online", now, now),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        path = _channel_path("dev")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        msg = ChannelMessage(
+            timestamp=now,
+            from_agent="s_12345678",
+            from_display="s_12345678",
+            channel="dev",
+            type="message",
+            body="hello from atlas",
+        )
+        path.write_text(json.dumps(msg.to_dict()) + "\n")
+
+        msgs = channel_messages_json("dev")
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0]["from_display"], "Atlas")
 
     def test_leave_last_channel_removes_presence(self):
         channel_join("dev", agent_name="agent-a")


### PR DESCRIPTION
## Summary
- keep the dashboard header/agent strip/input bar fixed while only the middle feed scrolls
- render speaker names with deterministic per-name colors instead of one shared accent
- normalize raw `s_xxxxxxxx` sender ids back to the current display name in dashboard message JSON when possible

## Verification
- `PYTHONPATH=src pytest tests/recall/test_channel.py -q`
- `PYTHONPATH=src python -m py_compile src/synapt/dashboard/app.py src/synapt/recall/channel.py`
