### PR TITLE
fix: keep recall scoped to current gripspace

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3907,17 +3907,21 @@ def _find_gripspace_root(path: Path) -> Path | None:
     while current != current.parent:
         gitgrip = current / ".gitgrip"
         if gitgrip.is_dir():
-            # Linked griptree has griptree.json (singular) — always resolve
-            # to parent gripspace, even if griptrees.json also exists (which
-            # happens when `gr` clones the full directory structure).
-            if (gitgrip / "griptree.json").exists():
+            has_griptrees = (gitgrip / "griptrees.json").exists()
+            has_griptree = (gitgrip / "griptree.json").exists()
+            # Some current workspaces carry both the root marker
+            # (griptrees.json) and the linked-worktree marker
+            # (griptree.json). In that mixed layout, prefer the current
+            # workspace as the gripspace root so recall state stays scoped
+            # to the active workspace instead of resolving upward into the
+            # parent workspace's shared store.
+            if has_griptrees:
+                _gripspace_cache[cache_key] = (current, time.monotonic())
+                return current
+            if has_griptree:
                 root = _resolve_griptree_parent(current)
                 _gripspace_cache[cache_key] = (root, time.monotonic())
                 return root
-            # Gripspace root has only griptrees.json (plural), no singular
-            if (gitgrip / "griptrees.json").exists():
-                _gripspace_cache[cache_key] = (current, time.monotonic())
-                return current
         # Don't walk above $HOME
         if current == home:
             break

--- a/tests/recall/test_gripspace.py
+++ b/tests/recall/test_gripspace.py
@@ -96,6 +96,16 @@ class TestFindGripspaceRoot:
         result = _find_gripspace_root(griptree)
         assert result == grip
 
+    def test_mixed_markers_prefer_current_workspace_root(self, tmp_path):
+        """When both root and linked markers exist, prefer the current workspace."""
+        grip = _make_gripspace(tmp_path)
+        (grip / ".gitgrip" / "griptree.json").write_text(
+            '{"branch": "workspace", "path": "' + str(grip) + '"}'
+        )
+
+        result = _find_gripspace_root(grip)
+        assert result == grip
+
     def test_linked_griptree_data_dir_matches_parent(self, tmp_path):
         """project_data_dir from a linked griptree should match the parent gripspace."""
         grip = _make_gripspace(tmp_path)
@@ -231,6 +241,16 @@ class TestProjectDataDirGripspace:
         grip = _make_gripspace(tmp_path)
         repo = _make_git_repo(grip, "my-repo")
         result = project_data_dir(repo)
+        assert result == grip / ".synapt" / "recall"
+
+    def test_mixed_marker_root_stays_local(self, tmp_path):
+        """A workspace root with both markers should not resolve upward."""
+        grip = _make_gripspace(tmp_path)
+        (grip / ".gitgrip" / "griptree.json").write_text(
+            '{"branch": "workspace", "path": "' + str(grip) + '"}'
+        )
+
+        result = project_data_dir(grip)
         assert result == grip / ".synapt" / "recall"
 
     def test_standalone_git_repo_unaffected(self, tmp_path):


### PR DESCRIPTION
## Summary\n- treat a workspace with both .gitgrip/griptrees.json and .gitgrip/griptree.json as the current gripspace root\n- keep project_data_dir() and transcript discovery scoped to the active workspace instead of resolving upward into the parent workspace's recall store\n- add regression coverage for the mixed-marker layout\n\n## Verification\n- PYTHONPATH=src pytest tests/recall/test_gripspace.py -q\n- PYTHONPATH=src python -m py_compile src/synapt/recall/core.py