### PR TITLE
Add explicit recall_save knowledge tool

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1,6 +1,6 @@
 """synapt.recall MCP server — expose transcript search as tools for Claude Code.
 
-Provides fourteen tools via the Model Context Protocol:
+Provides fifteen tools via the Model Context Protocol:
   - recall_search: Search past session transcripts by keyword/topic
   - recall_quick: Fast, low-cost knowledge-only search for speculative checks
   - recall_context: Drill down into a search result for full raw content
@@ -11,6 +11,7 @@ Provides fourteen tools via the Model Context Protocol:
   - recall_setup: Initialize synapt recall for the current project
   - recall_stats: Get index statistics
   - recall_journal: Read or write session journal entries
+  - recall_save: Explicitly save durable knowledge nodes
   - recall_remind: Manage cross-session reminders
   - recall_enrich: Enrich chunks with LLM-generated summaries
   - recall_consolidate: Extract durable knowledge from journal entries
@@ -38,9 +39,11 @@ _STARTUP_VERSION = getattr(_synapt_pkg, "__version__", "unknown")
 from synapt.recall.core import (
     TranscriptIndex,
     format_size,
+    project_data_dir,
     project_index_dir,
 )
 from synapt.recall._llm_util import truncate_at_word as _tw
+from synapt.recall.embeddings import get_embedding_provider
 
 
 def _cap_tokens(requested: int) -> int:
@@ -1410,6 +1413,67 @@ def recall_journal(
         return f"Journal failed: {exc}"
 
 
+def recall_save(
+    content: str,
+    category: str = "workflow",
+    confidence: float = 0.8,
+    tags: list[str] | None = None,
+    source_sessions: list[str] | None = None,
+    source_turns: list[str] | None = None,
+) -> str:
+    """Create a knowledge node directly and embed it for vector search.
+
+    Args:
+        content: Durable fact, convention, or decision to save.
+        category: Knowledge category (workflow, tooling, decision, etc.).
+        confidence: Confidence score from 0.0 to 1.0.
+        tags: Optional search tags.
+        source_sessions: Optional originating session IDs.
+        source_turns: Optional originating turn refs ("session_id:turn_num").
+    """
+    clean_content = (content or "").strip()
+    if not clean_content:
+        return "Error: content is required."
+
+    try:
+        from synapt.recall.knowledge import KnowledgeNode, append_node
+        from synapt.recall.storage import RecallDB
+
+        project = Path.cwd().resolve()
+        db = RecallDB(project_index_dir(project) / "recall.db")
+        try:
+            node = KnowledgeNode.create(
+                content=clean_content,
+                category=category,
+                source_sessions=[s for s in (source_sessions or []) if s],
+                confidence=confidence,
+                tags=[t for t in (tags or []) if t],
+                source_turns=[t for t in (source_turns or []) if t],
+            )
+            append_node(node, project_data_dir(project) / "knowledge.jsonl")
+            db.upsert_knowledge_node(node.to_dict())
+
+            embedded = False
+            provider = get_embedding_provider()
+            if provider:
+                rowid = db.get_knowledge_rowid(node.id)
+                if rowid is not None:
+                    embedding = provider.embed_single(node.content[:500])
+                    db.save_knowledge_embeddings({rowid: embedding})
+                    embedded = True
+        finally:
+            db.close()
+
+        _invalidate_cache()
+        status = "embedded for vector search" if embedded else "saved without embeddings"
+        return (
+            f"Knowledge node saved: {node.id} ({node.category}, confidence={node.confidence:.2f}). "
+            f"{status}."
+        )
+    except Exception as exc:
+        return f"Knowledge save failed: {exc}"
+
+
 def recall_remind(
     action: str = "add",
     text: str | None = None,
@@ -2017,6 +2081,7 @@ def register_tools(mcp) -> None:
     mcp.tool()(recall_import)
     mcp.tool()(_with_directive_check(recall_stats))
     mcp.tool()(_with_directive_check(recall_journal))
+    mcp.tool()(_with_directive_check(recall_save))
     mcp.tool()(_with_directive_check(recall_remind))
     mcp.tool()(recall_enrich)
     mcp.tool()(recall_consolidate)

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -1412,6 +1412,15 @@ class RecallDB:
             return None
         return self._knowledge_dict_from_row(row)
 
+    def get_knowledge_rowid(self, node_id: str) -> int | None:
+        """Fetch the SQLite rowid for a knowledge node by ID."""
+        row = self._conn.execute(
+            "SELECT rowid FROM knowledge WHERE id = ?", (node_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return int(row[0])
+
     def resolve_contradiction(
         self, contradiction_id: int, status: str = "confirmed",
     ) -> bool:

--- a/tests/recall/test_knowledge.py
+++ b/tests/recall/test_knowledge.py
@@ -338,6 +338,20 @@ class TestStorageKnowledge(unittest.TestCase):
         self.assertEqual(db.knowledge_count(), 1)
         db.close()
 
+    def test_get_knowledge_rowid(self):
+        from synapt.recall.storage import RecallDB
+        db = RecallDB(self.db_path)
+        db.upsert_knowledge_node({
+            "id": "k1", "content": "Test", "category": "workflow",
+            "confidence": 0.5, "source_sessions": [], "created_at": "",
+            "updated_at": "", "status": "active", "superseded_by": "", "tags": [],
+        })
+        rowid = db.get_knowledge_rowid("k1")
+        assert isinstance(rowid, int)
+        assert rowid > 0
+        assert db.get_knowledge_rowid("missing") is None
+        db.close()
+
     def test_existing_db_gets_knowledge_table(self):
         """Opening an existing DB without knowledge table adds it without data loss."""
         import sqlite3

--- a/tests/recall/test_supersession.py
+++ b/tests/recall/test_supersession.py
@@ -1431,3 +1431,71 @@ class TestCoRetrievalConflictDetection:
         db.add_pending_contradiction("n1", "new fact")
         assert db.has_pending_contradiction_for("n1")
         assert not db.has_pending_contradiction_for("n2")
+
+
+class _FakeEmbeddingProvider:
+    def embed_single(self, text: str) -> list[float]:
+        return [0.01] * 384
+
+
+class TestRecallSave:
+    """Test the recall_save MCP tool."""
+
+    def test_recall_save_creates_and_embeds_node(self, tmp_path):
+        from synapt.recall.core import project_index_dir
+        from synapt.recall.server import recall_save
+        from synapt.recall.storage import RecallDB
+
+        with patch("synapt.recall.server.Path.cwd", return_value=tmp_path), \
+             patch("synapt.recall.server.get_embedding_provider", return_value=_FakeEmbeddingProvider()), \
+             patch("synapt.recall.server._invalidate_cache"):
+            result = recall_save(
+                content="Deploy previews expire after 7 days",
+                category="workflow",
+                confidence=0.9,
+                tags=["preview", "deploy"],
+                source_sessions=["sess-1"],
+                source_turns=["sess-1:12"],
+            )
+
+        assert "Knowledge node saved:" in result
+        assert "embedded for vector search" in result
+
+        db = RecallDB(project_index_dir(tmp_path) / "recall.db")
+        try:
+            nodes = db.load_knowledge_nodes(status="active")
+            assert len(nodes) == 1
+            assert nodes[0]["content"] == "Deploy previews expire after 7 days"
+            assert nodes[0]["tags"] == ["preview", "deploy"]
+            assert nodes[0]["source_sessions"] == ["sess-1"]
+            assert nodes[0]["source_turns"] == ["sess-1:12"]
+            emb_map = db.get_knowledge_embeddings_by_id()
+            assert nodes[0]["id"] in emb_map
+        finally:
+            db.close()
+
+    def test_recall_save_without_embeddings_still_saves_node(self, tmp_path):
+        from synapt.recall.core import project_index_dir
+        from synapt.recall.server import recall_save
+        from synapt.recall.storage import RecallDB
+
+        with patch("synapt.recall.server.Path.cwd", return_value=tmp_path), \
+             patch("synapt.recall.server.get_embedding_provider", return_value=None), \
+             patch("synapt.recall.server._invalidate_cache"):
+            result = recall_save(content="Use staging before production")
+
+        assert "saved without embeddings" in result
+
+        db = RecallDB(project_index_dir(tmp_path) / "recall.db")
+        try:
+            nodes = db.load_knowledge_nodes(status="active")
+            assert len(nodes) == 1
+            assert nodes[0]["content"] == "Use staging before production"
+            assert db.get_knowledge_embeddings_by_id() == {}
+        finally:
+            db.close()
+
+    def test_recall_save_requires_content(self):
+        from synapt.recall.server import recall_save
+
+        assert "required" in recall_save(content="   ").lower()


### PR DESCRIPTION
## Summary
- add `recall_save` for explicit knowledge ingestion into recall storage
- eagerly persist knowledge embeddings when a provider is available
- add focused storage and server tests for saved and embedded nodes

## Testing
- PYTHONPATH=src pytest tests/recall/test_knowledge.py tests/recall/test_supersession.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/server.py src/synapt/recall/storage.py

Closes #497.