### PR TITLE
fix: discover linked worktree transcripts from gripspace root

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -4120,8 +4120,9 @@ def project_transcript_dirs(project_dir: Path | None = None) -> list[Path]:
     directories for both the main worktree and the current worktree (if
     different), so that ``recall build`` archives sessions from all worktrees.
 
-    In a gripspace, also discovers transcripts from all *direct child*
-    repos (directories with ``.git``).  Nested repos are not discovered.
+    In a gripspace, also discovers transcripts from:
+    - direct child repos (directories with ``.git``)
+    - linked worktrees under ``.worktrees/*`` (also directories with ``.git``)
     """
     actual_dir = (project_dir or Path.cwd()).resolve()
     dirs: list[Path] = []
@@ -4145,6 +4146,8 @@ def project_transcript_dirs(project_dir: Path | None = None) -> list[Path]:
                 dirs.append(main_d)
 
     # If in a gripspace, discover transcripts from all constituent repos
+    # plus linked worktrees under .worktrees/*. Active agent sessions often
+    # run from those clean worktrees rather than from the main child repos.
     grip_root = _find_gripspace_root(actual_dir)
     if grip_root is not None:
         try:
@@ -4159,6 +4162,19 @@ def project_transcript_dirs(project_dir: Path | None = None) -> list[Path]:
                     child_d = Path.home() / ".claude" / "projects" / child_slug
                     if child_d.is_dir() and any(child_d.glob("*.jsonl")):
                         dirs.append(child_d)
+            elif child.is_dir() and child.name == ".worktrees":
+                try:
+                    worktrees = sorted(child.iterdir())
+                except OSError:
+                    worktrees = []
+                for wt in worktrees:
+                    if wt.is_dir() and (wt / ".git").exists():
+                        wt_slug = project_slug(wt)
+                        if wt_slug not in seen_slugs:
+                            seen_slugs.add(wt_slug)
+                            wt_d = Path.home() / ".claude" / "projects" / wt_slug
+                            if wt_d.is_dir() and any(wt_d.glob("*.jsonl")):
+                                dirs.append(wt_d)
 
     return dirs
 

--- a/tests/recall/test_gripspace.py
+++ b/tests/recall/test_gripspace.py
@@ -337,6 +337,28 @@ class TestProjectTranscriptDirsGripspace:
         assert td_root in dirs
         assert td_repo in dirs
 
+    def test_discovers_linked_worktree_transcripts_from_gripspace_root(self, tmp_path):
+        """Gripspace-root discovery should include linked repos under .worktrees/*."""
+        grip = _make_gripspace(tmp_path)
+        repo = _make_git_repo(grip, "repo-a")
+
+        worktrees_root = grip / ".worktrees"
+        worktrees_root.mkdir()
+        linked = worktrees_root / "atlas-repo-a"
+        linked.mkdir()
+        (linked / ".git").write_text(f"gitdir: {repo / '.git' / 'worktrees' / 'atlas'}\n")
+
+        fake_home = tmp_path / "home"
+        slug_linked = str(linked).replace("\\", "/").replace("/", "-")
+        td_linked = fake_home / ".claude" / "projects" / slug_linked
+        td_linked.mkdir(parents=True)
+        (td_linked / "session-linked.jsonl").write_text("{}")
+
+        with patch("synapt.recall.core.Path.home", return_value=fake_home):
+            dirs = project_transcript_dirs(grip)
+
+        assert td_linked in dirs
+
     def test_standalone_repo_returns_empty_when_no_transcripts(self, tmp_path):
         """Standalone git repo outside any gripspace."""
         repo = tmp_path / "standalone"


### PR DESCRIPTION
## Summary
- include linked worktrees under `.worktrees/*` when discovering Claude transcript dirs from a gripspace root
- keep the existing direct-child repo discovery behavior
- add regression coverage for the gripspace-root + linked-worktree case

## Verification
- `PYTHONPATH=src pytest tests/recall/test_gripspace.py -q`
- `PYTHONPATH=src python -m py_compile src/synapt/recall/core.py`