### PR TITLE
Add wake transport emission layer

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -622,9 +622,6 @@ def _store_mentions(
                 created=msg.timestamp,
             )
         conn.commit()
-    except Exception as exc:
-        import logging
-        logging.getLogger("synapt.recall.channel").debug("Mention storage failed: %s", exc)
     finally:
         conn.close()
 
@@ -732,7 +729,11 @@ def channel_read_wakes(
     limit: int = 100,
     project_dir: Path | None = None,
 ) -> list[dict]:
-    """Read wake requests for one or more targets after a cursor."""
+    """Read wake requests for one or more targets after a cursor.
+
+    Intended for a single consumer per target set. Concurrent consumers
+    watching the same targets should coordinate cursor/ack handling.
+    """
     if isinstance(targets, str):
         target_list = [targets]
     else:
@@ -767,6 +768,23 @@ def channel_read_wakes(
                 "created": row["created"],
             })
         return result
+    finally:
+        conn.close()
+
+
+def channel_ack_wakes(
+    up_to_seq: int,
+    project_dir: Path | None = None,
+) -> int:
+    """Delete wake requests up to and including a sequence number."""
+    conn = _open_db(project_dir)
+    try:
+        cursor = conn.execute(
+            "DELETE FROM wake_requests WHERE seq <= ?",
+            (up_to_seq,),
+        )
+        conn.commit()
+        return cursor.rowcount
     finally:
         conn.close()
 

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -43,6 +43,7 @@ from synapt.recall.channel import (
     channel_rename,
     channel_claim,
     channel_unclaim,
+    channel_ack_wakes,
     channel_read_wakes,
     channel_wake_targets,
     channel_claim_intent,
@@ -386,6 +387,15 @@ class TestWakeTransport(unittest.TestCase):
         self.assertEqual(agent_wakes[0]["reason"], "directive")
         self.assertEqual(agent_wakes[0]["payload"]["to"], "s_target")
 
+    def test_broadcast_directive_emits_only_channel_wake(self):
+        channel_directive("dev", "everyone stop", to="*", agent_name="s_admin")
+
+        channel_wakes = channel_read_wakes("channel:dev")
+        agent_wakes = channel_read_wakes("agent:s_admin")
+        self.assertEqual(len(channel_wakes), 1)
+        self.assertEqual(channel_wakes[0]["reason"], "directive")
+        self.assertEqual(agent_wakes, [])
+
     def test_mentions_emit_agent_wakes(self):
         channel_join("dev", agent_name="s_apollo", display_name="Apollo")
         channel_post("dev", "hey @Apollo please review", agent_name="s_writer")
@@ -413,6 +423,21 @@ class TestWakeTransport(unittest.TestCase):
         self.assertEqual(len(later_wakes), 1)
         self.assertEqual(
             later_wakes[0]["payload"]["message_id"],
+            all_wakes[1]["payload"]["message_id"],
+        )
+
+    def test_channel_ack_wakes_deletes_consumed_rows(self):
+        channel_post("dev", "first", agent_name="s_writer")
+        channel_post("dev", "second", agent_name="s_writer")
+
+        all_wakes = channel_read_wakes("channel:dev")
+        deleted = channel_ack_wakes(all_wakes[0]["seq"])
+        remaining = channel_read_wakes("channel:dev")
+
+        self.assertEqual(deleted, 1)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(
+            remaining[0]["payload"]["message_id"],
             all_wakes[1]["payload"]["message_id"],
         )
 


### PR DESCRIPTION
## Summary
- add durable wake transport records to the channel SQLite store
- emit wake requests for channel activity, directives, mentions, and human input
- add transport read helpers and regression tests for the new wake paths

## Verification
- PYTHONPATH=src pytest tests/recall/test_channel.py -q
- PYTHONPATH=src python -m py_compile src/synapt/recall/channel.py