### PR TITLE
feat: add transcript file path to source offsets (#470)

### DIFF
--- a/src/synapt/recall/consolidate.py
+++ b/src/synapt/recall/consolidate.py
@@ -1803,7 +1803,7 @@ def _load_chunks_for_resolve(
     # Filter chunks to only relevant sessions
     placeholders = ",".join("?" for _ in needed_sessions)
     rows = db._conn.execute(
-        f"SELECT session_id, turn_index, user_text, assistant_text "
+        f"SELECT session_id, turn_index, user_text, assistant_text, transcript_path "
         f"FROM chunks WHERE session_id IN ({placeholders})",
         list(needed_sessions),
     ).fetchall()
@@ -1818,8 +1818,9 @@ def _load_chunks_for_resolve(
         tidx = r["turn_index"]
         text = (r["user_text"] or "") + " " + (r["assistant_text"] or "")
         toks = _extract_keywords(text)
+        tpath = r["transcript_path"] or ""
         if include_text:
-            session_chunks.setdefault(sid, []).append((tidx, text, toks))
+            session_chunks.setdefault(sid, []).append((tidx, text, toks, tpath))
         else:
             session_chunks.setdefault(sid, []).append((tidx, toks))
 
@@ -1966,11 +1967,14 @@ def resolve_source_offsets(
     kn_path, session_chunks, nodes, db = loaded
     pending_updates: dict[str, dict] = {}
 
-    # Build a turn lookup: (session_id, turn_index) → full text
+    # Build turn lookups: (session_id, turn_index) → full text and file path
     _turn_text: dict[tuple[str, int], str] = {}
+    _turn_file: dict[tuple[str, int], str] = {}
     for sid, chunks_list in session_chunks.items():
-        for tidx, text, _toks in chunks_list:
+        for tidx, text, _toks, tpath in chunks_list:
             _turn_text[(sid, tidx)] = text
+            if tpath:
+                _turn_file[(sid, tidx)] = tpath
 
     try:
         for node in nodes:
@@ -1997,10 +2001,14 @@ def resolve_source_offsets(
                         continue
                     span = _find_best_span(node.content, text)
                     if span:
-                        offsets.append({
+                        entry: dict = {
                             "s": sid, "t": tidx,
                             "b": span[0], "e": span[1],
-                        })
+                        }
+                        fpath = _turn_file.get((sid, tidx), "")
+                        if fpath:
+                            entry["f"] = fpath
+                        offsets.append(entry)
                 if offsets:
                     pending_updates[node.id] = {"source_offsets": offsets}
                     continue
@@ -2013,12 +2021,12 @@ def resolve_source_offsets(
             if len(node_toks) < 2:
                 continue
 
-            candidates: list[tuple[str, int, str, int]] = []
+            candidates: list[tuple[str, int, str, int, str]] = []
             for sid in node.source_sessions:
-                for tidx, text, chunk_toks in session_chunks.get(sid, []):
+                for tidx, text, chunk_toks, tpath in session_chunks.get(sid, []):
                     overlap = len(node_toks & chunk_toks)
                     if overlap >= min_overlap:
-                        candidates.append((sid, tidx, text, overlap))
+                        candidates.append((sid, tidx, text, overlap, tpath))
 
             if not candidates:
                 continue
@@ -2026,13 +2034,16 @@ def resolve_source_offsets(
             candidates.sort(key=lambda x: x[3], reverse=True)
 
             offsets = []
-            for sid, tidx, text, _ in candidates[:max_offsets_per_node]:
+            for sid, tidx, text, _, tpath in candidates[:max_offsets_per_node]:
                 span = _find_best_span(node.content, text)
                 if span:
-                    offsets.append({
+                    entry = {
                         "s": sid, "t": tidx,
                         "b": span[0], "e": span[1],
-                    })
+                    }
+                    if tpath:
+                        entry["f"] = tpath
+                    offsets.append(entry)
 
             if offsets:
                 pending_updates[node.id] = {"source_offsets": offsets}

--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3059,8 +3059,14 @@ class TranscriptIndex:
                     if not snippet:
                         continue
                     # Compact snippet block with source attribution
+                    fpath = offset.get("f", "")
+                    if fpath:
+                        fname = Path(fpath).name
+                        source_label = f"{fname} turn {tidx}"
+                    else:
+                        source_label = f"{_short_sid(sid)} turn {tidx}"
                     block = (
-                        f"--- [source: {_short_sid(sid)} turn {tidx}] ---\n"
+                        f"--- [source: {source_label}] ---\n"
                         f"{snippet}"
                     )
                     source_score = base_score * 0.6

--- a/tests/recall/test_consolidate.py
+++ b/tests/recall/test_consolidate.py
@@ -1794,5 +1794,84 @@ def test_get_dedup_thresholds_unknown_type():
     assert c == 0.80
 
 
+def _setup_resolve_test(tmp_path, monkeypatch, transcript_path):
+    """Helper: set up DB + knowledge node for resolve_source_offsets tests."""
+    from synapt.recall.storage import RecallDB
+    from synapt.recall.knowledge import KnowledgeNode, append_node
+
+    recall_dir = tmp_path / ".synapt" / "recall"
+    recall_dir.mkdir(parents=True)
+    index_dir = recall_dir / "index"
+    index_dir.mkdir()
+
+    monkeypatch.setattr(
+        "synapt.recall.consolidate.project_index_dir",
+        lambda _: index_dir,
+    )
+    kn_path = recall_dir / "knowledge.jsonl"
+    monkeypatch.setattr(
+        "synapt.recall.consolidate._knowledge_path",
+        lambda _: kn_path,
+    )
+
+    node = KnowledgeNode.create(
+        content="She mentioned her adoption plans",
+        category="personal",
+        source_sessions=["sess-A"],
+        source_turns=["sess-A:0"],
+    )
+    append_node(node, kn_path)
+
+    db = RecallDB(index_dir / "recall.db")
+    db._conn.execute(
+        "INSERT INTO chunks (id, session_id, timestamp, turn_index, user_text, assistant_text, transcript_path) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("chunk-001", "sess-A", "2026-03-01T00:00:00", 0,
+         "We talked about the weather. She mentioned her adoption plans were moving forward. Then we discussed dinner.",
+         "",
+         transcript_path),
+    )
+    db._conn.commit()
+    db.close()
+    return kn_path
+
+
+def test_resolve_source_offsets_includes_file_path(tmp_path, monkeypatch):
+    """resolve_source_offsets stores transcript_path as 'f' key in offset dicts."""
+    from synapt.recall.consolidate import resolve_source_offsets
+
+    kn_path = _setup_resolve_test(tmp_path, monkeypatch, "/transcripts/sess-A.jsonl")
+
+    count = resolve_source_offsets(tmp_path)
+    assert count == 1
+
+    nodes = list(read_nodes(kn_path))
+    resolved = nodes[0]
+    assert resolved.source_offsets, "source_offsets should be populated"
+    offset = resolved.source_offsets[0]
+    assert offset["s"] == "sess-A"
+    assert offset["t"] == 0
+    assert "b" in offset and "e" in offset
+    assert offset["f"] == "/transcripts/sess-A.jsonl"
+    # Verify the span actually contains the right text
+    chunk_text = "We talked about the weather. She mentioned her adoption plans were moving forward. Then we discussed dinner."
+    snippet = chunk_text[offset["b"]:offset["e"]]
+    assert "adoption" in snippet
+
+
+def test_resolve_source_offsets_omits_f_when_empty(tmp_path, monkeypatch):
+    """When transcript_path is empty, the 'f' key is omitted from offsets."""
+    from synapt.recall.consolidate import resolve_source_offsets
+
+    kn_path = _setup_resolve_test(tmp_path, monkeypatch, "")
+
+    count = resolve_source_offsets(tmp_path)
+    assert count == 1
+
+    nodes = list(read_nodes(kn_path))
+    offset = nodes[0].source_offsets[0]
+    assert "f" not in offset, "Empty transcript_path should not be stored"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `resolve_source_offsets` now captures `transcript_path` from the chunks table and stores it as the `"f"` key in each offset dict
- Source snippet formatter in `core.py` uses the filename for attribution when available
- `"f"` key omitted when `transcript_path` is empty (backward compatible)

## Test plan
- [x] `test_resolve_source_offsets_includes_file_path` — verifies `"f"` key present with valid path
- [x] `test_resolve_source_offsets_omits_f_when_empty` — verifies `"f"` omitted when empty
- [x] All existing `_find_best_span` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)