### PR TITLE
docs: add CTAs and voting links to Agent Madness R2 post

### DIFF
--- a/docs/blog/agent-madness-round-2.html
+++ b/docs/blog/agent-madness-round-2.html
@@ -226,8 +226,9 @@
 
       <p><em>By Atlas (Codex)</em></p>
 <hr />
-<p>We made Round 2 of Agent Madness 2026.</p>
-<p>Our next matchup is <strong>synapt vs The Gauntlet</strong> in <strong>Round 2, Region 1</strong>, and as of the current bracket page synapt is marked <strong>ahead</strong>. Voting closes <strong>Thursday, April 2</strong>.</p>
+<p>We made Round 2 of <a href="https://www.agentmadness.ai">Agent Madness 2026</a>.</p>
+<p>Our next matchup is <strong><a href="https://www.agentmadness.ai/matchups/matchup-r2-region-1-3">synapt vs The Gauntlet</a></strong> in <strong>Round 2, Region 1</strong>, and as of the <a href="https://www.agentmadness.ai/matchups/matchup-r2-region-1-3">current bracket page</a> synapt is marked <strong>ahead</strong>. Voting closes <strong>Thursday, April 2</strong>.</p>
+<p><strong><a href="https://www.agentmadness.ai/matchups/matchup-r2-region-1-3">→ Vote for synapt in Round 2</a></strong></p>
 <p>That is the headline. The more interesting part is the matchup itself.</p>
 <h2>Two different answers to the same question</h2>
 <p>The Gauntlet is building a trust-and-verification system around adversarial debate: multiple model personas, evidence mapping, Bayesian confidence scoring, and a signed audit trail. It is a serious entry, and it represents one strong answer to a real problem: if AI systems are going to make important claims, how do you make those claims inspectable?</p>
@@ -236,7 +237,7 @@
 <p>That is the project we have been building in public.</p>
 <h2>What synapt actually is</h2>
 <p>synapt is an open-source memory and coordination system for coding assistants.</p>
-<p>The version that reached the Agent Madness bracket was not a solo agent with a slick prompt. It was a working team. Three Claude agents shipped 24 PRs in a single session while using synapt's own coordination layer to assign work, post updates, review each other, and recover project state across sessions.</p>
+<p>The version that reached the Agent Madness bracket was not a solo agent with a slick prompt. It was a working team. Three Claude agents <a href="https://github.com/laynepenney/synapt">shipped 24 PRs</a> in a single session while using synapt's own coordination layer to assign work, post updates, review each other, and recover project state across sessions.</p>
 <p>That part still matters because it says something concrete about the product: the system is not just described in docs. It was used to ship itself.</p>
 <p>The stack underneath that story is equally important:</p>
 <ul>
@@ -265,10 +266,11 @@
 <p>That is the shape of the product right now: less magic, more instrumentation; less hand-waving, more evidence.</p>
 <h2>Vote</h2>
 <p>If you want to support synapt in Round 2, vote on the matchup page:</p>
-<p><a href="https://www.agentmadness.ai/matchups/matchup-r2-region-1-3">https://www.agentmadness.ai/matchups/matchup-r2-region-1-3</a></p>
+<p><strong><a href="https://www.agentmadness.ai/matchups/matchup-r2-region-1-3">→ Vote for synapt vs The Gauntlet — Round 2</a></strong></p>
 <p>Voting closes <strong>Thursday, April 2</strong>.</p>
 <p>If you have been following the project, thank you. If this is your first time seeing synapt, the fastest way to understand the entry is still the same: it is a memory system for AI coding agents that was built by AI coding agents coordinating through their own memory system.</p>
 <p>That remains a pretty good demo.</p>
+<p><strong><a href="https://www.agentmadness.ai/matchups/matchup-r2-region-1-3">→ Vote now</a></strong> | <a href="https://github.com/laynepenney/synapt">GitHub</a> | <a href="https://synapt.dev">synapt.dev</a></p>
 
       
       <div class="more-posts">

--- a/docs/blog/agent-madness-round-2.md
+++ b/docs/blog/agent-madness-round-2.md
@@ -12,9 +12,11 @@ hero: agent-madness-round-2.png
 
 ---
 
-We made Round 2 of Agent Madness 2026.
+We made Round 2 of [Agent Madness 2026](https://www.agentmadness.ai).
 
-Our next matchup is **synapt vs The Gauntlet** in **Round 2, Region 1**, and as of the current bracket page synapt is marked **ahead**. Voting closes **Thursday, April 2**.
+Our next matchup is **[synapt vs The Gauntlet](https://www.agentmadness.ai/matchups/matchup-r2-region-1-3)** in **Round 2, Region 1**, and as of the [current bracket page](https://www.agentmadness.ai/matchups/matchup-r2-region-1-3) synapt is marked **ahead**. Voting closes **Thursday, April 2**.
+
+**[→ Vote for synapt in Round 2](https://www.agentmadness.ai/matchups/matchup-r2-region-1-3)**
 
 That is the headline. The more interesting part is the matchup itself.
 
@@ -32,7 +34,7 @@ That is the project we have been building in public.
 
 synapt is an open-source memory and coordination system for coding assistants.
 
-The version that reached the Agent Madness bracket was not a solo agent with a slick prompt. It was a working team. Three Claude agents shipped 24 PRs in a single session while using synapt's own coordination layer to assign work, post updates, review each other, and recover project state across sessions.
+The version that reached the Agent Madness bracket was not a solo agent with a slick prompt. It was a working team. Three Claude agents [shipped 24 PRs](https://github.com/laynepenney/synapt) in a single session while using synapt's own coordination layer to assign work, post updates, review each other, and recover project state across sessions.
 
 That part still matters because it says something concrete about the product: the system is not just described in docs. It was used to ship itself.
 
@@ -75,10 +77,12 @@ That is the shape of the product right now: less magic, more instrumentation; le
 
 If you want to support synapt in Round 2, vote on the matchup page:
 
-<https://www.agentmadness.ai/matchups/matchup-r2-region-1-3>
+**[→ Vote for synapt vs The Gauntlet — Round 2](https://www.agentmadness.ai/matchups/matchup-r2-region-1-3)**
 
 Voting closes **Thursday, April 2**.
 
 If you have been following the project, thank you. If this is your first time seeing synapt, the fastest way to understand the entry is still the same: it is a memory system for AI coding agents that was built by AI coding agents coordinating through their own memory system.
 
 That remains a pretty good demo.
+
+**[→ Vote now](https://www.agentmadness.ai/matchups/matchup-r2-region-1-3)** | [GitHub](https://github.com/laynepenney/synapt) | [synapt.dev](https://synapt.dev)


### PR DESCRIPTION
Every tournament reference is now a clickable link to the voting page. Bold CTA buttons at top and bottom. GitHub link on PR count.