### PR TITLE
Carry forward unresolved journal next steps

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -1176,8 +1176,10 @@ def cmd_journal(args: argparse.Namespace) -> None:
         format_entry_full,
         format_for_session_start,
         latest_transcript_path,
+        merge_carried_forward_next_steps,
         read_entries,
         read_latest,
+        read_previous_meaningful,
     )
 
     if args.read:
@@ -1224,6 +1226,7 @@ def cmd_journal(args: argparse.Namespace) -> None:
     project = Path.cwd().resolve()
     transcript_path = latest_transcript_path(project)
     entry = auto_extract_entry(transcript_path=transcript_path, cwd=str(project))
+    previous_entry = read_previous_meaningful(entry.session_id)
 
     # Merge CLI-provided fields
     if args.focus:
@@ -1234,6 +1237,11 @@ def cmd_journal(args: argparse.Namespace) -> None:
         entry.decisions = [d.strip() for d in args.decisions.split(";")]
     if args.next:
         entry.next_steps = [n.strip() for n in args.next.split(";")]
+    entry.next_steps = merge_carried_forward_next_steps(
+        entry.next_steps,
+        entry.done,
+        previous_entry,
+    )
 
     # Clear auto flag if user provided rich content
     if entry.has_rich_content():

--- a/src/synapt/recall/journal.py
+++ b/src/synapt/recall/journal.py
@@ -143,6 +143,24 @@ def read_latest(path: Path | None = None, meaningful: bool = False) -> JournalEn
     return None
 
 
+def read_previous_meaningful(
+    current_session_id: str = "",
+    path: Path | None = None,
+) -> JournalEntry | None:
+    """Read the most recent meaningful entry from a prior session.
+
+    If *current_session_id* is provided, entries from the same session are
+    skipped so repeated writes do not carry forward their own next steps.
+    """
+    for entry in read_entries(path, n=50):
+        if not entry.has_rich_content():
+            continue
+        if current_session_id and entry.session_id == current_session_id:
+            continue
+        return entry
+    return None
+
+
 def read_entries(path: Path | None = None, n: int = 5) -> list[JournalEntry]:
     """Read the last N journal entries (most recent first).
 
@@ -316,6 +334,40 @@ def format_entry_full(entry: JournalEntry) -> str:
         for c in entry.git_log:
             lines.append(f"- {c}")
     return "\n".join(lines)
+
+
+def _step_key(step: str) -> str:
+    """Normalize a next-step string for exact matching."""
+    return " ".join(step.split()).casefold()
+
+
+def merge_carried_forward_next_steps(
+    current_next_steps: list[str],
+    current_done: list[str],
+    previous_entry: JournalEntry | None,
+) -> list[str]:
+    """Merge unresolved prior-session next steps into the current entry.
+
+    Carries forward prior next steps unless the current entry already includes
+    them or marks them done. New next steps stay first; carried items append.
+    """
+    merged = [step.strip() for step in current_next_steps if step and step.strip()]
+    seen = {_step_key(step) for step in merged}
+    done = {_step_key(item) for item in current_done if item and item.strip()}
+
+    if not previous_entry or not previous_entry.next_steps:
+        return merged
+
+    for step in previous_entry.next_steps:
+        clean = step.strip()
+        if not clean:
+            continue
+        key = _step_key(clean)
+        if key in seen or key in done:
+            continue
+        merged.append(clean)
+        seen.add(key)
+    return merged
 
 
 def extract_session_id(path: Path | str) -> str:

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1362,8 +1362,10 @@ def recall_journal(
             format_entry_full,
             format_for_session_start,
             latest_transcript_path,
+            merge_carried_forward_next_steps,
             read_entries,
             read_latest,
+            read_previous_meaningful,
         )
 
         if action == "read":
@@ -1382,6 +1384,7 @@ def recall_journal(
             project = Path.cwd().resolve()
             transcript_path = latest_transcript_path(project)
             entry = auto_extract_entry(transcript_path=transcript_path, cwd=str(project))
+            previous_entry = read_previous_meaningful(entry.session_id)
 
             if focus:
                 entry.focus = focus
@@ -1391,6 +1394,11 @@ def recall_journal(
                 entry.decisions = [d.strip() for d in decisions.split(";")]
             if next_steps:
                 entry.next_steps = [n.strip() for n in next_steps.split(";")]
+            entry.next_steps = merge_carried_forward_next_steps(
+                entry.next_steps,
+                entry.done,
+                previous_entry,
+            )
 
             # Clear auto flag when user provides rich content
             if entry.has_rich_content():

--- a/tests/recall/test_cli.py
+++ b/tests/recall/test_cli.py
@@ -8,7 +8,15 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from synapt.recall.core import project_slug, project_index_dir, project_archive_dir, project_worktree_dir, project_transcript_dir
-from synapt.recall.cli import discover_transcript_dirs, _ensure_gitignore, _install_global_hooks, cmd_rebuild, cmd_sync, main
+from synapt.recall.cli import (
+    discover_transcript_dirs,
+    _ensure_gitignore,
+    _install_global_hooks,
+    cmd_journal,
+    cmd_rebuild,
+    cmd_sync,
+    main,
+)
 
 
 def _write_codex_transcript(path: Path, cwd: Path) -> None:
@@ -749,6 +757,51 @@ def test_catchup_writes_journal_for_codex_session(tmp_path):
     entries = read_entries(journal_path, n=1)
     assert len(entries) == 1
     assert entries[0].session_id == "codex-session-001"
+
+
+def test_cmd_journal_write_carries_forward_unresolved_next_steps(tmp_path, capsys):
+    """Journal write merges prior unresolved next_steps into the new entry."""
+    from synapt.recall.journal import JournalEntry, append_entry, read_latest
+
+    project = tmp_path / "project"
+    project.mkdir()
+    journal_path = project_worktree_dir(project) / "journal.jsonl"
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    append_entry(
+        JournalEntry(
+            timestamp="2026-03-31T10:00:00+00:00",
+            session_id="prior-session",
+            focus="previous work",
+            next_steps=["ship docs", "follow up with team"],
+        ),
+        journal_path,
+    )
+
+    args = argparse.Namespace(
+        read=False,
+        list=False,
+        show=None,
+        write=True,
+        focus="current work",
+        done="ship docs",
+        decisions=None,
+        next="close loop",
+    )
+
+    with patch("synapt.recall.cli.Path.cwd", return_value=project), \
+         patch("synapt.recall.journal.latest_transcript_path", return_value=None), \
+         patch("synapt.recall.journal.auto_extract_entry", return_value=JournalEntry(
+             timestamp="2026-04-01T12:00:00+00:00",
+             session_id="current-session",
+         )):
+        cmd_journal(args)
+
+    latest = read_latest(journal_path)
+    assert latest is not None
+    assert latest.next_steps == ["close loop", "follow up with team"]
+
+    captured = capsys.readouterr()
+    assert "Journal entry written" in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recall/test_journal.py
+++ b/tests/recall/test_journal.py
@@ -14,8 +14,10 @@ from synapt.recall.journal import (
     compact_journal,
     format_entry_full,
     format_for_session_start,
+    merge_carried_forward_next_steps,
     read_entries,
     read_latest,
+    read_previous_meaningful,
 )
 
 
@@ -419,6 +421,58 @@ class TestDedupAndCompact(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].focus, "focus + done")
         self.assertEqual(result[0].done, ["task"])
+
+
+class TestNextStepCarryForward(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.path = Path(self.tmpdir) / "journal.jsonl"
+
+    def test_read_previous_meaningful_skips_current_session(self):
+        append_entry(JournalEntry(
+            timestamp="2026-03-01T10:00:00",
+            session_id="prior",
+            focus="prior session",
+            next_steps=["follow up"],
+        ), self.path)
+        append_entry(JournalEntry(
+            timestamp="2026-03-02T10:00:00",
+            session_id="current",
+            focus="current session",
+            next_steps=["new task"],
+        ), self.path)
+
+        previous = read_previous_meaningful("current", self.path)
+        self.assertIsNotNone(previous)
+        self.assertEqual(previous.session_id, "prior")
+
+    def test_merge_carries_forward_unresolved_prior_steps(self):
+        previous = JournalEntry(
+            timestamp="2026-03-01T10:00:00",
+            next_steps=["ship docs", "follow up with team"],
+        )
+
+        merged = merge_carried_forward_next_steps(
+            current_next_steps=["write tests"],
+            current_done=["ship docs"],
+            previous_entry=previous,
+        )
+
+        self.assertEqual(merged, ["write tests", "follow up with team"])
+
+    def test_merge_deduplicates_existing_next_steps(self):
+        previous = JournalEntry(
+            timestamp="2026-03-01T10:00:00",
+            next_steps=["Write tests", "follow up with team"],
+        )
+
+        merged = merge_carried_forward_next_steps(
+            current_next_steps=["write tests", "close loop"],
+            current_done=[],
+            previous_entry=previous,
+        )
+
+        self.assertEqual(merged, ["write tests", "close loop", "follow up with team"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- carry forward unresolved prior-session journal next steps on write
- skip carried items that are already done or already present
- apply the same behavior to both MCP and CLI journal write paths

## Testing
- PYTHONPATH=src pytest tests/recall/test_journal.py tests/recall/test_cli.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/journal.py src/synapt/recall/server.py src/synapt/recall/cli.py

Closes #411.