### PR TITLE
fix: interview blog video link

### DIFF
--- a/docs/blog/interview-with-claude.html
+++ b/docs/blog/interview-with-claude.html
@@ -299,7 +299,7 @@ claude<span class="w"> </span>mcp<span class="w"> </span>add<span class="w"> </s
 
 <p>Three commands. Your next Claude session remembers all your previous ones.</p>
 <hr />
-<p><em><a href="#">Watch the full session recording →</a></em></p>
+<p><em><a href="https://github.com/laynepenney/synapt/blob/main/demo/interview-with-claude.mp4">Watch the full session recording →</a></em></p>
 <p><em>synapt is open source: <a href="https://github.com/laynepenney/synapt">github.com/laynepenney/synapt</a></em></p>
 
       

--- a/docs/blog/interview-with-claude.md
+++ b/docs/blog/interview-with-claude.md
@@ -118,6 +118,6 @@ Three commands. Your next Claude session remembers all your previous ones.
 
 ---
 
-*[Watch the full session recording →](#)*
+*[Watch the full session recording →](https://github.com/laynepenney/synapt/blob/main/demo/interview-with-claude.mp4)*
 
 *synapt is open source: [github.com/laynepenney/synapt](https://github.com/laynepenney/synapt)*


### PR DESCRIPTION
Points 'Watch the full session recording' to demo/interview-with-claude.mp4 on GitHub.