### PR TITLE
feat: shared_channels_dir for cross-gripspace channels (#428)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -8,6 +8,11 @@ Any process that can append/read files can participate -- no daemon required.
 External agents that cannot use SQLite can still write JSONL lines directly;
 the SQLite layer is used by agents that import this module.
 
+Cross-gripspace sharing:
+  Set SYNAPT_SHARED_CHANNELS_DIR to a directory accessible by all gripspaces.
+  Channel JSONL logs and attachments use the shared dir; presence/cursor state
+  (channels.db) stays local per gripspace to avoid cross-contamination.
+
 Agent identity: every agent has three layers, but only `id` is passed around.
   - id:           session hash (s_xxxxxxxx), primary key everywhere
   - griptree:     auto-detected (gripspace/repo), stored on join
@@ -45,9 +50,26 @@ _JOIN_MENTION_LOOKBACK_MINUTES = 10  # How far back to scan for @mentions on joi
 # ---------------------------------------------------------------------------
 
 
-def _channels_dir(project_dir: Path | None = None) -> Path:
-    """Return the shared channels directory: <data>/.synapt/recall/channels/."""
+def _shared_channels_dir() -> Path | None:
+    """Return the shared channels directory from env var, or None."""
+    shared = os.environ.get("SYNAPT_SHARED_CHANNELS_DIR")
+    if shared:
+        return Path(shared)
+    return None
+
+
+def _local_channels_dir(project_dir: Path | None = None) -> Path:
+    """Return the local (per-gripspace) channels directory."""
     return project_data_dir(project_dir) / "channels"
+
+
+def _channels_dir(project_dir: Path | None = None) -> Path:
+    """Return the channels directory for JSONL logs and attachments.
+
+    Uses SYNAPT_SHARED_CHANNELS_DIR if set, otherwise falls back to the
+    local per-gripspace directory.
+    """
+    return _shared_channels_dir() or _local_channels_dir(project_dir)
 
 
 def _channel_path(channel: str, project_dir: Path | None = None) -> Path:
@@ -56,13 +78,17 @@ def _channel_path(channel: str, project_dir: Path | None = None) -> Path:
 
 
 def _db_path(project_dir: Path | None = None) -> Path:
-    """Return the SQLite database path for channel state."""
-    return _channels_dir(project_dir) / "channels.db"
+    """Return the SQLite database path for channel state.
+
+    Always uses the local directory — presence, cursors, pins, and mutes
+    are per-gripspace even when channels are shared.
+    """
+    return _local_channels_dir(project_dir) / "channels.db"
 
 
 def _presence_path(project_dir: Path | None = None) -> Path:
     """Return the legacy presence JSON file path (for migration)."""
-    return _channels_dir(project_dir) / "_presence.json"
+    return _local_channels_dir(project_dir) / "_presence.json"
 
 
 def _attachments_dir(project_dir: Path | None = None) -> Path:

--- a/tests/recall/test_channel.py
+++ b/tests/recall/test_channel.py
@@ -1,6 +1,8 @@
 """Tests for synapt.recall.channel -- cross-worktree agent communication."""
 
 import json
+import os
+import shutil
 import sqlite3
 import tempfile
 import time
@@ -13,6 +15,8 @@ from synapt.recall.channel import (
     ChannelMessage,
     _channel_path,
     _channels_dir,
+    _local_channels_dir,
+    _shared_channels_dir,
     _db_path,
     _open_db,
     _read_messages,
@@ -2708,6 +2712,90 @@ class TestStatusBoard(unittest.TestCase):
         conn.close()
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["body"], "v1")
+
+
+class TestSharedChannelsDir(unittest.TestCase):
+    """Test cross-gripspace shared channel directory support."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._shared_dir = Path(self._tmpdir) / "shared_channels"
+        self._shared_dir.mkdir()
+        self._local_dir = Path(self._tmpdir) / "local" / ".synapt" / "recall"
+        self._local_dir.mkdir(parents=True)
+        self._patcher = patch(
+            "synapt.recall.channel.project_data_dir",
+            return_value=self._local_dir,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self._tmpdir)
+
+    def test_channels_dir_defaults_to_local(self):
+        """Without env var, _channels_dir returns local path."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SYNAPT_SHARED_CHANNELS_DIR", None)
+            result = _channels_dir()
+        self.assertEqual(result, self._local_dir / "channels")
+
+    def test_channels_dir_uses_shared_when_set(self):
+        """With SYNAPT_SHARED_CHANNELS_DIR, _channels_dir returns shared path."""
+        with patch.dict(os.environ, {"SYNAPT_SHARED_CHANNELS_DIR": str(self._shared_dir)}):
+            result = _channels_dir()
+        self.assertEqual(result, self._shared_dir)
+
+    def test_db_path_always_local(self):
+        """channels.db stays local even when shared dir is set."""
+        with patch.dict(os.environ, {"SYNAPT_SHARED_CHANNELS_DIR": str(self._shared_dir)}):
+            result = _db_path()
+        self.assertEqual(result, self._local_dir / "channels" / "channels.db")
+
+    def test_channel_path_uses_shared(self):
+        """JSONL log paths use the shared directory."""
+        with patch.dict(os.environ, {"SYNAPT_SHARED_CHANNELS_DIR": str(self._shared_dir)}):
+            result = _channel_path("dev")
+        self.assertEqual(result, self._shared_dir / "dev.jsonl")
+
+    def test_post_and_read_across_gripspaces(self):
+        """Two gripspaces sharing a dir can see each other's messages."""
+        local_a = Path(self._tmpdir) / "grip_a" / ".synapt" / "recall"
+        local_b = Path(self._tmpdir) / "grip_b" / ".synapt" / "recall"
+        local_a.mkdir(parents=True)
+        local_b.mkdir(parents=True)
+
+        with patch.dict(os.environ, {"SYNAPT_SHARED_CHANNELS_DIR": str(self._shared_dir)}):
+            # Gripspace A posts
+            with patch("synapt.recall.channel.project_data_dir", return_value=local_a):
+                channel_join("dev", agent_name="s_agent_a", display_name="AgentA")
+                channel_post("dev", "hello from A", agent_name="s_agent_a")
+
+            # Gripspace B reads
+            with patch("synapt.recall.channel.project_data_dir", return_value=local_b):
+                channel_join("dev", agent_name="s_agent_b", display_name="AgentB")
+                result = channel_read("dev", agent_name="s_agent_b", limit=10)
+
+        self.assertIn("hello from A", result)
+
+    def test_presence_stays_local(self):
+        """Each gripspace has its own presence state."""
+        local_a = Path(self._tmpdir) / "grip_a" / ".synapt" / "recall"
+        local_b = Path(self._tmpdir) / "grip_b" / ".synapt" / "recall"
+        local_a.mkdir(parents=True)
+        local_b.mkdir(parents=True)
+
+        with patch.dict(os.environ, {"SYNAPT_SHARED_CHANNELS_DIR": str(self._shared_dir)}):
+            with patch("synapt.recall.channel.project_data_dir", return_value=local_a):
+                channel_join("dev", agent_name="s_agent_a", display_name="AgentA")
+
+            # Gripspace B's DB should not see agent A's join
+            db_b = local_b / "channels" / "channels.db"
+            self.assertFalse(db_b.exists())
+
+            # But gripspace A's DB has the join
+            db_a = local_a / "channels" / "channels.db"
+            self.assertTrue(db_a.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `SYNAPT_SHARED_CHANNELS_DIR` env var support to channel path resolution
- When set, channel JSONL logs and attachments use the shared directory
- Presence/cursor state (channels.db) stays local per gripspace — no cross-contamination
- Unblocks cross-gripspace communication for Conversa migration

## Changes
- `channel.py`: Split `_channels_dir()` into `_shared_channels_dir()` (env var) + `_local_channels_dir()` (per-gripspace). `_db_path()` and `_presence_path()` always use local.
- `test_channel.py`: 6 new tests covering shared dir routing, local state isolation, and cross-gripspace post/read

## Test plan
- [x] 6 new unit tests pass
- [x] Full test suite (182 tests) passes with no regressions
- [ ] Manual test: set env var, verify two gripspaces share a channel

Closes synapt-dev/gitgrip#428