### PR TITLE
Boost journal next steps for pending-work queries

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -34,7 +34,7 @@ from synapt.recall.scrub import scrub_text
 logger = logging.getLogger("synapt.recall")
 
 from synapt.recall.bm25 import BM25, _tokenize
-from synapt.recall.hybrid import extract_entities
+from synapt.recall.hybrid import augment_query_for_intent, extract_entities
 from synapt.recall.storage import RecallDB
 from synapt.recall.sharded_db import ShardedRecallDB
 
@@ -1662,7 +1662,9 @@ class TranscriptIndex:
         # Apply caller override for knowledge boost (after intent classification)
         _knowledge_boost = knowledge_boost if knowledge_boost is not None else kb_default
 
-        query_tokens = _tokenize(query)
+        retrieval_query = augment_query_for_intent(query, intent) if intent else query
+
+        query_tokens = _tokenize(retrieval_query)
         if not query_tokens:
             self._last_diagnostics = SearchDiagnostics(
                 total_chunks=len(self.chunks),
@@ -1675,7 +1677,7 @@ class TranscriptIndex:
 
         if max_sessions is not None:
             result = self._progressive_lookup(
-                query, query_tokens, max_chunks, max_tokens, max_sessions,
+                retrieval_query, query_tokens, max_chunks, max_tokens, max_sessions,
                 date_filter, after, before, half_life, threshold_ratio, depth,
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=_knowledge_boost,
@@ -1684,7 +1686,7 @@ class TranscriptIndex:
             )
         else:
             result = self._global_lookup(
-                query, query_tokens, max_chunks, max_tokens, date_filter,
+                retrieval_query, query_tokens, max_chunks, max_tokens, date_filter,
                 after, before,
                 half_life, threshold_ratio, depth, include_archived,
                 include_historical,
@@ -2983,9 +2985,11 @@ class TranscriptIndex:
             # Journal decision boost: journal chunks with "Decisions:" content
             # rank higher for decision-intent queries. This surfaces the raw
             # rationale instead of distilled knowledge nodes.
-            if intent == "decision":
-                if chunk.turn_index < 0 and "Decisions:" in chunk.assistant_text:
+            if chunk.turn_index < 0:
+                if intent == "decision" and "Decisions:" in chunk.assistant_text:
                     score *= 1.3
+                elif intent == "status" and "Next steps:" in chunk.assistant_text:
+                    score *= 1.5
             block = self._format_chunk_block(idx, intent=intent, query=query)
             emit_items.append((score, block, "chunk", chunk.id, chunk.timestamp))
 

--- a/src/synapt/recall/hybrid.py
+++ b/src/synapt/recall/hybrid.py
@@ -285,6 +285,24 @@ _DECISION_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
+_STATUS_PATTERNS = re.compile(
+    r"\b("
+    r"what(?:'s|\s+is)?\s+(?:pending|left|remaining|next)"
+    r"|what\s+should\s+(?:i|we)\s+do\s+next"
+    r"|what\s+do\s+(?:i|we)\s+need\s+to\s+do"
+    r"|what\s+still\s+needs?\s+to\s+be\s+done"
+    r"|what\s+remains?\s+to\s+do"
+    r"|next\s+steps?"
+    r"|follow[- ]?ups?"
+    r"|open\s+items?"
+    r"|outstanding\s+tasks?"
+    r"|todo\b|to-do\b"
+    r"|pending\s+work"
+    r"|what\s+is\s+the\s+status"
+    r")\b",
+    re.IGNORECASE,
+)
+
 _EXPLORATORY_PATTERNS = re.compile(
     r"\b(how\s+did\s+we|what\s+did\s+we|tried|approach|strategy|"
     r"alternative|consider|experiment|explore|"
@@ -367,6 +385,7 @@ def classify_query_intent(query: str) -> str:
         "factual"     — Looking up a specific fact (config value, version, etc.)
         "debug"       — Investigating an error or failure
         "decision"    — What was chosen and why (product/business/technical)
+        "status"      — What is still pending / what should happen next
         "exploratory" — Understanding what was tried, general exploration
         "procedural"  — How to do something (steps, workflow)
         "aggregation" — Gathering scattered facts across multiple sessions
@@ -387,6 +406,7 @@ def classify_query_intent(query: str) -> str:
         "factual": len(_FACTUAL_PATTERNS.findall(query)),
         "debug": len(_DEBUG_PATTERNS.findall(query)),
         "decision": len(_DECISION_PATTERNS.findall(query)),
+        "status": len(_STATUS_PATTERNS.findall(query)),
         "exploratory": len(_EXPLORATORY_PATTERNS.findall(query)),
         "procedural": len(_PROCEDURAL_PATTERNS.findall(query)),
         "aggregation": len(_AGGREGATION_PATTERNS.findall(query)),
@@ -394,8 +414,9 @@ def classify_query_intent(query: str) -> str:
 
     # Aggregation wins over factual since factual patterns match many aggregation
     # queries ("what does X have") but aggregation needs different treatment.
-    # Decision > aggregation > temporal > exploratory > procedural > debug > factual.
-    priority = ["decision", "aggregation", "temporal", "exploratory", "procedural", "debug", "factual"]
+    # Status/pending queries should beat decision/exploratory because they need
+    # explicit unresolved next steps rather than general history or rationale.
+    priority = ["status", "decision", "aggregation", "temporal", "exploratory", "procedural", "debug", "factual"]
     best_score = max(scores.values())
     if best_score == 0:
         return "general"
@@ -438,6 +459,13 @@ def intent_search_params(intent: str) -> dict:
             "emb_weight": 1.5,         # Semantic matching important
             "max_knowledge": 3,        # Cap knowledge — journal entries preferred
         }
+    elif intent == "status":
+        return {
+            "knowledge_boost": 0.6,    # Prefer raw journal next_steps over distilled facts
+            "half_life": 14.0,         # Pending work is strongly recency-sensitive
+            "emb_weight": 1.5,         # Keep semantic matching available in full search
+            "max_knowledge": 2,        # Leave room for journal evidence
+        }
     elif intent == "exploratory":
         return {
             "knowledge_boost": 1.5,    # Knowledge somewhat boosted
@@ -464,6 +492,19 @@ def intent_search_params(intent: str) -> dict:
             "half_life": 60.0,         # Default recency
             "emb_weight": 1.0,         # Balanced
         }
+
+
+def augment_query_for_intent(query: str, intent: str) -> str:
+    """Expand intent-specific queries with retrieval-friendly synonyms.
+
+    This is intentionally narrow. It exists to help lexical retrieval hit the
+    journal surfaces we already store, especially ``Next steps:`` entries,
+    when users ask paraphrased status questions like "what's pending?".
+    """
+    if intent != "status":
+        return query
+    extras = "next steps pending remaining left todo follow up"
+    return f"{query} {extras}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -44,6 +44,7 @@ from synapt.recall.core import (
 )
 from synapt.recall._llm_util import truncate_at_word as _tw
 from synapt.recall.embeddings import get_embedding_provider
+from synapt.recall.hybrid import classify_query_intent
 
 
 def _cap_tokens(requested: int) -> int:
@@ -364,9 +365,10 @@ def recall_quick(query: str) -> str:
     """Quick, low-cost memory check. Use this speculatively — when you're
     not sure if past context exists but want to check.
 
-    Returns only knowledge nodes and cluster summaries (no raw transcript
-    chunks), keeping output short and fast. If you find something relevant,
-    follow up with recall_search or recall_context for full detail.
+    Returns concise results by default, and for pending-work queries it
+    switches to summary mode so recent journal ``Next steps:`` entries can
+    surface. If you find something relevant, follow up with recall_search
+    or recall_context for full detail.
 
     Cost: ~500 tokens, <100ms. Cheaper than guessing wrong.
     Use BEFORE making assumptions about past work, decisions, or conventions.
@@ -375,8 +377,11 @@ def recall_quick(query: str) -> str:
         query: Natural language query or keywords to search for.
     """
     quick_budget = _cap_tokens(500)
-    # Skip embedding loading for quick checks — concise depth only uses
-    # BM25/FTS5 + knowledge nodes, not semantic embeddings (#472)
+    intent = classify_query_intent(query)
+    depth = "summary" if intent == "status" else "concise"
+    # Skip embedding loading for quick checks. Pending-work queries use
+    # summary mode (knowledge + journal), everything else uses concise
+    # mode (knowledge + cluster summaries).
     index = _get_index(use_embeddings=False)
     if index is None:
         index_dir = project_index_dir()
@@ -388,8 +393,8 @@ def recall_quick(query: str) -> str:
             max_chunks=5,
             max_tokens=quick_budget,
             half_life=None,
+            depth=depth,
             threshold_ratio=0.2,
-            depth="concise",
         )
         if result:
             return result

--- a/tests/recall/test_hybrid.py
+++ b/tests/recall/test_hybrid.py
@@ -267,6 +267,12 @@ class TestQueryIntentClassification:
         assert classify_query_intent("why did we chose Stripe") == "decision"
         assert classify_query_intent("tradeoffs we considered") == "decision"
 
+    def test_status(self):
+        assert classify_query_intent("what's pending") == "status"
+        assert classify_query_intent("what should we do next") == "status"
+        assert classify_query_intent("what still needs to be done") == "status"
+        assert classify_query_intent("next steps for this lane") == "status"
+
     def test_exploratory(self):
         assert classify_query_intent("how did we solve the auth problem") == "exploratory"
         assert classify_query_intent("what did we try for caching") == "exploratory"
@@ -319,7 +325,7 @@ class TestQueryIntentClassification:
 
     def test_intent_params_keys(self):
         """All intents return the expected parameter keys."""
-        for intent in ["temporal", "factual", "debug", "decision", "exploratory", "procedural", "aggregation", "general"]:
+        for intent in ["temporal", "factual", "debug", "decision", "status", "exploratory", "procedural", "aggregation", "general"]:
             params = intent_search_params(intent)
             assert "knowledge_boost" in params
             assert "half_life" in params
@@ -379,6 +385,14 @@ class TestQueryIntentClassification:
         assert decision_params["knowledge_boost"] < general_params["knowledge_boost"]
         # Embedding weight higher → semantic matching for paraphrased decisions
         assert decision_params["emb_weight"] > general_params["emb_weight"]
+
+    def test_status_params_prefer_recent_journal_next_steps(self):
+        """Pending-work queries should de-boost knowledge and cap it tightly."""
+        status_params = intent_search_params("status")
+        general_params = intent_search_params("general")
+        assert status_params["knowledge_boost"] < general_params["knowledge_boost"]
+        assert status_params["half_life"] < general_params["half_life"]
+        assert status_params["max_knowledge"] <= 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recall/test_hybrid_integration.py
+++ b/tests/recall/test_hybrid_integration.py
@@ -256,6 +256,7 @@ class TestIntentParameterFlow:
         queries = {
             "factual": "what is the database port",
             "debug": "error in the deployment pipeline",
+            "status": "what's pending",
             "exploratory": "how did we solve the auth problem",
             "procedural": "how to deploy the service",
             "general": "authentication token refresh",

--- a/tests/recall/test_journal_index.py
+++ b/tests/recall/test_journal_index.py
@@ -345,3 +345,29 @@ class TestJournalInIndex:
         sessions = index.list_sessions()
 
         assert sessions[0]["turn_count"] == 1  # Only the transcript turn
+
+    def test_status_query_surfaces_next_steps_in_summary_mode(self):
+        """Pending-work queries should route to journal next_steps cleanly."""
+        next_steps_chunk = TranscriptChunk(
+            id="sessnext:journal:11111111",
+            session_id="sess-next",
+            timestamp="2026-03-02T15:00:00+00:00",
+            turn_index=-1,
+            user_text="Session focus: Finish sprint work",
+            assistant_text="Next steps: Merge PR #416 - Check rollout status",
+        )
+        decision_chunk = TranscriptChunk(
+            id="sessdone:journal:22222222",
+            session_id="sess-done",
+            timestamp="2026-03-01T10:00:00+00:00",
+            turn_index=-1,
+            user_text="Session focus: Prior architecture discussion",
+            assistant_text="Decisions: Use JSONL for journaling",
+        )
+        index = TranscriptIndex([decision_chunk, next_steps_chunk], use_embeddings=False)
+
+        result = index.lookup("what's pending", max_chunks=2, depth="summary")
+
+        assert "Next steps:" in result
+        assert "Merge PR #416" in result
+        assert "Decisions: Use JSONL for journaling" not in result

--- a/tests/recall/test_live.py
+++ b/tests/recall/test_live.py
@@ -574,6 +574,51 @@ class TestRecallSearchLiveIntegration(unittest.TestCase):
         self.assertIn("Run `synapt recall setup`", result)
 
 
+class TestRecallQuickStatusRouting(unittest.TestCase):
+
+    def test_pending_query_uses_summary_depth(self):
+        """Pending-work queries should let recall_quick surface journal entries."""
+        from synapt.recall.server import recall_quick
+
+        calls = []
+
+        class MockIndex:
+            _last_diagnostics = None
+            _embedding_status = "disabled"
+
+            def lookup(self, query, **kwargs):
+                calls.append((query, kwargs))
+                return "Past session context:\n--- journal result ---"
+
+        with patch("synapt.recall.server._get_index", return_value=MockIndex()):
+            result = recall_quick("what's pending")
+
+        self.assertIn("journal result", result)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1]["depth"], "summary")
+
+    def test_non_status_query_keeps_concise_depth(self):
+        """Ordinary quick checks should preserve concise mode."""
+        from synapt.recall.server import recall_quick
+
+        calls = []
+
+        class MockIndex:
+            _last_diagnostics = None
+            _embedding_status = "disabled"
+
+            def lookup(self, query, **kwargs):
+                calls.append((query, kwargs))
+                return "Past session context:\n--- concise result ---"
+
+        with patch("synapt.recall.server._get_index", return_value=MockIndex()):
+            result = recall_quick("what is the database port")
+
+        self.assertIn("concise result", result)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1]["depth"], "concise")
+
+
 # ---------------------------------------------------------------------------
 # PreCompact journal write
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a status intent for pending/next-step queries and expand those queries for lexical retrieval
- route `recall_quick` pending-work queries to summary depth so journal next_steps can surface
- boost journal `Next steps:` entries for status lookups and cover the new flow with recall tests

## Testing
- PYTHONPATH=src pytest tests/recall/test_hybrid.py tests/recall/test_hybrid_integration.py tests/recall/test_journal_index.py tests/recall/test_live.py -q
- PYTHONPATH=src pytest tests/recall/test_core.py tests/recall/test_supersession.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/hybrid.py src/synapt/recall/core.py src/synapt/recall/server.py