### PR TITLE
fix: exclude pins from unread polls (#476)

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1954,7 +1954,11 @@ def recall_channel(
             return channel_heartbeat()
 
         if action == "unread":
-            return channel_unread_read(limit=limit, show_pins=show_pins, detail=detail)
+            # Unread is a polling action — pins are static and waste context
+            # on every tick.  Only include them if explicitly requested via
+            # detail='high'/'max' (#476).
+            unread_pins = show_pins if detail in ("high", "max") else False
+            return channel_unread_read(limit=limit, show_pins=unread_pins, detail=detail)
 
         if action == "pin":
             if not message:

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -742,6 +742,20 @@ class TestUnreadMessages(unittest.TestCase):
         self.assertIn("@Apollo please take #371", result)
         self.assertNotIn("...", result)
 
+    def test_unread_read_excludes_pins_by_default(self):
+        """Unread polls should not include pinned messages (#476)."""
+        channel_join("dev", agent_name="agent-a")
+        channel_post("dev", "important pin", agent_name="agent-b")
+        msgs = _read_messages(_channel_path("dev"))
+        pin_id = msgs[-1].id
+        channel_pin("dev", pin_id, agent_name="agent-b")
+        channel_post("dev", "regular msg", agent_name="agent-c")
+
+        result = channel_unread_read(agent_name="agent-a")
+
+        self.assertIn("regular msg", result)
+        self.assertNotIn("Pinned in #dev", result)
+
 
     def test_join_surfaces_recent_mentions_with_content(self):
         """Join response includes recent @mention content so agents get directives (#453)."""


### PR DESCRIPTION
## Summary
- MCP `unread` action no longer includes pinned messages by default
- Pins only shown when `detail='high'` or `detail='max'` is explicitly requested
- Saves significant context tokens on monitoring loops (sprint plans, benchmark tables)

## Root cause
`recall_channel(action='unread')` passed `show_pins=True` (the MCP function default) to `channel_unread_read()`, overriding its own `show_pins=False` default. Every poll tick re-sent all pinned sprint plans.

## Test plan
- [x] `test_unread_read_excludes_pins_by_default` — verifies pins absent, regular messages present
- [x] All 10 unread tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)