### PR TITLE
Fix C++ FTS query handling

### DIFF
--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -211,7 +211,7 @@ CREATE VIRTUAL TABLE chunks_fts USING fts5(
     user_text, assistant_text, tools_used, files_touched, tool_content, date_text,
     content=chunks,
     content_rowid=rowid,
-    tokenize="porter unicode61 tokenchars '._'"
+    tokenize="porter unicode61 tokenchars '._+'"
 );
 """
 
@@ -243,7 +243,7 @@ CREATE VIRTUAL TABLE knowledge_fts USING fts5(
     content, category, tags,
     content=knowledge,
     content_rowid=rowid,
-    tokenize="porter unicode61 tokenchars '._'"
+    tokenize="porter unicode61 tokenchars '._+'"
 );
 """
 
@@ -278,7 +278,7 @@ CREATE VIRTUAL TABLE clusters_fts USING fts5(
     topic, search_text,
     content='clusters',
     content_rowid='id',
-    tokenize="porter unicode61 tokenchars '._'"
+    tokenize="porter unicode61 tokenchars '._+'"
 );
 """
 
@@ -306,8 +306,8 @@ _FTS5_KEYWORDS = frozenset({"and", "or", "not", "near"})
 
 
 def _escape_fts_token(tok: str) -> str:
-    """Quote a single FTS5 token if it contains dots or is a keyword."""
-    if "." in tok or tok in _FTS5_KEYWORDS:
+    """Quote a single FTS5 token if it contains special chars or is a keyword."""
+    if any(ch in tok for ch in "._+") or tok in _FTS5_KEYWORDS:
         return f'"{tok}"'
     return tok
 
@@ -337,7 +337,7 @@ def _escape_fts_tokens(query: str) -> list[str]:
     Single-character tokens and stop words are dropped to reduce noise.
     """
     tokens = [
-        t for t in re.sub(r"[^a-zA-Z0-9_.]", " ", query.lower()).split()
+        t for t in re.sub(r"[^a-zA-Z0-9_.+]", " ", query.lower()).split()
         if len(t) > 1 and t not in _FTS_STOP_WORDS
     ]
     return [_escape_fts_token(tok) for tok in tokens]
@@ -456,6 +456,16 @@ class RecallDB:
         if krow is None:
             self._conn.executescript(_KNOWLEDGE_FTS_TABLE_SQL)
             self._conn.executescript(_KNOWLEDGE_FTS_TRIGGERS_SQL)
+        elif self._needs_knowledge_fts_migration():
+            self._conn.execute("DROP TABLE IF EXISTS knowledge_fts")
+            for name in ("knowledge_ai", "knowledge_ad", "knowledge_au"):
+                self._conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+            self._conn.executescript(_KNOWLEDGE_FTS_TABLE_SQL)
+            self._conn.executescript(_KNOWLEDGE_FTS_TRIGGERS_SQL)
+            self._conn.execute(
+                "INSERT INTO knowledge_fts(knowledge_fts) VALUES('rebuild')"
+            )
+            self._conn.commit()
         else:
             # Verify triggers exist
             existing_kt = {r[0] for r in self._conn.execute(
@@ -735,6 +745,17 @@ class RecallDB:
             return False
         current = " ".join((row[0] or "").lower().split())
         expected = " ".join(_FTS_TABLE_SQL.strip().lower().split())
+        return current != expected
+
+    def _needs_knowledge_fts_migration(self) -> bool:
+        """Check if the knowledge FTS definition differs from the current schema."""
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='knowledge_fts'"
+        ).fetchone()
+        if row is None:
+            return False
+        current = " ".join((row[0] or "").lower().split())
+        expected = " ".join(_KNOWLEDGE_FTS_TABLE_SQL.strip().lower().split())
         return current != expected
 
     def close(self) -> None:

--- a/tests/recall/test_storage.py
+++ b/tests/recall/test_storage.py
@@ -289,6 +289,23 @@ class TestFTSSearch:
         results = db.fts_search("api_index.py")
         assert len(results) > 0
 
+    def test_search_terms_with_plus(self, db):
+        """FTS5 can search literal C++-style terms without collapsing to empty."""
+        chunks = [
+            TranscriptChunk(
+                id="cpp11111:t0",
+                session_id="session-cpp",
+                timestamp="2026-03-02T10:00:00Z",
+                turn_index=0,
+                user_text="Sentinel joked about being the C++O and writing C#.",
+                assistant_text="C++O means Chief Everything Officer.",
+                tools_used=[],
+                files_touched=[],
+            ),
+        ]
+        db.save_chunks(chunks)
+        assert len(db.fts_search("C++O")) > 0
+
     def test_limit_respected(self, db, sample_chunks):
         db.save_chunks(sample_chunks)
         results = db.fts_search("the", limit=1)
@@ -449,6 +466,10 @@ class TestFTSEscaping:
         assert "hello" in result
         assert "world" in result
 
+    def test_plus_tokens_preserved_and_quoted(self):
+        result = _escape_fts_query("C++O")
+        assert '"c++o"' in result
+
     def test_fts_keywords_quoted(self):
         """FTS5 reserved keywords (AND, OR, NOT, NEAR) are double-quoted."""
         result = _escape_fts_query("NOT working OR broken")
@@ -488,6 +509,10 @@ class TestFTSEscaping:
         assert '"api_index.py"' in tokens
         # "in" is a stop word and should be filtered
         assert "in" not in tokens
+
+    def test_escape_fts_tokens_preserves_plus(self):
+        tokens = _escape_fts_tokens("C++O")
+        assert '"c++o"' in tokens
 
     def test_stop_words_filtered(self):
         """Stop words are removed from FTS queries to improve AND precision."""


### PR DESCRIPTION
## Summary
- preserve `+` in FTS tokenization so literal `C++` / `C++O` terms do not collapse to an empty query
- quote plus-containing tokens for safe `MATCH` queries
- migrate chunks/knowledge/clusters FTS tables to the new tokenchars config and rebuild as needed
- add storage regression tests for plus-token escaping and literal `C++O` search

## Verification
- `PYTHONPATH=src pytest tests/recall/test_storage.py -q`
- `PYTHONPATH=src python -m py_compile src/synapt/recall/storage.py`

Closes #445.