### PR TITLE
fix: scope wake ack to consumer targets (#473)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -775,15 +775,29 @@ def channel_read_wakes(
 
 def channel_ack_wakes(
     up_to_seq: int,
+    targets: str | list[str] | None = None,
     project_dir: Path | None = None,
 ) -> int:
-    """Delete wake requests up to and including a sequence number."""
+    """Delete wake requests up to and including a sequence number.
+
+    Args:
+        targets: If provided, only delete wakes matching these targets.
+            Prevents one consumer from destroying another's unread wakes.
+    """
     conn = _open_db(project_dir)
     try:
-        cursor = conn.execute(
-            "DELETE FROM wake_requests WHERE seq <= ?",
-            (up_to_seq,),
-        )
+        if targets:
+            target_list = [targets] if isinstance(targets, str) else targets
+            placeholders = ",".join("?" for _ in target_list)
+            cursor = conn.execute(
+                f"DELETE FROM wake_requests WHERE seq <= ? AND target IN ({placeholders})",
+                (up_to_seq, *target_list),
+            )
+        else:
+            cursor = conn.execute(
+                "DELETE FROM wake_requests WHERE seq <= ?",
+                (up_to_seq,),
+            )
         conn.commit()
         return cursor.rowcount
     finally:

--- a/src/synapt/recall/wake.py
+++ b/src/synapt/recall/wake.py
@@ -110,15 +110,24 @@ class WakeConsumer:
     def ack(self, up_to_seq: int) -> int:
         """Acknowledge processed wakes up to *up_to_seq*.
 
-        Deletes acknowledged rows from the transport table and advances
-        the internal cursor so future polls skip them.
+        Only deletes agent-specific wakes (``agent:<id>``).  Shared
+        channel wakes are left intact so other consumers can still
+        read them (#473).  The internal cursor advances regardless,
+        so :meth:`poll` won't re-deliver already-seen wakes.
 
         Returns:
             Number of wake rows deleted.
         """
         if up_to_seq <= self._cursor:
             return 0
-        deleted = channel_ack_wakes(up_to_seq, self._project_dir)
+        # Only delete agent-scoped wakes — channel wakes are shared
+        agent_targets = [t for t in self.targets if t.startswith("agent:")]
+        deleted = 0
+        if agent_targets:
+            deleted = channel_ack_wakes(
+                up_to_seq, targets=agent_targets,
+                project_dir=self._project_dir,
+            )
         self._cursor = up_to_seq
         return deleted
 

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -441,6 +441,29 @@ class TestWakeTransport(unittest.TestCase):
             all_wakes[1]["payload"]["message_id"],
         )
 
+    def test_channel_ack_wakes_scoped_to_targets(self):
+        """Ack with targets only deletes matching wakes (#473)."""
+        channel_join("dev", agent_name="s_apollo", display_name="Apollo")
+        channel_directive("dev", "do this", to="s_apollo", agent_name="s_admin")
+
+        # Both channel and agent wakes exist
+        channel_wakes = channel_read_wakes("channel:dev")
+        agent_wakes = channel_read_wakes("agent:s_apollo")
+        self.assertGreater(len(channel_wakes), 0)
+        self.assertGreater(len(agent_wakes), 0)
+        max_seq = max(
+            max(w["seq"] for w in channel_wakes),
+            max(w["seq"] for w in agent_wakes),
+        )
+
+        # Ack only agent:s_apollo — channel wakes should survive
+        channel_ack_wakes(max_seq, targets=["agent:s_apollo"])
+        remaining_agent = channel_read_wakes("agent:s_apollo")
+        remaining_channel = channel_read_wakes("channel:dev")
+
+        self.assertEqual(remaining_agent, [])
+        self.assertGreater(len(remaining_channel), 0)
+
 
 class TestStaleDetectionTiers(unittest.TestCase):
     """Test online/idle/away/offline status tiers."""

--- a/tests/recall/test_wake.py
+++ b/tests/recall/test_wake.py
@@ -195,16 +195,34 @@ class TestWakeConsumer(unittest.TestCase):
         wakes3 = consumer.poll()
         self.assertGreater(len(wakes3), 0)
 
-    def test_ack_returns_deleted_count(self):
+    def test_ack_advances_cursor_and_deletes_agent_wakes(self):
         consumer = WakeConsumer(agent_name="s_apollo")
-        channel_post("dev", "msg1", agent_name="s_writer")
-        channel_post("dev", "msg2", agent_name="s_writer")
+        # Ack existing
+        raw = channel_read_wakes(consumer.targets)
+        if raw:
+            max_seq = max(w["seq"] for w in raw)
+            channel_ack_wakes(max_seq)
+            consumer._cursor = max_seq
 
+        # Directive creates an agent:s_apollo wake
+        channel_directive("dev", "review", to="s_apollo", agent_name="s_admin")
         wakes = consumer.poll()
         max_seq = max(w["max_seq"] for w in wakes)
         deleted = consumer.ack(max_seq)
         self.assertGreater(deleted, 0)
         self.assertEqual(consumer.cursor, max_seq)
+
+    def test_ack_advances_cursor_for_channel_only_wakes(self):
+        consumer = WakeConsumer(agent_name="s_apollo")
+        channel_post("dev", "msg1", agent_name="s_writer")
+
+        wakes = consumer.poll()
+        max_seq = max(w["max_seq"] for w in wakes)
+        old_cursor = consumer.cursor
+        consumer.ack(max_seq)
+        # Cursor advances even though no agent wakes were deleted
+        self.assertEqual(consumer.cursor, max_seq)
+        self.assertGreater(consumer.cursor, old_cursor)
 
     def test_ack_noop_when_cursor_not_advanced(self):
         consumer = WakeConsumer(agent_name="s_apollo")
@@ -306,6 +324,42 @@ class TestWakeConsumer(unittest.TestCase):
         self.assertEqual(len(dev_wakes), 1)
         self.assertEqual(dev_wakes[0]["coalesced_count"], 3)
         self.assertEqual(len(dev_wakes[0]["message_ids"]), 3)
+
+    def test_ack_scopes_to_consumer_targets(self):
+        """Consumer.ack() only deletes its own targets' wakes (#473)."""
+        # Set up two agents on the same channel
+        channel_join("dev", agent_name="s_sentinel", display_name="Sentinel")
+        consumer_apollo = WakeConsumer(agent_name="s_apollo")
+        consumer_sentinel = WakeConsumer(agent_name="s_sentinel")
+
+        # Ack existing wakes for both consumers
+        for c in (consumer_apollo, consumer_sentinel):
+            raw = channel_read_wakes(c.targets)
+            if raw:
+                max_seq = max(w["seq"] for w in raw)
+                channel_ack_wakes(max_seq)
+                c._cursor = max_seq
+
+        # Directive targets apollo specifically — creates agent:s_apollo wake
+        channel_directive("dev", "apollo task", to="s_apollo", agent_name="s_admin")
+
+        # Both consumers see channel:dev wakes
+        apollo_wakes = consumer_apollo.poll()
+        sentinel_wakes = consumer_sentinel.poll()
+        self.assertGreater(len(apollo_wakes), 0)
+        self.assertGreater(len(sentinel_wakes), 0)
+
+        # Apollo acks — should NOT destroy sentinel's wakes
+        apollo_max = max(w["max_seq"] for w in apollo_wakes)
+        consumer_apollo.ack(apollo_max)
+
+        # Sentinel should still see its wakes
+        sentinel_wakes_after = channel_read_wakes(
+            consumer_sentinel.targets,
+            after_seq=consumer_sentinel._cursor,
+        )
+        sentinel_channel = [w for w in sentinel_wakes_after if w["target"] == "channel:dev"]
+        self.assertGreater(len(sentinel_channel), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `channel_ack_wakes()` now accepts optional `targets` param — `DELETE WHERE seq <= ? AND target IN (?)`
- `WakeConsumer.ack()` only deletes agent-specific wakes (`agent:<id>`), not shared channel wakes
- Cursor advances regardless, so `poll()` skips already-seen wakes even without deletion

## Root cause
`channel_ack_wakes(up_to_seq)` deleted ALL wakes with `seq <= up_to_seq` globally. If agent A acks seq 50, agent B's unread wakes at seq 30-50 are destroyed silently.

## Design choice
Agent-only ack (not channel ack) because `channel:dev` is a shared target — both Apollo and Sentinel watch it. Deleting channel wakes on ack would still break multi-consumer. Channel wakes need periodic GC (future work).

## Test plan
- [x] `test_channel_ack_wakes_scoped_to_targets` — L1: ack agent target, verify channel wakes survive
- [x] `test_ack_scopes_to_consumer_targets` — L2: two consumers, Apollo ack does not destroy Sentinel wakes
- [x] `test_ack_advances_cursor_and_deletes_agent_wakes` — directive wakes get deleted
- [x] `test_ack_advances_cursor_for_channel_only_wakes` — cursor advances even with zero deletions
- [x] All 163 existing channel tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)