### PR TITLE
feat: recall_quick intent routing (#412)

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -44,7 +44,7 @@ from synapt.recall.core import (
 )
 from synapt.recall._llm_util import truncate_at_word as _tw
 from synapt.recall.embeddings import get_embedding_provider
-from synapt.recall.hybrid import classify_query_intent
+from synapt.recall.hybrid import classify_query_intent, intent_search_params
 
 
 def _cap_tokens(requested: int) -> int:
@@ -379,6 +379,7 @@ def recall_quick(query: str) -> str:
     quick_budget = _cap_tokens(500)
     intent = classify_query_intent(query)
     depth = "summary" if intent == "status" else "concise"
+    params = intent_search_params(intent)
     # Skip embedding loading for quick checks. Pending-work queries use
     # summary mode (knowledge + journal), everything else uses concise
     # mode (knowledge + cluster summaries).
@@ -392,9 +393,11 @@ def recall_quick(query: str) -> str:
             query,
             max_chunks=5,
             max_tokens=quick_budget,
-            half_life=None,
+            half_life=params.get("half_life"),
             depth=depth,
             threshold_ratio=0.2,
+            knowledge_boost=params.get("knowledge_boost"),
+            max_knowledge=params.get("max_knowledge"),
         )
         if result:
             return result

--- a/tests/recall/test_hybrid_integration.py
+++ b/tests/recall/test_hybrid_integration.py
@@ -374,3 +374,50 @@ class TestQueryCache:
         # Fourth query should evict the oldest
         index.lookup("rollback procedure", max_chunks=5)
         assert len(index._query_cache) == 3
+
+
+class TestRecallQuickIntentRouting:
+    """Test that recall_quick passes intent-derived params to lookup (#412)."""
+
+    def test_factual_query_boosts_knowledge(self):
+        """Factual intent should pass knowledge_boost=3.0."""
+        from unittest.mock import MagicMock, patch
+        from synapt.recall.server import recall_quick
+
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "some result"
+
+        with patch("synapt.recall.server._get_index", return_value=mock_index):
+            recall_quick("what is the database port")
+
+        call_kwargs = mock_index.lookup.call_args.kwargs
+        assert call_kwargs.get("knowledge_boost") == 3.0
+
+    def test_status_query_caps_knowledge(self):
+        """Status intent should cap max_knowledge=2."""
+        from unittest.mock import MagicMock, patch
+        from synapt.recall.server import recall_quick
+
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "some result"
+
+        with patch("synapt.recall.server._get_index", return_value=mock_index):
+            recall_quick("what's pending")
+
+        call_kwargs = mock_index.lookup.call_args.kwargs
+        assert call_kwargs.get("max_knowledge") == 2
+        assert call_kwargs.get("depth") == "summary"
+
+    def test_debug_query_uses_recency(self):
+        """Debug intent should set half_life=30."""
+        from unittest.mock import MagicMock, patch
+        from synapt.recall.server import recall_quick
+
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "some result"
+
+        with patch("synapt.recall.server._get_index", return_value=mock_index):
+            recall_quick("why did the build fail")
+
+        call_kwargs = mock_index.lookup.call_args.kwargs
+        assert call_kwargs.get("half_life") == 30.0


### PR DESCRIPTION
## Summary
- `recall_quick` now passes `knowledge_boost`, `max_knowledge`, and `half_life` from `intent_search_params()` into `lookup()`
- Previously only depth mode (summary vs concise) varied by intent — now search weighting adapts too
- Factual queries: 3x knowledge boost. Status queries: max 2 knowledge nodes. Debug: 30-day recency decay.

## Test plan
- [x] `test_factual_query_boosts_knowledge` — knowledge_boost=3.0 passed
- [x] `test_status_query_caps_knowledge` — max_knowledge=2, depth=summary
- [x] `test_debug_query_uses_recency` — half_life=30.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)