### PR TITLE
feat: configurable snippet context margin (#344)

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -3555,13 +3555,17 @@ class TranscriptIndex:
         #   -1 or unset → no snippeting (default — full chunk)
         #    0           → tight snippets (40-char margin, original #340)
         #    N           → N chars of context margin on each side
-        snippet_ctx = os.environ.get("SYNAPT_SNIPPET_CONTEXT", "-1")
+        snippet_ctx = os.environ.get("SYNAPT_SNIPPET_CONTEXT")
+        if snippet_ctx is None and os.environ.get("SYNAPT_ENABLE_SNIPPETS"):
+            snippet_ctx = "0"  # backward compat for legacy env var
+        if snippet_ctx is None:
+            snippet_ctx = "-1"
         try:
             snippet_margin = int(snippet_ctx)
         except ValueError:
             snippet_margin = -1
         if query and snippet_margin >= 0:
-            margin = max(40, snippet_margin) if snippet_margin > 0 else 40
+            margin = snippet_margin if snippet_margin > 0 else 40
             asst = chunk.assistant_text or ""
             user = chunk.user_text or ""
             # Try assistant text first — that's the evidence source

--- a/tests/recall/test_core.py
+++ b/tests/recall/test_core.py
@@ -2427,3 +2427,109 @@ def test_snippet_wider_margin(monkeypatch):
     assert "ArgoCD" in block
     # With 200-char margin, should include surrounding context
     assert "..." in block  # Still a snippet, not full text
+
+
+def test_snippet_tight_context_zero(monkeypatch):
+    """SYNAPT_SNIPPET_CONTEXT=0 enables tight snippets (40-char margin)."""
+    monkeypatch.setenv("SYNAPT_SNIPPET_CONTEXT", "0")
+    chunks = [
+        TranscriptChunk(
+            id="s001:t0",
+            session_id="session-001",
+            timestamp="2026-03-24T12:00:00Z",
+            turn_index=0,
+            user_text="Tell me about Docker",
+            assistant_text=(
+                "Docker is a containerization platform. "
+                "It lets you package applications into containers. "
+                "Containers are lightweight and portable. "
+                "You can deploy them anywhere. "
+                "Docker uses images as templates. "
+                "Images are built from Dockerfiles. "
+                "The Docker Hub hosts public images. "
+                "Kubernetes can orchestrate Docker containers at scale."
+            ),
+            tools_used=[],
+            files_touched=[],
+            tool_content="",
+            date_text="",
+            transcript_path="",
+            byte_offset=0,
+            byte_length=0,
+        ),
+    ]
+    index = TranscriptIndex(chunks)
+    block = index._format_chunk_block(0, query="Kubernetes orchestrate containers")
+    # Tight snippet — should be shorter than full block
+    full_block = index._format_chunk_block(0)
+    assert len(block) < len(full_block)
+    assert "Kubernetes" in block
+
+
+def test_snippet_invalid_env_value_disables(monkeypatch):
+    """Invalid SYNAPT_SNIPPET_CONTEXT value falls back to no snippeting."""
+    monkeypatch.setenv("SYNAPT_SNIPPET_CONTEXT", "not_a_number")
+    chunks = [
+        TranscriptChunk(
+            id="s001:t0",
+            session_id="session-001",
+            timestamp="2026-03-24T12:00:00Z",
+            turn_index=0,
+            user_text="Hello",
+            assistant_text=(
+                "Docker is a containerization platform. "
+                "Kubernetes can orchestrate Docker containers at scale. "
+                "Both are essential for modern deployments. "
+                "CI/CD pipelines automate the build and deploy process."
+            ),
+            tools_used=[],
+            files_touched=[],
+            tool_content="",
+            date_text="",
+            transcript_path="",
+            byte_offset=0,
+            byte_length=0,
+        ),
+    ]
+    index = TranscriptIndex(chunks)
+    block = index._format_chunk_block(0, query="Kubernetes orchestrate")
+    # Invalid value → no snippeting → full block with User: and Assistant:
+    assert "User: Hello" in block
+    assert "Docker is a containerization" in block
+
+
+def test_snippet_legacy_enable_snippets_compat(monkeypatch):
+    """SYNAPT_ENABLE_SNIPPETS=1 still works for backward compat."""
+    monkeypatch.setenv("SYNAPT_ENABLE_SNIPPETS", "1")
+    monkeypatch.delenv("SYNAPT_SNIPPET_CONTEXT", raising=False)
+    chunks = [
+        TranscriptChunk(
+            id="s001:t0",
+            session_id="session-001",
+            timestamp="2026-03-24T12:00:00Z",
+            turn_index=0,
+            user_text="Tell me about Docker",
+            assistant_text=(
+                "Docker is a containerization platform. "
+                "It lets you package applications into containers. "
+                "Containers are lightweight and portable. "
+                "You can deploy them anywhere. "
+                "Docker uses images as templates. "
+                "Images are built from Dockerfiles. "
+                "The Docker Hub hosts public images. "
+                "Kubernetes can orchestrate Docker containers at scale."
+            ),
+            tools_used=[],
+            files_touched=[],
+            tool_content="",
+            date_text="",
+            transcript_path="",
+            byte_offset=0,
+            byte_length=0,
+        ),
+    ]
+    index = TranscriptIndex(chunks)
+    block = index._format_chunk_block(0, query="Kubernetes orchestrate containers")
+    full_block = index._format_chunk_block(0)
+    # Legacy env var should enable snippets (tight mode)
+    assert len(block) < len(full_block)


### PR DESCRIPTION
## Summary
- Replace binary `SYNAPT_ENABLE_SNIPPETS` with configurable `SYNAPT_SNIPPET_CONTEXT`
- `-1` or unset = no snippeting (default), `0` = tight (40-char margin), `N` = N-char margin
- Snippets disabled by default — LOCOMO bisect proved they clip evidence

## Context
#340 added query-aware snippets that saved 3.4% tokens but caused single-hop collapse (13.64% -> 4.55%). Binary on/off was the wrong tradeoff. This gives users a knob for token-constrained scenarios while keeping full chunks as default.

## Test plan
- [x] `test_snippet_disabled_by_default` — no snippeting without env var
- [x] `test_snippet_wider_margin` — SYNAPT_SNIPPET_CONTEXT=200 gives wider context
- [x] Existing snippet tests updated to use new env var (all pass)
- [x] All 9 snippet/query_span tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)