### PR TITLE
fix: scope wake acknowledgements to consumer targets

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -775,15 +775,35 @@ def channel_read_wakes(
 
 def channel_ack_wakes(
     up_to_seq: int,
+    targets: str | list[str] | None = None,
     project_dir: Path | None = None,
 ) -> int:
-    """Delete wake requests up to and including a sequence number."""
+    """Delete wake requests up to and including a sequence number.
+
+    When *targets* is provided, only rows for those wake targets are
+    deleted. This prevents one consumer from deleting another target's
+    unread wakes when they share the same transport DB.
+    """
     conn = _open_db(project_dir)
     try:
-        cursor = conn.execute(
-            "DELETE FROM wake_requests WHERE seq <= ?",
-            (up_to_seq,),
-        )
+        if targets is None:
+            cursor = conn.execute(
+                "DELETE FROM wake_requests WHERE seq <= ?",
+                (up_to_seq,),
+            )
+        else:
+            if isinstance(targets, str):
+                target_list = [targets]
+            else:
+                target_list = [t for t in targets if t]
+            if not target_list:
+                return 0
+            placeholders = ",".join("?" for _ in target_list)
+            cursor = conn.execute(
+                f"DELETE FROM wake_requests "
+                f"WHERE seq <= ? AND target IN ({placeholders})",
+                (up_to_seq, *target_list),
+            )
         conn.commit()
         return cursor.rowcount
     finally:

--- a/src/synapt/recall/wake.py
+++ b/src/synapt/recall/wake.py
@@ -118,7 +118,11 @@ class WakeConsumer:
         """
         if up_to_seq <= self._cursor:
             return 0
-        deleted = channel_ack_wakes(up_to_seq, self._project_dir)
+        deleted = channel_ack_wakes(
+            up_to_seq,
+            targets=self.targets,
+            project_dir=self._project_dir,
+        )
         self._cursor = up_to_seq
         return deleted
 

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -441,6 +441,34 @@ class TestWakeTransport(unittest.TestCase):
             all_wakes[1]["payload"]["message_id"],
         )
 
+    def test_channel_ack_wakes_can_scope_to_targets(self):
+        channel_join("dev", agent_name="s_apollo", display_name="Apollo")
+        existing = channel_read_wakes(["channel:dev", "agent:s_apollo"])
+        if existing:
+            channel_ack_wakes(
+                max(w["seq"] for w in existing),
+                targets=["channel:dev", "agent:s_apollo"],
+            )
+        channel_post("dev", "hello", agent_name="s_writer")
+        channel_directive("dev", "review", to="s_apollo", agent_name="s_admin")
+
+        channel_wakes = channel_read_wakes("channel:dev")
+        agent_wakes = channel_read_wakes("agent:s_apollo")
+        self.assertEqual(len(channel_wakes), 2)
+        self.assertEqual(len(agent_wakes), 1)
+
+        deleted = channel_ack_wakes(
+            max(w["seq"] for w in channel_wakes),
+            targets="channel:dev",
+        )
+        remaining_channel = channel_read_wakes("channel:dev")
+        remaining_agent = channel_read_wakes("agent:s_apollo")
+
+        self.assertEqual(deleted, 2)
+        self.assertEqual(remaining_channel, [])
+        self.assertEqual(len(remaining_agent), 1)
+        self.assertEqual(remaining_agent[0]["target"], "agent:s_apollo")
+
 
 class TestStaleDetectionTiers(unittest.TestCase):
     """Test online/idle/away/offline status tiers."""

--- a/tests/recall/test_wake.py
+++ b/tests/recall/test_wake.py
@@ -206,6 +206,27 @@ class TestWakeConsumer(unittest.TestCase):
         self.assertGreater(deleted, 0)
         self.assertEqual(consumer.cursor, max_seq)
 
+    def test_ack_does_not_delete_other_targets(self):
+        consumer = WakeConsumer(agent_name="s_apollo")
+        raw = channel_read_wakes(consumer.targets)
+        if raw:
+            max_seq = max(w["seq"] for w in raw)
+            channel_ack_wakes(max_seq, targets=consumer.targets)
+            consumer._cursor = max_seq
+
+        channel_directive("dev", "review now", to="s_apollo", agent_name="s_admin")
+        channel_directive("dev", "review now", to="s_other", agent_name="s_admin")
+
+        wakes = consumer.poll()
+        max_seq = max(w["max_seq"] for w in wakes)
+        deleted = consumer.ack(max_seq)
+
+        self.assertGreater(deleted, 0)
+        self.assertEqual(channel_read_wakes("agent:s_apollo"), [])
+        other_wakes = channel_read_wakes("agent:s_other")
+        self.assertEqual(len(other_wakes), 1)
+        self.assertEqual(other_wakes[0]["target"], "agent:s_other")
+
     def test_ack_noop_when_cursor_not_advanced(self):
         consumer = WakeConsumer(agent_name="s_apollo")
         deleted = consumer.ack(0)


### PR DESCRIPTION
## Summary
- add optional target scoping to `channel_ack_wakes()` so one consumer cannot delete another target's unread wakes
- make `WakeConsumer.ack()` pass its watched target set to the transport
- add transport and consumer regressions covering the cross-target deletion bug

## Root cause
`channel_ack_wakes(up_to_seq)` deleted `wake_requests` globally with `DELETE WHERE seq <= ?`. In the shared transport, if agent A acked seq 50 then agent B could silently lose unread wakes at seq 1..50 even though B had not consumed them.

## Verification
- `PYTHONPATH=src pytest tests/recall/test_channel.py tests/recall/test_wake.py -q`
- `PYTHONPATH=src python -m py_compile src/synapt/recall/channel.py src/synapt/recall/wake.py`
