### PR TITLE
feat: expand @team/@all mentions to all active agents (#466)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -602,26 +602,45 @@ def _store_mentions(
                 if len(parts) > 1:
                     identity_map[parts[-1].lower()] = aid
 
-        for name in names:
-            mentioned = identity_map.get(name.lower(), name)
+        # Collect all unique agent_ids from the identity map (for @team/@all)
+        all_agents = sorted(set(identity_map.values()))
+
+        def _insert_mention_and_wake(agent_id: str) -> None:
             conn.execute(
                 "INSERT INTO mentions (message_id, channel, mentioned, timestamp) "
                 "VALUES (?, ?, ?, ?)",
-                (msg.id, msg.channel, mentioned, msg.timestamp),
+                (msg.id, msg.channel, agent_id, msg.timestamp),
             )
             _enqueue_wake_request(
                 conn,
-                target=f"agent:{mentioned}",
+                target=f"agent:{agent_id}",
                 reason="mention",
                 source=msg.from_agent,
                 payload={
                     "message_id": msg.id,
                     "channel": msg.channel,
                     "type": msg.type,
-                    "mentioned": mentioned,
+                    "mentioned": agent_id,
                 },
                 created=msg.timestamp,
             )
+
+        seen: set[str] = set()
+        for name in names:
+            lower = name.lower()
+            if lower in ("team", "all"):
+                # Expand to all active agents except the sender
+                for aid in all_agents:
+                    if aid == msg.from_agent or aid in seen:
+                        continue
+                    seen.add(aid)
+                    _insert_mention_and_wake(aid)
+            else:
+                mentioned = identity_map.get(lower, name)
+                if mentioned in seen:
+                    continue
+                seen.add(mentioned)
+                _insert_mention_and_wake(mentioned)
         conn.commit()
     finally:
         conn.close()

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -2518,5 +2518,67 @@ class TestCheckDirectives(unittest.TestCase):
         self.assertIn("opus", mentioned)
 
 
+    def test_team_mention_expands_to_all_agents(self):
+        """@team expands to individual mentions for all active agents."""
+        channel_join("dev", agent_name="s_opus")
+        channel_join("dev", agent_name="s_atlas")
+        channel_join("dev", agent_name="s_sentinel")
+        channel_post("dev", "hey @team stand by", agent_name="s_opus")
+        conn = _open_db()
+        rows = conn.execute(
+            "SELECT mentioned FROM mentions ORDER BY mentioned"
+        ).fetchall()
+        conn.close()
+        mentioned = [r["mentioned"] for r in rows]
+        # Should mention atlas and sentinel but NOT opus (the sender)
+        self.assertIn("s_atlas", mentioned)
+        self.assertIn("s_sentinel", mentioned)
+        self.assertNotIn("s_opus", mentioned)
+
+    def test_all_mention_expands_to_all_agents(self):
+        """@all works the same as @team."""
+        channel_join("dev", agent_name="s_opus")
+        channel_join("dev", agent_name="s_apollo")
+        channel_post("dev", "attention @all", agent_name="s_opus")
+        conn = _open_db()
+        rows = conn.execute(
+            "SELECT mentioned FROM mentions ORDER BY mentioned"
+        ).fetchall()
+        conn.close()
+        mentioned = [r["mentioned"] for r in rows]
+        self.assertIn("s_apollo", mentioned)
+        self.assertNotIn("s_opus", mentioned)
+
+    def test_team_mention_no_duplicates(self):
+        """@team + explicit @atlas doesn't double-mention atlas."""
+        channel_join("dev", agent_name="s_opus")
+        channel_join("dev", agent_name="s_atlas")
+        conn = _open_db()
+        conn.execute("UPDATE presence SET display_name = 'Atlas' WHERE agent_id = 's_atlas'")
+        conn.commit()
+        conn.close()
+        channel_post("dev", "@atlas and @team please review", agent_name="s_opus")
+        conn = _open_db()
+        rows = conn.execute(
+            "SELECT mentioned FROM mentions WHERE mentioned = 's_atlas'"
+        ).fetchall()
+        conn.close()
+        self.assertEqual(len(rows), 1)
+
+    def test_team_unread_surfaces_for_all_agents(self):
+        """@team mention surfaces in unread for each team member."""
+        channel_join("dev", agent_name="s_opus")
+        channel_join("dev", agent_name="s_atlas")
+        channel_join("dev", agent_name="s_sentinel")
+        channel_read("dev", agent_name="s_atlas")
+        channel_read("dev", agent_name="s_sentinel")
+        channel_post("dev", "@team deploy is frozen", agent_name="s_opus")
+        # Both atlas and sentinel should see the mention in unread
+        atlas_unread = channel_unread_read(agent_name="s_atlas")
+        sentinel_unread = channel_unread_read(agent_name="s_sentinel")
+        self.assertIn("deploy is frozen", atlas_unread)
+        self.assertIn("deploy is frozen", sentinel_unread)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- When `_store_mentions` sees `@team` or `@all`, resolves all agents from the presence table and stores individual mention rows for each (excluding the sender)
- Deduplicates when both `@team` and an explicit `@name` target the same agent
- Existing mention/directive tests unchanged

## Test plan
- [x] `test_team_mention_expands_to_all_agents` — verifies expansion, sender excluded
- [x] `test_all_mention_expands_to_all_agents` — @all works same as @team
- [x] `test_team_mention_no_duplicates` — @atlas + @team doesn't double-mention
- [x] `test_team_unread_surfaces_for_all_agents` — end-to-end unread visibility
- [x] All 13 existing TestCheckDirectives tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)