### PR TITLE
fix(channel): zero-token response for empty polls (#441)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1004,6 +1004,10 @@ def channel_read(
     # Take last N messages
     messages = messages[-limit:]
 
+    # Zero-token response for empty polls (#441)
+    if not messages and since:
+        return ""
+
     lines = []
 
     # Pins at top
@@ -1289,7 +1293,7 @@ def channel_unread_read(
         conn.close()
 
     if not unread_channels:
-        return "No unread messages."
+        return ""
 
     sections = []
     for ch, last_read, count in sorted(unread_channels):

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -619,7 +619,7 @@ class TestUnreadMessages(unittest.TestCase):
 
         result = channel_unread_read(agent_name="agent-a")
 
-        self.assertEqual(result, "No unread messages.")
+        self.assertEqual(result, "")
 
     def test_unread_multiple_channels(self):
         channel_join("dev", agent_name="agent-a")


### PR DESCRIPTION
## Summary
- `channel_unread_read()` now returns `""` instead of `"No unread messages."` when there are no unread messages
- `channel_read()` returns `""` when a `since`-filtered query yields no messages after mute filtering
- Saves ~5-10 context tokens per empty monitoring tick across all polling agents

## Context
Every 2-minute monitoring loop tick that finds nothing still consumed tokens for "No unread messages." With 4 agents polling, that's ~20+ wasted tokens per tick, adding up over hours.

## Test plan
- [x] `pytest tests/recall/test_channel.py` — 153 passed
- [x] Updated `test_unread_read_reports_no_unread_messages` to expect `""`
- [x] Existing unread tests with actual messages still pass

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)