### PR TITLE
fix: favor recent journals for status queries

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1488,6 +1488,38 @@ class TranscriptIndex:
                 pass
         return candidates
 
+    def _status_recency_multiplier(
+        self,
+        timestamp: str,
+        now: datetime | None = None,
+        half_life: float = 3.0,
+    ) -> float:
+        """Extra recency preference for status-style journal chunks.
+
+        Status queries are asking for *current* open work. The general recency
+        decay already helps, but old journal entries that happen to contain
+        ``Next steps:`` can still compete too well with the latest carry-forward
+        journal. This multiplier makes recent pending-work journals win more
+        decisively without changing other intents.
+        """
+        if not timestamp:
+            return 1.0
+        if now is None:
+            now = datetime.now(timezone.utc)
+        elif now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        try:
+            ts = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            age_days = max((now - ts).total_seconds() / 86400.0, 0.0)
+        except (ValueError, TypeError):
+            return 1.0
+
+        decay_rate = math.log(2) / half_life
+        freshness = math.exp(-decay_rate * age_days)
+        return 1.0 + (1.5 * freshness)
+
     def _apply_threshold_with_diagnostics(
         self,
         candidates: list[tuple[int, float]],
@@ -2990,6 +3022,7 @@ class TranscriptIndex:
                     score *= 1.3
                 elif intent == "status" and "Next steps:" in chunk.assistant_text:
                     score *= 1.5
+                    score *= self._status_recency_multiplier(chunk.timestamp)
             block = self._format_chunk_block(idx, intent=intent, query=query)
             emit_items.append((score, block, "chunk", chunk.id, chunk.timestamp))
 

--- a/tests/recall/test_journal_index.py
+++ b/tests/recall/test_journal_index.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+from datetime import datetime, timedelta, timezone
 
 from synapt.recall.core import parse_journal_entries, TranscriptChunk, TranscriptIndex
 
@@ -371,3 +372,30 @@ class TestJournalInIndex:
         assert "Next steps:" in result
         assert "Merge PR #416" in result
         assert "Decisions: Use JSONL for journaling" not in result
+
+    def test_status_query_prefers_latest_next_steps_journal(self):
+        """Status queries should prioritize the newest pending journal."""
+        now = datetime.now(timezone.utc)
+        older = TranscriptChunk(
+            id="sessold:journal:11111111",
+            session_id="sess-old",
+            timestamp=(now - timedelta(days=14)).isoformat(),
+            turn_index=-1,
+            user_text="Session focus: Earlier sprint work",
+            assistant_text="Next steps: Finish old migration plan",
+        )
+        latest = TranscriptChunk(
+            id="sessnew:journal:22222222",
+            session_id="sess-new",
+            timestamp=now.isoformat(),
+            turn_index=-1,
+            user_text="Session focus: Current sprint work",
+            assistant_text="Next steps: Merge the current PR",
+        )
+        index = TranscriptIndex([older, latest], use_embeddings=False)
+
+        result = index.lookup("what's pending", max_chunks=1, depth="summary")
+
+        assert "Merge the current PR" in result
+        assert "Finish old migration plan" in result
+        assert result.index("Merge the current PR") < result.index("Finish old migration plan")


### PR DESCRIPTION
## Summary
- add an extra recency-sensitive multiplier for status-mode journal chunks with `Next steps:`
- make pending-work queries prefer the latest carry-forward journal instead of an older matching journal
- add a regression test that asserts newest pending-work journals rank ahead of older ones

## Testing
- `PYTHONPATH=src pytest tests/recall/test_journal_index.py tests/recall/test_hybrid_integration.py tests/recall/test_hybrid.py -q`
- `PYTHONPATH=src python -m py_compile src/synapt/recall/core.py src/synapt/recall/hybrid.py src/synapt/recall/server.py`
