### PR TITLE
fix: rebuild shard FTS after split

### DIFF
--- a/src/synapt/recall/sharding.py
+++ b/src/synapt/recall/sharding.py
@@ -292,6 +292,13 @@ def split_monolithic_db(
             finally:
                 shard.close()
 
+            # Finalize the shard through RecallDB so it has the same schema
+            # guarantees as any normally-opened DB: FTS tables, triggers, and
+            # rebuild for preexisting chunk rows.
+            from synapt.recall.storage import RecallDB
+            shard_db = RecallDB(shard_path)
+            shard_db.close()
+
             # Record shard metadata
             min_ts = batch[0]["timestamp"] if batch else ""
             max_ts = batch[-1]["timestamp"] if batch else ""

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -426,6 +426,15 @@ class RecallDB:
         if row is None:
             self._conn.executescript(_FTS_TABLE_SQL)
             self._conn.executescript(_FTS_TRIGGERS_SQL)
+            chunk_count = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+            if chunk_count > 0:
+                # A DB may already contain chunk rows (e.g. split-created shards)
+                # before chunks_fts exists. Rebuild immediately so first search
+                # sees the existing content instead of an empty FTS index.
+                self._conn.execute(
+                    "INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')"
+                )
+                self._conn.commit()
         elif self._needs_fts_migration():
             # Tokenizer changed (e.g., porter added) — recreate FTS table
             # and rebuild from the content table so search keeps working.

--- a/tests/recall/test_sharding.py
+++ b/tests/recall/test_sharding.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from synapt.recall.sharded_db import ShardedRecallDB
 from synapt.recall.sharding import (
     shard_name_for_index,
     list_shards,
@@ -119,12 +120,15 @@ class TestSplitMonolithicDb(unittest.TestCase):
             "'2025-01-01', '2025-01-01', '', '', '', NULL, NULL, 1, '')"
         )
         for i in range(num_chunks):
+            user_text = f"user chunk {i}"
+            assistant_text = f"assistant unique_term_{i}"
             db._conn.execute(
                 "INSERT INTO chunks (id, session_id, timestamp, turn_index, user_text, "
                 "assistant_text, tools_used, files_touched, tool_content, transcript_path, "
                 "byte_offset, byte_length) "
                 f"VALUES ('c{i}', 's1', '2025-01-{(i % 28) + 1:02d}T10:00:00Z', {i}, "
-                "'user', 'assistant', '[]', '[]', '', '', 0, 0)"
+                f"?, ?, '[]', '[]', '', '', 0, 0)",
+                (user_text, assistant_text),
             )
         db._conn.commit()
         db.close()
@@ -176,6 +180,19 @@ class TestSplitMonolithicDb(unittest.TestCase):
         self.assertEqual(rows[0]["chunk_count"], 10)
         self.assertEqual(rows[2]["shard_name"], "data_003.db")
         self.assertEqual(rows[2]["is_active"], 1)  # Last shard is active
+
+    def test_split_produces_queryable_shards(self):
+        tmpdir = tempfile.mkdtemp()
+        self._create_monolithic(tmpdir, num_chunks=25)
+        d = Path(tmpdir)
+        split_monolithic_db(d, threshold=10)
+
+        db = ShardedRecallDB.open(d)
+        try:
+            results = db.fts_search("unique_term_17")
+            self.assertEqual(len(results), 1)
+        finally:
+            db.close()
 
     def test_dry_run_doesnt_write(self):
         tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
## Summary
- rebuild FTS when a DB gains a new chunks_fts table after chunks already exist
- finalize each split shard through RecallDB so FTS tables, triggers, and rebuild happen immediately
- add a regression test proving split shards are queryable via FTS right after split

## Verification
- PYTHONPATH=src pytest tests/recall/test_sharding.py tests/recall/test_storage.py tests/recall/test_sharded_db.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/storage.py src/synapt/recall/sharding.py src/synapt/recall/sharded_db.py