### PR TITLE
perf: lazy-load transcript chunks on sqlite load

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -956,35 +956,11 @@ class TranscriptIndex:
         use_embeddings: bool = False,
         cache_dir: Path | None = None,
         db: RecallDB | ShardedRecallDB | None = None,
+        lazy_chunks: bool = False,
     ):
         # Sort by timestamp descending (most recent first)
         self.chunks = sorted(chunks, key=lambda c: c.timestamp, reverse=True)
-
-        # Content profile — adapts filters and retrieval to content type
-        from synapt.recall.content_profile import (
-            adaptive_params,
-            detect_content_profile,
-            forced_content_profile,
-        )
-        if os.environ.get("SYNAPT_DISABLE_CONTENT_PROFILE"):
-            from synapt.recall.content_profile import ContentProfile
-            self.content_profile = ContentProfile(
-                _type="code", file_refs=0, personal_refs=0, total_chunks=len(self.chunks)
-            )
-        else:
-            self.content_profile = (
-                forced_content_profile(total_chunks=len(self.chunks))
-                or detect_content_profile(self.chunks)
-            )
-        self._adaptive = adaptive_params(self.content_profile)
-        if self.content_profile.content_type != "code":
-            logger.info(
-                "Content profile: %s (file_refs=%d, personal=%d, chunks=%d)",
-                self.content_profile.content_type,
-                self.content_profile.file_refs,
-                self.content_profile.personal_refs,
-                self.content_profile.total_chunks,
-            )
+        self._lazy_chunks = lazy_chunks
 
         # Group by session for progressive search
         self.sessions: dict[str, list[TranscriptChunk]] = {}
@@ -1036,6 +1012,43 @@ class TranscriptIndex:
 
         if db is not None and db.chunk_count() > 0:
             self._refresh_rowid_map()
+
+        # Content profile — adapts filters and retrieval to content type
+        from synapt.recall.content_profile import (
+            adaptive_params,
+            detect_content_profile,
+            forced_content_profile,
+        )
+        if os.environ.get("SYNAPT_DISABLE_CONTENT_PROFILE"):
+            from synapt.recall.content_profile import ContentProfile
+            self.content_profile = ContentProfile(
+                _type="code", file_refs=0, personal_refs=0, total_chunks=len(self.chunks)
+            )
+        else:
+            forced = forced_content_profile(total_chunks=len(self.chunks))
+            if forced is not None:
+                self.content_profile = forced
+            elif self._lazy_chunks and self._db is not None and self._idx_to_rowid:
+                sample_size = min(len(self.chunks), 200)
+                sample_rowids = [self._idx_to_rowid[i] for i in range(sample_size)]
+                sample_chunks = [
+                    chunk for _, chunk in sorted(
+                        self._db.load_chunks_by_rowids(sample_rowids).items()
+                    )
+                ]
+                self.content_profile = detect_content_profile(sample_chunks)
+                self.content_profile.total_chunks = len(self.chunks)
+            else:
+                self.content_profile = detect_content_profile(self.chunks)
+        self._adaptive = adaptive_params(self.content_profile)
+        if self.content_profile.content_type != "code":
+            logger.info(
+                "Content profile: %s (file_refs=%d, personal=%d, chunks=%d)",
+                self.content_profile.content_type,
+                self.content_profile.file_refs,
+                self.content_profile.personal_refs,
+                self.content_profile.total_chunks,
+            )
 
         if self._rowid_to_idx:
             # FTS5 is ready — skip in-memory BM25
@@ -1094,6 +1107,37 @@ class TranscriptIndex:
         self._use_reranker = is_reranker_enabled()
         if self._use_reranker:
             logger.info("Cross-encoder reranking enabled")
+
+    def _get_chunk(self, idx: int) -> TranscriptChunk:
+        """Return a chunk, hydrating it from the DB on demand when needed."""
+        chunk = self.chunks[idx]
+        if not self._lazy_chunks or self._db is None:
+            return chunk
+        if chunk.user_text or chunk.assistant_text or chunk.tool_content or chunk.transcript_path:
+            return chunk
+        rowid = self._idx_to_rowid.get(idx)
+        if rowid is None:
+            return chunk
+        loaded = self._db.load_chunk_by_rowid(rowid)
+        if loaded is None:
+            return chunk
+        self.chunks[idx] = loaded
+        session_chunks = self.sessions.get(loaded.session_id, [])
+        for pos, existing in enumerate(session_chunks):
+            if existing.id == loaded.id:
+                session_chunks[pos] = loaded
+                break
+        if loaded.turn_index >= 0:
+            self._turn_lookup[(loaded.session_id, loaded.turn_index)] = loaded
+        return loaded
+
+    def _materialize_all_chunks(self) -> list[TranscriptChunk]:
+        """Force hydration of all chunks when a full-scan path needs raw text."""
+        if not self._lazy_chunks:
+            return self.chunks
+        for i in range(len(self.chunks)):
+            self._get_chunk(i)
+        return self.chunks
 
     def _rerank_candidates(
         self,
@@ -1231,7 +1275,7 @@ class TranscriptIndex:
         chunk_id_to_idx: dict[str, int] = {}
         for idx, _ in result[:5]:
             if idx < len(self.chunks):
-                cid = self.chunks[idx].id
+                cid = self._get_chunk(idx).id
                 source_ids.append(cid)
                 idx_to_chunk_id[idx] = cid
                 chunk_id_to_idx[cid] = idx
@@ -1309,7 +1353,7 @@ class TranscriptIndex:
                 pass
 
         # Build embeddings
-        texts = [c.text[:500] for c in self.chunks]  # cap text length
+        texts = [c.text[:500] for c in self._materialize_all_chunks()]  # cap text length
         try:
             all_embs = []
             for i in range(0, len(texts), 64):
@@ -1334,7 +1378,7 @@ class TranscriptIndex:
             return  # Embeddings are current — fetch on demand during lookup
 
         # Build embeddings and store as per-row BLOBs
-        texts = [c.text[:500] for c in self.chunks]
+        texts = [c.text[:500] for c in self._materialize_all_chunks()]
         try:
             all_embs = []
             for i in range(0, len(texts), 64):
@@ -1386,7 +1430,7 @@ class TranscriptIndex:
         correctly invalidate cached embeddings.
         """
         h = hashlib.sha256()
-        for c in self.chunks:
+        for c in self._materialize_all_chunks():
             h.update(
                 f"{c.id}|{c.user_text}|{c.assistant_text}|{c.tool_content}\n"
                 .encode()
@@ -1473,7 +1517,7 @@ class TranscriptIndex:
             now = now.replace(tzinfo=timezone.utc)
         decay_rate = math.log(2) / half_life
         for j, (idx, score) in enumerate(candidates):
-            chunk = self.chunks[idx]
+            chunk = self._get_chunk(idx)
             if not chunk.timestamp:
                 continue
             try:
@@ -1899,7 +1943,7 @@ class TranscriptIndex:
             if date_filter is not None and idx not in date_filter:
                 continue
             # In summary mode, only include journal chunks (turn_index == -1)
-            if depth == "summary" and self.chunks[idx].turn_index >= 0:
+            if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
                 continue
             candidates.append((idx, score))
 
@@ -1935,7 +1979,7 @@ class TranscriptIndex:
                         continue
                     if date_filter is not None and idx not in date_filter:
                         continue
-                    if depth == "summary" and self.chunks[idx].turn_index >= 0:
+                    if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
                         continue
                     emb_ranked.append((idx, sim))
                 emb_ranked = self._decay_candidates(emb_ranked, half_life, now=now)
@@ -1979,7 +2023,7 @@ class TranscriptIndex:
             for idx, score in top:
                 if idx >= len(self.chunks):
                     continue
-                chunk = self.chunks[idx]
+                chunk = self._get_chunk(idx)
                 sid = chunk.session_id
                 ti = chunk.turn_index
                 # Add surrounding turns from same session
@@ -2160,7 +2204,7 @@ class TranscriptIndex:
                 if depth == "summary":
                     emb_ranked = [
                         (i, s) for i, s in emb_ranked
-                        if self.chunks[i].turn_index < 0
+                        if self._get_chunk(i).turn_index < 0
                     ]
 
                 merged = weighted_rrf_merge(
@@ -2272,7 +2316,7 @@ class TranscriptIndex:
                 if date_filter is not None and idx not in date_filter:
                     continue
                 # In summary mode, skip raw transcript chunks (keep journal only)
-                if depth == "summary" and self.chunks[idx].turn_index >= 0:
+                if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
                     continue
                 session_hits.append((idx, score))
 
@@ -2312,7 +2356,7 @@ class TranscriptIndex:
                         continue
                     if date_filter is not None and idx not in date_filter:
                         continue
-                    if depth == "summary" and self.chunks[idx].turn_index >= 0:
+                    if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
                         continue
                     emb_ranked.append((idx, sim))
                 emb_ranked = self._decay_candidates(emb_ranked, half_life, now=now)
@@ -2923,7 +2967,7 @@ class TranscriptIndex:
                     i = indices[0]
                     if i in ranked_indices:
                         continue
-                    chunk = self.chunks[i]
+                    chunk = self._get_chunk(i)
                     full_text = (chunk.user_text or "") + " " + (chunk.assistant_text or "")
                     snippet = full_text[begin:end].strip()
                     if not snippet:
@@ -2950,7 +2994,7 @@ class TranscriptIndex:
                     for i in _chunks_by_session.get(sid, []):
                         if i in ranked_indices:
                             continue
-                        chunk = self.chunks[i]
+                        chunk = self._get_chunk(i)
                         if chunk.turn_index < 0:
                             continue
                         chunk_toks = set(_tokenize(chunk.text))
@@ -2963,7 +3007,7 @@ class TranscriptIndex:
                     source_score = base_score * 0.6
                     cblock = self._format_chunk_block(i, intent=intent, query=query)
                     emit_items.append(
-                        (source_score, cblock, "chunk", self.chunks[i].id, self.chunks[i].timestamp)
+                        (source_score, cblock, "chunk", self._get_chunk(i).id, self._get_chunk(i).timestamp)
                     )
                     ranked_indices.add(i)
 
@@ -2977,7 +3021,7 @@ class TranscriptIndex:
         _subchunk_ids: set[str] = set()
 
         for idx, score in ungrouped:
-            chunk = self.chunks[idx]
+            chunk = self._get_chunk(idx)
             if chunk.user_text.startswith("(context:"):
                 _subchunk_ids.add(chunk.id)
             # Journal decision boost: journal chunks with "Decisions:" content
@@ -3150,7 +3194,7 @@ class TranscriptIndex:
             if item["item_type"] == "chunk":
                 idx = self._id_to_idx.get(item["item_id"])
                 if idx is not None:
-                    content = self.chunks[idx].assistant_text
+                    content = self._get_chunk(idx).assistant_text
             elif item["item_type"] == "knowledge":
                 content = knowledge_content.get(item["item_id"], "")
             wm.record(item["item_type"], item["item_id"], content)
@@ -3228,7 +3272,7 @@ class TranscriptIndex:
         cluster_scores: dict[str, float] = {}
 
         for idx, score in ranked:
-            chunk = self.chunks[idx]
+            chunk = self._get_chunk(idx)
             clusters = self._db.clusters_for_chunk(chunk.id)
             if clusters:
                 cid = clusters[0]
@@ -3325,7 +3369,7 @@ class TranscriptIndex:
         for cid in chunk_ids:
             idx = self._id_to_idx.get(cid)
             if idx is not None:
-                member_chunks.append(self.chunks[idx])
+                member_chunks.append(self._get_chunk(idx))
         if not member_chunks:
             return ""
         from synapt.recall.clustering import generate_concat_summary
@@ -3387,7 +3431,7 @@ class TranscriptIndex:
         sentence span and emits a focused snippet instead of the full turn.
         Falls back to the full turn if no good span is found.
         """
-        chunk = self.chunks[idx]
+        chunk = self._get_chunk(idx)
         ts_display = _format_timestamp_display(chunk.timestamp, intent=intent)
         turn_label = "journal" if chunk.turn_index == -1 else f"turn {chunk.turn_index}"
         # Freshness label for chunks — same style as knowledge nodes
@@ -3485,7 +3529,7 @@ class TranscriptIndex:
         """
         # Find chunk by ID (O(1) via index map)
         idx = self._id_to_idx.get(chunk_id)
-        chunk = self.chunks[idx] if idx is not None else None
+        chunk = self._get_chunk(idx) if idx is not None else None
         if chunk is None and self._db:
             # Try DB lookup
             row = self._db._conn.execute(
@@ -3603,7 +3647,7 @@ class TranscriptIndex:
 
         if self._db is not None:
             # SQLite path
-            self._db.save_chunks(self.chunks)
+            self._db.save_chunks(self._materialize_all_chunks())
             self._db.save_manifest(manifest)
             self._refresh_rowid_map()
             return
@@ -3611,7 +3655,7 @@ class TranscriptIndex:
         # Legacy file-based path
         chunks_path = directory / "chunks.jsonl"
         with open(chunks_path, "w", encoding="utf-8") as f:
-            for chunk in self.chunks:
+            for chunk in self._materialize_all_chunks():
                 f.write(json.dumps(chunk.to_dict()) + "\n")
 
         h = hashlib.sha256()
@@ -3639,8 +3683,14 @@ class TranscriptIndex:
             db = None
             try:
                 db = ShardedRecallDB.open(directory)
-                chunks = db.load_chunks()
-                return cls(chunks, use_embeddings=use_embeddings, cache_dir=directory, db=db)
+                chunks = db.load_chunk_headers()
+                return cls(
+                    chunks,
+                    use_embeddings=use_embeddings,
+                    cache_dir=directory,
+                    db=db,
+                    lazy_chunks=True,
+                )
             except (sqlite3.DatabaseError, OSError) as exc:
                 logger.warning("Corrupt recall DB, rebuilding: %s", exc)
                 if db is not None:
@@ -3724,7 +3774,8 @@ class TranscriptIndex:
         pattern_lower = pattern.lower()
 
         hits: list[tuple[int, float]] = []
-        for i, chunk in enumerate(self.chunks):
+        for i in range(len(self.chunks)):
+            chunk = self._get_chunk(i)
             if date_filter is not None and i not in date_filter:
                 continue
             if not chunk.files_touched:
@@ -3739,7 +3790,7 @@ class TranscriptIndex:
             return ""
 
         # Sort newest-first by timestamp
-        hits.sort(key=lambda x: self.chunks[x[0]].timestamp, reverse=True)
+        hits.sort(key=lambda x: self._get_chunk(x[0]).timestamp, reverse=True)
         return self._format_results(hits[:max_chunks], max_tokens, query=pattern)
 
     # -------------------------------------------------------------------
@@ -3777,15 +3828,17 @@ class TranscriptIndex:
             )
             first_msg = ""
             for c in sorted_chunks:
-                if c.user_text:
-                    first_msg = c.user_text[:120]
-                    if len(c.user_text) > 120:
+                full = self._get_chunk(self._id_to_idx[c.id])
+                if full.user_text:
+                    first_msg = full.user_text[:120]
+                    if len(full.user_text) > 120:
                         first_msg += "..."
                     break
 
             all_files = set()
             for c in chunks:
-                all_files.update(c.files_touched)
+                full = self._get_chunk(self._id_to_idx[c.id])
+                all_files.update(full.files_touched)
 
             results.append({
                 "session_id": session_id,
@@ -3819,10 +3872,10 @@ class TranscriptIndex:
             },
             "avg_chunks_per_session": len(self.chunks) / max(len(self.sessions), 1),
             "total_tools_used": len(set(
-                t for c in self.chunks for t in c.tools_used
+                t for c in self._materialize_all_chunks() for t in c.tools_used
             )),
             "total_files_touched": len(set(
-                f for c in self.chunks for f in c.files_touched
+                f for c in self._materialize_all_chunks() for f in c.files_touched
             )),
             "embeddings_active": (
                 self._embeddings is not None

--- a/src/synapt/recall/sharded_db.py
+++ b/src/synapt/recall/sharded_db.py
@@ -118,6 +118,39 @@ class ShardedRecallDB:
             return all_chunks
         return self._index.load_chunks()
 
+    def load_chunk_headers(self) -> list["TranscriptChunk"]:  # noqa: F821
+        """Load lightweight chunk metadata."""
+        if self._data_dbs:
+            all_chunks = []
+            for db in self._data_dbs:
+                all_chunks.extend(db.load_chunk_headers())
+            return all_chunks
+        return self._index.load_chunk_headers()
+
+    def load_chunk_by_rowid(self, rowid: int):
+        """Load one chunk by rowid."""
+        if self._data_dbs:
+            for db in self._data_dbs:
+                chunk = db.load_chunk_by_rowid(rowid)
+                if chunk is not None:
+                    return chunk
+            return None
+        return self._index.load_chunk_by_rowid(rowid)
+
+    def load_chunks_by_rowids(self, rowids: list[int]):
+        """Load multiple chunks by rowid."""
+        if self._data_dbs:
+            loaded = {}
+            remaining = set(rowids)
+            for db in self._data_dbs:
+                if not remaining:
+                    break
+                partial = db.load_chunks_by_rowids(list(remaining))
+                loaded.update(partial)
+                remaining.difference_update(partial)
+            return loaded
+        return self._index.load_chunks_by_rowids(rowids)
+
     def save_chunks(self, chunks: list["TranscriptChunk"]) -> None:  # noqa: F821
         """Save chunks to the appropriate database.
 

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -873,6 +873,73 @@ class RecallDB:
             ))
         return chunks
 
+    def load_chunk_headers(self) -> list[TranscriptChunk]:
+        """Load lightweight chunk metadata, ordered by rowid."""
+        from synapt.recall.core import TranscriptChunk
+
+        rows = self._conn.execute(
+            "SELECT id, session_id, timestamp, turn_index "
+            "FROM chunks ORDER BY rowid"
+        ).fetchall()
+
+        return [
+            TranscriptChunk(
+                id=r["id"],
+                session_id=r["session_id"],
+                timestamp=r["timestamp"],
+                turn_index=r["turn_index"],
+                user_text="",
+                assistant_text="",
+                tools_used=[],
+                files_touched=[],
+                tool_content="",
+                transcript_path="",
+                byte_offset=-1,
+                byte_length=0,
+            )
+            for r in rows
+        ]
+
+    def load_chunk_by_rowid(self, rowid: int) -> TranscriptChunk | None:
+        """Load one chunk by rowid."""
+        from synapt.recall.core import TranscriptChunk
+
+        r = self._conn.execute(
+            "SELECT id, session_id, timestamp, turn_index, "
+            "user_text, assistant_text, tools_used, files_touched, "
+            "tool_content, date_text, transcript_path, byte_offset, byte_length "
+            "FROM chunks WHERE rowid = ?",
+            (rowid,),
+        ).fetchone()
+        if r is None:
+            return None
+
+        return TranscriptChunk(
+            id=r["id"],
+            session_id=r["session_id"],
+            timestamp=r["timestamp"],
+            turn_index=r["turn_index"],
+            user_text=r["user_text"],
+            assistant_text=r["assistant_text"],
+            tools_used=json.loads(r["tools_used"]) if r["tools_used"] else [],
+            files_touched=json.loads(r["files_touched"]) if r["files_touched"] else [],
+            tool_content=r["tool_content"] or "",
+            date_text=r["date_text"] or "",
+            transcript_path=r["transcript_path"] or "",
+            byte_offset=r["byte_offset"] if r["byte_offset"] is not None else -1,
+            byte_length=r["byte_length"] if r["byte_length"] is not None else 0,
+        )
+
+    def load_chunks_by_rowids(self, rowids: list[int]) -> dict[int, TranscriptChunk]:
+        """Load multiple chunks by rowid."""
+        if not rowids:
+            return {}
+        return {
+            rowid: chunk
+            for rowid in rowids
+            if (chunk := self.load_chunk_by_rowid(rowid)) is not None
+        }
+
     def chunk_count(self) -> int:
         """Number of chunks in the database."""
         row = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()

--- a/tests/recall/test_core.py
+++ b/tests/recall/test_core.py
@@ -688,6 +688,27 @@ def test_save_load_sqlite_roundtrip(tmp_path):
     db.close()
 
 
+def test_load_sqlite_uses_lazy_chunk_headers(tmp_path):
+    """SQLite loads should defer full chunk hydration until needed."""
+    from synapt.recall.storage import RecallDB
+
+    chunks = make_test_chunks()
+
+    save_dir = tmp_path / "test-index"
+    save_dir.mkdir(parents=True)
+    db = RecallDB(save_dir / "recall.db")
+    index = TranscriptIndex(chunks, db=db)
+    index.save(save_dir)
+
+    loaded = TranscriptIndex.load(save_dir)
+    assert loaded._lazy_chunks is True
+    assert any(not c.user_text and not c.assistant_text for c in loaded.chunks)
+
+    result = loaded.lookup("quality curve")
+    assert "quality curve" in result.lower() or "hermite" in result.lower()
+    db.close()
+
+
 def test_lookup_via_fts5():
     """TranscriptIndex with a RecallDB uses FTS5, not BM25 fallback."""
     from synapt.recall.storage import RecallDB

--- a/tests/recall/test_storage.py
+++ b/tests/recall/test_storage.py
@@ -167,6 +167,23 @@ class TestChunksCRUD:
         assert got.files_touched == orig.files_touched
         assert got.date_text == orig.date_text
 
+    def test_load_chunk_by_rowid_and_headers(self, db, sample_chunks):
+        db.save_chunks(sample_chunks)
+
+        headers = db.load_chunk_headers()
+        assert len(headers) == len(sample_chunks)
+        assert headers[0].user_text == ""
+        assert headers[0].assistant_text == ""
+
+        loaded = db.load_chunk_by_rowid(1)
+        assert loaded is not None
+        assert loaded.id == sample_chunks[0].id
+        assert loaded.user_text == sample_chunks[0].user_text
+
+        batch = db.load_chunks_by_rowids([1, 2])
+        assert set(batch) == {1, 2}
+        assert batch[2].id == sample_chunks[1].id
+
     def test_save_replaces_existing(self, db, sample_chunks):
         db.save_chunks(sample_chunks)
         assert db.chunk_count() == 3


### PR DESCRIPTION
## Summary
- add rowid-based chunk loaders plus lightweight header loading in the recall storage layer
- load SQLite-backed indexes with lightweight chunk headers, then hydrate full chunks on demand during search/formatting
- add regression coverage for rowid loaders and lazy SQLite index loads

## Verification
- PYTHONPATH=src pytest tests/recall/test_storage.py tests/recall/test_core.py -q
- PYTHONPATH=src pytest tests/recall/test_sharded_db.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/storage.py src/synapt/recall/sharded_db.py src/synapt/recall/core.py