### PR TITLE
feat: mutable status board per channel (#442)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -372,6 +372,22 @@ CREATE TABLE IF NOT EXISTS wake_requests (
 
 CREATE INDEX IF NOT EXISTS idx_wake_requests_target_seq
     ON wake_requests(target, seq);
+
+CREATE TABLE IF NOT EXISTS status_board (
+    channel TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (channel, agent_id)
+);
+
+CREATE TABLE IF NOT EXISTS status_board_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL
+);
 """
 
 _WAKE_PRIORITIES = {
@@ -1251,6 +1267,13 @@ def channel_read(
         ).fetchall():
             claim_map[r["message_id"]] = r["claimed_by"]
 
+        # Load status board entries
+        board_rows = conn.execute(
+            "SELECT agent_id, body, updated_at FROM status_board "
+            "WHERE channel = ? ORDER BY updated_at DESC",
+            (channel,),
+        ).fetchall()
+
         # Update read cursor
         conn.execute(
             "INSERT INTO cursors (agent_id, channel, last_read_at) "
@@ -1293,6 +1316,15 @@ def channel_read(
             by = display_map.get(pin["pinned_by"], pin["pinned_by"])
             mid = f" [{pin['message_id']}]" if pin["message_id"] and _show_ids else ""
             lines.append(f"  [pin]{mid} {ts}  {by}: {pin['body']}")
+        lines.append("")
+
+    # Status board after pins
+    if not _one_line and board_rows:
+        lines.append(f"## Status Board — #{channel}")
+        for r in board_rows:
+            bd = display_map.get(r["agent_id"], r["agent_id"])
+            bts = r["updated_at"][:16].replace("T", " ")
+            lines.append(f"  {bd} ({bts}): {r['body']}")
         lines.append("")
 
     lines.append(f"## #{channel} ({len(messages)} messages)")
@@ -1787,6 +1819,76 @@ def channel_broadcast(
     for ch in channels:
         channel_post(ch, message, agent_name=agent_name, project_dir=project_dir)
     return f"Broadcast to {len(channels)} channel(s): {', '.join(f'#{c}' for c in channels)}"
+
+
+def channel_board(
+    channel: str = "dev",
+    message: str | None = None,
+    agent_name: str | None = None,
+    project_dir: Path | None = None,
+) -> str:
+    """Read or update the mutable status board for a channel.
+
+    Each agent has one row on the board. Setting a message replaces
+    the previous value (previous state archived to history).
+    Reading returns all agents' current board entries.
+    Pass an empty string to clear your entry.
+    """
+    aid = agent_name or _agent_id(project_dir)
+    now = _now_iso()
+    conn = _open_db(project_dir)
+    try:
+        if message is not None:
+            # Archive previous state
+            conn.execute(
+                "INSERT INTO status_board_history (channel, agent_id, body, updated_at) "
+                "SELECT channel, agent_id, body, updated_at "
+                "FROM status_board WHERE channel = ? AND agent_id = ?",
+                (channel, aid),
+            )
+            if message:
+                conn.execute(
+                    "INSERT OR REPLACE INTO status_board (channel, agent_id, body, updated_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (channel, aid, message, now),
+                )
+            else:
+                # Empty string = clear entry
+                conn.execute(
+                    "DELETE FROM status_board WHERE channel = ? AND agent_id = ?",
+                    (channel, aid),
+                )
+            conn.commit()
+
+            # Resolve display name inline
+            row = conn.execute(
+                "SELECT display_name FROM presence WHERE agent_id = ?", (aid,)
+            ).fetchone()
+            display = (row["display_name"] if row and row["display_name"] else aid)
+            return f"Board updated for {display} in #{channel}."
+
+        # Read mode
+        rows = conn.execute(
+            "SELECT agent_id, body, updated_at FROM status_board "
+            "WHERE channel = ? ORDER BY updated_at DESC",
+            (channel,),
+        ).fetchall()
+        if not rows:
+            return f"No status board entries in #{channel}."
+
+        # Build display name map
+        display_map: dict[str, str] = {}
+        for r in conn.execute("SELECT agent_id, display_name FROM presence").fetchall():
+            display_map[r["agent_id"]] = r["display_name"] or r["agent_id"]
+
+        lines = [f"## Status Board — #{channel}"]
+        for r in rows:
+            display = display_map.get(r["agent_id"], r["agent_id"])
+            ts = r["updated_at"][:16].replace("T", " ")
+            lines.append(f"  {display} ({ts}): {r['body']}")
+        return "\n".join(lines)
+    finally:
+        conn.close()
 
 
 def channel_rename(

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1881,7 +1881,7 @@ def recall_channel(
     Args:
         action: "join", "leave", "post", "read", "read_message", "who", "heartbeat", "unread",
                 "pin", "directive", "mute", "unmute", "kick", "broadcast",
-                "list", "search", "rename", "claim", "unclaim", "intent".
+                "list", "search", "rename", "claim", "unclaim", "intent", "board".
         channel: Channel name (default "dev"). Any name works -- created on first post.
         message: Message body (required for "post", "directive", "broadcast") or message_id for "read_message"/pin actions.
         to: Target agent for "directive" action.
@@ -1924,6 +1924,7 @@ def recall_channel(
             channel_unmute,
             channel_kick,
             channel_broadcast,
+            channel_board,
             channel_list_channels,
         )
 
@@ -1997,6 +1998,9 @@ def recall_channel(
                 return "Error: message is required for 'broadcast' action."
             return channel_broadcast(message=message)
 
+        if action == "board":
+            return channel_board(channel=channel, message=message)
+
         if action == "list":
             channels = channel_list_channels()
             if not channels:
@@ -2044,7 +2048,7 @@ def recall_channel(
         return (
             f"Unknown action: {action}. Use 'join', 'leave', 'post', 'read', "
             f"'who', 'heartbeat', 'unread', 'pin', 'directive', 'mute', "
-            f"'unmute', 'kick', 'broadcast', 'list', 'search', 'rename', "
+            f"'unmute', 'kick', 'broadcast', 'board', 'list', 'search', 'rename', "
             f"'claim', 'unclaim', or 'intent'."
         )
     except Exception as exc:

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -36,6 +36,7 @@ from synapt.recall.channel import (
     channel_unmute,
     channel_kick,
     channel_broadcast,
+    channel_board,
     channel_agents_json,
     channel_list_channels,
     channel_messages_json,
@@ -2592,6 +2593,70 @@ class TestCheckDirectives(unittest.TestCase):
         sentinel_unread = channel_unread_read(agent_name="s_sentinel")
         self.assertIn("deploy is frozen", atlas_unread)
         self.assertIn("deploy is frozen", sentinel_unread)
+
+
+class TestStatusBoard(unittest.TestCase):
+    """Tests for the mutable status board (#442)."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self._tmpdir)
+        self._patcher.start()
+        channel_join("dev", agent_name="s_opus")
+        channel_join("dev", agent_name="s_atlas")
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_set_and_read_board(self):
+        """Setting a board entry makes it visible on read."""
+        channel_board("dev", message="PR #478: in review", agent_name="s_opus")
+        result = channel_board("dev", agent_name="s_atlas")
+        self.assertIn("PR #478: in review", result)
+        self.assertIn("Status Board", result)
+
+    def test_update_replaces_previous(self):
+        """Updating a board entry replaces the old value."""
+        channel_board("dev", message="working on #442", agent_name="s_opus")
+        channel_board("dev", message="done with #442", agent_name="s_opus")
+        result = channel_board("dev", agent_name="s_atlas")
+        self.assertIn("done with #442", result)
+        self.assertNotIn("working on #442", result)
+
+    def test_clear_entry(self):
+        """Empty string clears the agent's board entry."""
+        channel_board("dev", message="busy", agent_name="s_opus")
+        channel_board("dev", message="", agent_name="s_opus")
+        result = channel_board("dev", agent_name="s_atlas")
+        self.assertIn("No status board entries", result)
+
+    def test_multiple_agents(self):
+        """Each agent has their own board entry."""
+        channel_board("dev", message="reviewing PRs", agent_name="s_opus")
+        channel_board("dev", message="running evals", agent_name="s_atlas")
+        result = channel_board("dev", agent_name="s_opus")
+        self.assertIn("reviewing PRs", result)
+        self.assertIn("running evals", result)
+
+    def test_board_in_channel_read(self):
+        """Board entries appear in channel_read output."""
+        channel_board("dev", message="sprint planning", agent_name="s_opus")
+        channel_post("dev", "hello", agent_name="s_atlas")
+        result = channel_read("dev", agent_name="s_atlas")
+        self.assertIn("Status Board", result)
+        self.assertIn("sprint planning", result)
+
+    def test_history_preserved(self):
+        """Previous board states are archived in history table."""
+        channel_board("dev", message="v1", agent_name="s_opus")
+        channel_board("dev", message="v2", agent_name="s_opus")
+        conn = _open_db()
+        rows = conn.execute(
+            "SELECT body FROM status_board_history WHERE agent_id = 's_opus'"
+        ).fetchall()
+        conn.close()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["body"], "v1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- New `status_board` table: per-agent, per-channel mutable entries with full-replace semantics
- `channel_board()` function: set/update/clear/read board entries
- Previous board states archived to `status_board_history` for audit
- Board renders between pins and messages in `channel_read` output (skipped in `min` detail)
- Wired into MCP server as `action="board"`

## Test plan
- [x] `test_set_and_read_board` — set entry, verify visible on read
- [x] `test_update_replaces_previous` — update replaces old value
- [x] `test_clear_entry` — empty string clears entry
- [x] `test_multiple_agents` — each agent has own board row
- [x] `test_board_in_channel_read` — board appears in channel_read output
- [x] `test_history_preserved` — previous states archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)