### PR TITLE
feat: wake-to-prompt bridge (#484)

### DIFF
--- a/src/synapt/recall/wake_bridge.py
+++ b/src/synapt/recall/wake_bridge.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from synapt.recall.wake import WakeConsumer
 
@@ -25,22 +26,22 @@ logger = logging.getLogger("synapt.recall.wake_bridge")
 # substituted from the wake payload.
 _PROMPT_TEMPLATES: dict[str, str] = {
     "user_action": (
-        'Check #dev for unread messages using recall_channel('
+        "Check #{channel} for unread messages using recall_channel("
         "action='unread', show_pins=false, detail='medium'). "
         "Layne posted — check immediately."
     ),
     "directive": (
-        'Check #dev for unread messages using recall_channel('
+        "Check #{channel} for unread messages using recall_channel("
         "action='unread', show_pins=false, detail='medium'). "
         "New directive from {source} — act on it."
     ),
     "mention": (
-        'Check #dev for unread messages using recall_channel('
+        "Check #{channel} for unread messages using recall_channel("
         "action='unread', show_pins=false, detail='medium'). "
         "You were @mentioned — check unread."
     ),
     "channel_activity": (
-        'Check #dev for unread messages using recall_channel('
+        "Check #{channel} for unread messages using recall_channel("
         "action='unread', show_pins=false, detail='medium'). "
         "If there are new messages, read them and act on any "
         "directives or assignments. If no unread, return empty."
@@ -51,8 +52,17 @@ _DEFAULT_PROMPT = _PROMPT_TEMPLATES["channel_activity"]
 
 
 # ---------------------------------------------------------------------------
-# Platform adapters
+# Platform adapter protocol
 # ---------------------------------------------------------------------------
+
+@runtime_checkable
+class PromptAdapter(Protocol):
+    """Interface for platform-specific prompt injection."""
+
+    def is_alive(self, target: str) -> bool: ...
+
+    def inject_prompt(self, target: str, prompt: str) -> bool: ...
+
 
 class TmuxAdapter:
     """Injects prompts into tmux panes.
@@ -75,10 +85,21 @@ class TmuxAdapter:
             return False
 
     def inject_prompt(self, target: str, prompt: str) -> bool:
-        """Send a prompt string into the agent's tmux pane."""
+        """Send a prompt string into the agent's tmux pane.
+
+        Uses ``-l`` (literal mode) to prevent tmux from interpreting
+        special characters in the prompt text.
+        """
         try:
             result = subprocess.run(
-                ["tmux", "send-keys", "-t", target, prompt, "Enter"],
+                ["tmux", "send-keys", "-t", target, "-l", prompt],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode != 0:
+                return False
+            # Send Enter separately so -l doesn't escape it
+            result = subprocess.run(
+                ["tmux", "send-keys", "-t", target, "Enter"],
                 capture_output=True, text=True, timeout=5,
             )
             return result.returncode == 0
@@ -95,10 +116,14 @@ class AgentBinding:
     """Maps an agent to its WakeConsumer and platform target."""
     agent_name: str
     target: str  # opaque adapter target (e.g. "synapt:apollo")
+    project_dir: Path | None = None
     consumer: WakeConsumer = field(init=False)
 
     def __post_init__(self):
-        self.consumer = WakeConsumer(agent_name=self.agent_name)
+        self.consumer = WakeConsumer(
+            agent_name=self.agent_name,
+            project_dir=self.project_dir,
+        )
 
 
 class WakeBridge:
@@ -114,14 +139,16 @@ class WakeBridge:
     def __init__(
         self,
         agents: dict[str, str],
-        adapter: TmuxAdapter | None = None,
+        adapter: PromptAdapter | None = None,
         poll_interval: float = 10.0,
         project_dir: Path | None = None,
     ) -> None:
-        self._adapter = adapter or TmuxAdapter()
+        self._adapter: PromptAdapter = adapter or TmuxAdapter()
         self._poll_interval = poll_interval
         self._bindings: list[AgentBinding] = [
-            AgentBinding(agent_name=name, target=target)
+            AgentBinding(
+                agent_name=name, target=target, project_dir=project_dir,
+            )
             for name, target in agents.items()
         ]
 
@@ -144,10 +171,11 @@ class WakeBridge:
             # Build prompt from highest-priority wake
             top_wake = wakes[0]  # already priority-sorted by WakeConsumer
             prompt = self._build_prompt(top_wake)
-
-            # Inject
-            ok = self._adapter.inject_prompt(binding.target, prompt)
             max_seq = max(w["max_seq"] for w in wakes)
+
+            # No-overlap: mark target as processing during injection
+            with binding.consumer.processing(top_wake["target"]):
+                ok = self._adapter.inject_prompt(binding.target, prompt)
 
             if ok:
                 binding.consumer.ack(max_seq)

--- a/tests/recall/test_wake_bridge.py
+++ b/tests/recall/test_wake_bridge.py
@@ -12,7 +12,9 @@ from synapt.recall.channel import (
     channel_read_wakes,
     channel_ack_wakes,
 )
-from synapt.recall.wake_bridge import TmuxAdapter, WakeBridge, _PROMPT_TEMPLATES
+from synapt.recall.wake_bridge import (
+    PromptAdapter, TmuxAdapter, WakeBridge, _PROMPT_TEMPLATES,
+)
 
 
 def _patch_data_dir(tmpdir):
@@ -65,6 +67,12 @@ class TestBuildPrompt(unittest.TestCase):
         wake = {"reason": "user_action", "source": "dashboard", "payload": {"channel": "dev"}}
         prompt = WakeBridge._build_prompt(wake)
         self.assertIn("Layne", prompt)
+
+    def test_channel_substituted_in_prompt(self):
+        wake = {"reason": "channel_activity", "source": "s_writer", "payload": {"channel": "eval"}}
+        prompt = WakeBridge._build_prompt(wake)
+        self.assertIn("#eval", prompt)
+        self.assertNotIn("#dev", prompt)
 
     def test_unknown_reason_falls_back(self):
         wake = {"reason": "unknown_reason", "source": "x", "payload": {}}
@@ -186,6 +194,16 @@ class TestWakeBridge(unittest.TestCase):
 
         self.assertEqual(count, 0)
         self.assertEqual(len(adapter.injections), 1)  # still just 1
+
+
+class TestProtocol(unittest.TestCase):
+    """Adapter Protocol conformance."""
+
+    def test_tmux_adapter_satisfies_protocol(self):
+        self.assertIsInstance(TmuxAdapter(), PromptAdapter)
+
+    def test_fake_adapter_satisfies_protocol(self):
+        self.assertIsInstance(FakeAdapter(), PromptAdapter)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `WakeBridge` polls wake_requests and injects prompts into agent tmux sessions
- `TmuxAdapter` checks pane liveness and sends prompts via `tmux send-keys`
- Coalesced: N wakes for same agent = 1 prompt injection (via WakeConsumer)
- Priority-aware: directive/mention/user_action get different prompt text
- Structured logging with seq range, target, reason per injection

## Design (per Atlas review)
- Dedicated bridge, not overloading `synapt watch`
- Adapter takes opaque target string (`session:window`) for transport flexibility
- Coalescing inherited from WakeConsumer — bridge never sends duplicate prompts
- Prompt templates map wake reason to appropriate urgency text

## Test plan
- [x] 5 prompt template tests (all reasons + unknown fallback)
- [x] `test_tick_injects_on_new_message` — basic injection works
- [x] `test_tick_no_wakes_no_injection` — quiet poll produces nothing
- [x] `test_tick_skips_dead_agent` — dead pane = no injection
- [x] `test_tick_coalesces_multiple_messages` — 3 messages = 1 prompt
- [x] `test_tick_uses_highest_priority_wake` — directive wins over activity
- [x] `test_tick_acks_after_injection` — no redelivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)