### PR TITLE
fix: presence collision — human role preserved (#546)

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1254,14 +1254,28 @@ def channel_join(
                     f"({conflict['agent_id']}). Choose a different name."
                 )
 
-        # Upsert presence with identity
-        conn.execute(
-            "INSERT INTO presence (agent_id, griptree, display_name, role, status, last_seen, joined_at) "
-            "VALUES (?, ?, ?, ?, 'online', ?, ?) "
-            "ON CONFLICT(agent_id) DO UPDATE SET status='online', last_seen=?, "
-            "griptree=?, display_name=?, role=?",
-            (aid, griptree, display, role, now, now, now, griptree, display, role),
-        )
+        # Upsert presence with identity.
+        # Role escalation: never downgrade human → agent. A human session
+        # that shares an agent_id with an agent (same griptree) keeps the
+        # human role and display name. Fixes recall#546.
+        existing = conn.execute(
+            "SELECT role, display_name FROM presence WHERE agent_id = ?",
+            (aid,),
+        ).fetchone()
+        if existing and existing["role"] == "human" and role != "human":
+            # Agent joining with a human's agent_id — preserve human identity
+            conn.execute(
+                "UPDATE presence SET status='online', last_seen=? WHERE agent_id=?",
+                (now, aid),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO presence (agent_id, griptree, display_name, role, status, last_seen, joined_at) "
+                "VALUES (?, ?, ?, ?, 'online', ?, ?) "
+                "ON CONFLICT(agent_id) DO UPDATE SET status='online', last_seen=?, "
+                "griptree=?, display_name=?, role=?",
+                (aid, griptree, display, role, now, now, now, griptree, display, role),
+            )
 
         # Add membership
         conn.execute(

--- a/tests/recall/test_presence_collision.py
+++ b/tests/recall/test_presence_collision.py
@@ -1,0 +1,101 @@
+"""Tests for recall#546: presence collision when two sessions share griptree.
+
+TDD — the bug: when a human and an agent session share the same
+griptree (e.g., Layne runs Claude from Opus's workdir), both get
+the same agent_id from _agent_id() and the second join overwrites
+the first's presence (including role).
+
+Fix: channel_join should not overwrite a human's presence with an
+agent's presence when the agent_id matches. Role escalation
+(human > agent) should be preserved.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from synapt.recall.channel import (
+    _open_db,
+    channel_join,
+    channel_who,
+)
+
+
+def _patch_data_dir(tmpdir):
+    data_dir = Path(tmpdir) / "project" / ".synapt" / "recall"
+    return patch(
+        "synapt.recall.channel.project_data_dir",
+        return_value=data_dir,
+    )
+
+
+class TestPresenceCollision(unittest.TestCase):
+    """Presence collision when two sessions share the same agent_id."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._patcher = _patch_data_dir(self._tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_human_presence_not_overwritten_by_agent(self):
+        """An agent joining with same agent_id should not overwrite a human's role."""
+        # Human joins first
+        channel_join("dev", agent_name="shared-id", role="human", display_name="Layne")
+
+        # Agent joins with same agent_id (same griptree, different session)
+        channel_join("dev", agent_name="shared-id", role="agent", display_name="Opus")
+
+        conn = _open_db()
+        row = conn.execute(
+            "SELECT role, display_name FROM presence WHERE agent_id = 'shared-id'"
+        ).fetchone()
+        conn.close()
+
+        # Human role should be preserved (human > agent)
+        self.assertEqual(row["role"], "human")
+
+    def test_agent_can_join_without_overwriting_human_display_name(self):
+        """When an agent shares agent_id with a human, the human's display name is preserved."""
+        channel_join("dev", agent_name="shared-id", role="human", display_name="Layne")
+        channel_join("dev", agent_name="shared-id", role="agent", display_name="Opus")
+
+        conn = _open_db()
+        row = conn.execute(
+            "SELECT display_name FROM presence WHERE agent_id = 'shared-id'"
+        ).fetchone()
+        conn.close()
+
+        # Human's display name should be preserved
+        self.assertEqual(row["display_name"], "Layne")
+
+    def test_who_shows_human_after_agent_collision(self):
+        """channel_who should show the human, not the agent, after a collision."""
+        channel_join("dev", agent_name="shared-id", role="human", display_name="Layne")
+        channel_join("dev", agent_name="shared-id", role="agent", display_name="Opus")
+
+        result = channel_who("dev")
+        self.assertIn("human", result)
+
+    def test_agent_to_agent_overwrites_normally(self):
+        """When two agents share agent_id (no human involved), normal overwrite applies."""
+        channel_join("dev", agent_name="agent-id", role="agent", display_name="Agent1")
+        channel_join("dev", agent_name="agent-id", role="agent", display_name="Agent2")
+
+        conn = _open_db()
+        row = conn.execute(
+            "SELECT display_name FROM presence WHERE agent_id = 'agent-id'"
+        ).fetchone()
+        conn.close()
+
+        # Agent-to-agent: last writer wins
+        self.assertEqual(row["display_name"], "Agent2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
When a human and agent share the same agent_id (same griptree), channel_join no longer overwrites the human's role/display_name. Human > agent role escalation preserved.

## Bug
Layne joins from Opus's workdir → both get same agent_id → Opus's join overwrites Layne's presence as "agent".

## Fix
Check existing presence role before upsert. If existing role is "human" and new role is "agent", only update last_seen timestamp.

## Tests (4, all passing)
- human role not overwritten by agent
- human display_name preserved
- channel_who shows human after collision
- agent-to-agent still overwrites normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)