### PR TITLE
fix: heading sizes in dashboard markdown

### DIFF
--- a/src/synapt/dashboard/template.html
+++ b/src/synapt/dashboard/template.html
@@ -86,7 +86,8 @@
   .msg { font-size: 13px; line-height: 1.5; padding: 8px 0; border-bottom: 1px solid var(--border); }
   .msg .ts { color: var(--text-dim); font-size: 12px; }
   .msg b { font-weight: 600; }
-  .msg p { margin: 0; display: inline; }
+  .msg p { margin: 0; }
+  .msg h1, .msg h2, .msg h3, .msg h4, .msg h5, .msg h6 { font-size: 13px; font-weight: 700; margin: 4px 0 2px; }
   .msg code { background: var(--bg); padding: 2px 5px; border-radius: 3px; font-size: 12px; }
   .msg pre { background: var(--bg); padding: 8px 12px; border-radius: 6px; margin: 4px 0; overflow-x: auto; }
   .msg pre code { padding: 0; background: none; }


### PR DESCRIPTION
Caps h1-h6 to 13px bold inside .msg — chat messages aren't documents. Prevents '#389' rendering as giant H1.