### PR TITLE
fix(test): update mixed-profile dedup assertion after #461

### DIFF
--- a/tests/recall/test_content_profile.py
+++ b/tests/recall/test_content_profile.py
@@ -22,7 +22,7 @@ def test_adaptive_params_keep_personal_dedup_conservative():
 def test_adaptive_params_keep_mixed_profile_defaults():
     params = adaptive_params(ContentProfile(total_chunks=10, _type="mixed"))
 
-    assert params.dedup_jaccard == 0.75
+    assert params.dedup_jaccard == 0.70
     assert params.max_knowledge_default == 5
 
 


### PR DESCRIPTION
## Summary
- Updates `test_adaptive_params_keep_mixed_profile_defaults` to expect `dedup_jaccard == 0.70` (changed from 0.75 in #461)
- One-line fix — should have been caught in #461

## Lesson learned
When touching threshold values, grep for ALL test assertions that reference the old value. This is the exact "broken windows" pattern Opus flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)