### PR TITLE
test: add sharding readiness gate

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -648,10 +648,17 @@ def discover_transcript_dirs() -> list[Path]:
 # Commands
 # ---------------------------------------------------------------------------
 
+_SPLIT_EXPERIMENTAL_WARNING = (
+    "WARNING: sharded split mode is still experimental. "
+    "Verify end-to-end sharded search results before treating split shards as production-safe."
+)
+
+
 def cmd_split(args: argparse.Namespace) -> None:
     """Split monolithic recall.db into quarterly shards."""
     from synapt.recall.sharding import split_monolithic_db, estimate_split
     index_dir = project_index_dir()
+    print(_SPLIT_EXPERIMENTAL_WARNING, file=sys.stderr)
 
     if args.dry_run:
         plan = split_monolithic_db(index_dir, dry_run=True)
@@ -2302,7 +2309,10 @@ def main():
     build_parser.add_argument("--rescrub", action="store_true", help="Re-scrub archived transcripts with latest patterns before building")
 
     # Split
-    split_parser = subparsers.add_parser("split", help="Split monolithic recall.db into quarterly shards")
+    split_parser = subparsers.add_parser(
+        "split",
+        help="Split monolithic recall.db into quarterly shards (experimental)",
+    )
     split_parser.add_argument("--dry-run", action="store_true", help="Show split plan without writing")
 
     # Search

--- a/tests/recall/test_cli.py
+++ b/tests/recall/test_cli.py
@@ -14,6 +14,7 @@ from synapt.recall.cli import (
     _install_global_hooks,
     cmd_journal,
     cmd_rebuild,
+    cmd_split,
     cmd_sync,
     main,
 )
@@ -438,6 +439,20 @@ def test_cmd_sync_errors_without_config(tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert "no sync target" in captured.err
+
+
+def test_cmd_split_prints_experimental_warning(tmp_path, capsys):
+    """split warns that sharded mode is still experimental."""
+    with patch("synapt.recall.cli.project_index_dir", return_value=tmp_path), \
+         patch("synapt.recall.sharding.split_monolithic_db", return_value={
+             "index.db": 0,
+             "data_001.db": 3,
+         }):
+        cmd_split(argparse.Namespace(dry_run=False))
+
+    captured = capsys.readouterr()
+    assert "experimental" in captured.err.lower()
+    assert "Split complete: 3 chunks across 1 quarterly shard(s)" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recall/test_sharding.py
+++ b/tests/recall/test_sharding.py
@@ -194,6 +194,28 @@ class TestSplitMonolithicDb(unittest.TestCase):
         finally:
             db.close()
 
+    def test_split_supports_real_transcript_index_search(self):
+        from synapt.recall.core import TranscriptIndex
+
+        tmpdir = tempfile.mkdtemp()
+        self._create_monolithic(tmpdir, num_chunks=25)
+        d = Path(tmpdir)
+        split_monolithic_db(d, threshold=10)
+
+        index = TranscriptIndex.load(d, use_embeddings=False)
+        try:
+            self.assertEqual(index._db.chunk_count(), 25)
+            self.assertEqual(len(index._rowid_to_idx), 25)
+
+            late_result = index.lookup("unique_term_17", max_chunks=3, max_tokens=500)
+            early_result = index.lookup("unique_term_3", max_chunks=3, max_tokens=500)
+
+            self.assertIn("unique_term_17", late_result)
+            self.assertIn("unique_term_3", early_result)
+        finally:
+            if index._db is not None:
+                index._db.close()
+
     def test_dry_run_doesnt_write(self):
         tmpdir = tempfile.mkdtemp()
         self._create_monolithic(tmpdir)


### PR DESCRIPTION
## Summary
- add an end-to-end sharding regression that proves `split -> TranscriptIndex.load -> lookup` works through the real sharded search path
- warn at `recall split` time that shard mode is still experimental instead of implying the output is production-safe
- mark the `split` CLI help as experimental so the risk is visible before execution

## Testing
- PYTHONPATH=src pytest tests/recall/test_sharding.py tests/recall/test_cli.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/cli.py src/synapt/recall/sharding.py src/synapt/recall/sharded_db.py src/synapt/recall/core.py