### PR TITLE
fix: clear stale display name claims on reuse

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -175,9 +175,9 @@ def _find_display_name_conflict(
 ) -> sqlite3.Row | None:
     """Return another online/active agent already using this display name.
 
-    Stale agents (idle or worse — >30 min since last heartbeat) do not
-    block name claims. This handles crashes, force-quits, and OOM kills
-    that leave orphaned name claims without a clean channel leave.
+    Stale agents (anything no longer "online" in the <5 minute heartbeat
+    window) do not block name claims. Their old claim is cleared eagerly
+    so display-name targeting stays unambiguous after the new join/rename.
     """
     normalized = _normalize_display_name(display_name)
     if not normalized:
@@ -194,9 +194,13 @@ def _find_display_name_conflict(
         if _normalize_display_name(existing) != normalized:
             continue
         status = _agent_status(row["last_seen"])
-        # Release name claims from stale agents (idle, away, offline)
-        # Only "online" (<5 min) agents truly hold a name claim
+        # Release name claims from stale agents before allowing reuse.
+        # Only "online" (<5 min) agents truly hold a live claim.
         if status != "online":
+            conn.execute(
+                "UPDATE presence SET display_name = '' WHERE agent_id = ?",
+                (row["agent_id"],),
+            )
             continue
         return row
     return None

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -1750,6 +1750,39 @@ class TestRename(unittest.TestCase):
 
         self.assertIn("Joined #dev as Apollo", result)
 
+    def test_stale_display_name_claim_is_cleared_before_reuse(self):
+        stale_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        channel_join("dev", agent_name="s_old", display_name="Sentinel")
+
+        conn = _open_db()
+        try:
+            conn.execute(
+                "UPDATE presence SET last_seen = ?, status = 'online' WHERE agent_id = 's_old'",
+                (stale_time,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = channel_join("dev", agent_name="s_new", display_name="Sentinel")
+        self.assertIn("Joined #dev as Sentinel", result)
+
+        conn = _open_db()
+        try:
+            old_row = conn.execute(
+                "SELECT display_name FROM presence WHERE agent_id = 's_old'"
+            ).fetchone()
+            new_row = conn.execute(
+                "SELECT display_name FROM presence WHERE agent_id = 's_new'"
+            ).fetchone()
+            self.assertEqual(old_row["display_name"], "")
+            self.assertEqual(new_row["display_name"], "Sentinel")
+            self.assertEqual(_resolve_target_id("Sentinel", conn), "s_new")
+        finally:
+            conn.close()
+
 
 class TestFromDisplay(unittest.TestCase):
     """Test from_display persistence in JSONL messages (#292)."""


### PR DESCRIPTION
Follow-up to merged #405.

#405 stopped stale sessions from blocking a reused display name, but it did not actually clear the stale row's `display_name`. That allowed duplicate presence rows with the same display name and made `_resolve_target_id()` / display-name targeting ambiguous.

This patch clears stale claims eagerly when they are bypassed and adds regression coverage proving that:
- the stale row loses its `display_name`
- the new join keeps the claim
- `_resolve_target_id("Sentinel", conn)` resolves to the new live session

Verification:
- `PYTHONPATH=src pytest tests/recall/test_channel.py -q` -> `153 passed`
