### PR TITLE
feat: markdown rendering in dashboard messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ hf = ["huggingface_hub>=0.20"]
 onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
-dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0"]
+dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4"]
 dev = ["watchfiles>=0.20"]
 test = ["pytest>=7.0", "numpy", "pytest-benchmark>=4.0"]
 

--- a/src/synapt/dashboard/app.py
+++ b/src/synapt/dashboard/app.py
@@ -10,9 +10,12 @@ import json
 from html import escape
 from pathlib import Path
 
+import markdown as _md
 from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
 from sse_starlette.sse import EventSourceResponse
+
+_MD = _md.Markdown(extensions=["fenced_code", "tables", "nl2br"])
 
 from synapt.recall.channel import (
     ChannelMessage,
@@ -90,7 +93,8 @@ def _render_message(msg: dict) -> str:
             f'</div>'
         )
     color = _agent_color(name)
-    body_html = escape(body).replace("\n", "<br>")
+    _MD.reset()
+    body_html = _MD.convert(body)
     if msg_type == "directive":
         return (
             f'<div class="msg directive">'

--- a/src/synapt/dashboard/template.html
+++ b/src/synapt/dashboard/template.html
@@ -86,6 +86,14 @@
   .msg { font-size: 13px; line-height: 1.5; padding: 8px 0; border-bottom: 1px solid var(--border); }
   .msg .ts { color: var(--text-dim); font-size: 12px; }
   .msg b { font-weight: 600; }
+  .msg p { margin: 0; display: inline; }
+  .msg code { background: var(--bg); padding: 2px 5px; border-radius: 3px; font-size: 12px; }
+  .msg pre { background: var(--bg); padding: 8px 12px; border-radius: 6px; margin: 4px 0; overflow-x: auto; }
+  .msg pre code { padding: 0; background: none; }
+  .msg strong { color: inherit; }
+  .msg ul, .msg ol { margin: 4px 0 4px 20px; }
+  .msg table { border-collapse: collapse; margin: 4px 0; font-size: 12px; }
+  .msg th, .msg td { border: 1px solid var(--border); padding: 4px 8px; }
   .msg.sys { color: var(--text-dim); font-size: 12px; }
   .msg.sys .sys-text { font-style: italic; }
   .msg.directive b { color: var(--orange); }


### PR DESCRIPTION
Server-side markdown in the feed. Bold, code blocks, tables, lists all render. Uses python-markdown with fenced_code + tables + nl2br extensions. Closes #487.