### PR TITLE
fix: add agent input UI to dashboard template (recall#544)

### DIFF
--- a/src/synapt/dashboard/app.py
+++ b/src/synapt/dashboard/app.py
@@ -77,7 +77,7 @@ def _render_agent_tile(agent: dict) -> str:
     channels = ", ".join(f"#{c}" for c in agent["channels"]) or "no channels"
     seen = agent["last_seen"][11:16] if len(agent["last_seen"]) > 16 else ""
     return (
-        f'<div class="tile" style="border-left:4px solid {color}">'
+        f'<div class="tile clickable" data-agent="{escape(name)}" style="border-left:4px solid {color}">'
         f'<div class="tile-name">{escape(name)}</div>'
         f'<div class="tile-role">{escape(role)}</div>'
         f'<div class="tile-meta">'

--- a/src/synapt/dashboard/template.html
+++ b/src/synapt/dashboard/template.html
@@ -159,6 +159,32 @@
     font-weight: 600;
   }
   #input-bar button:hover { opacity: 0.9; }
+  /* Agent input panel */
+  #agent-input-panel {
+    display: none;
+    padding: 8px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+  #agent-input-panel.active { display: flex; gap: 8px; align-items: flex-end; }
+  #agent-input-panel .agent-target {
+    font-size: 12px; font-weight: 600; color: var(--accent);
+    white-space: nowrap; align-self: center;
+  }
+  #agent-input-panel input[type="text"] {
+    flex: 1; background: var(--bg); color: var(--text);
+    border: 1px solid var(--border); padding: 8px 12px;
+    border-radius: 6px; font-family: inherit; font-size: 13px; outline: none;
+  }
+  #agent-input-panel input[type="text"]:focus { border-color: var(--accent); }
+  #agent-input-panel button {
+    background: var(--accent); color: white; border: none;
+    padding: 8px 16px; border-radius: 6px; cursor: pointer;
+    font-family: inherit; font-size: 13px; font-weight: 600;
+  }
+  .tile.clickable { cursor: pointer; transition: border-color 0.15s; border: 1px solid transparent; }
+  .tile.clickable:hover { border-color: var(--accent); }
+  .tile.clickable.selected { border-color: var(--accent); background: rgba(139,92,246,0.08); }
 </style>
 </head>
 <body>
@@ -173,6 +199,12 @@
 <div id="sse-container" hx-ext="sse" sse-connect="/api/stream?channel=dev">
   <div id="agents" sse-swap="agents" hx-swap="innerHTML">
     <div class="tile empty">Loading agents...</div>
+  </div>
+
+  <div id="agent-input-panel">
+    <span class="agent-target" id="agent-target-label">→ agent</span>
+    <input type="text" id="agent-input-text" placeholder="Send input to agent..." autocomplete="off">
+    <button id="agent-input-send">Send to Agent</button>
   </div>
 
   <div id="feed" sse-swap="messages" hx-swap="beforeend">
@@ -291,6 +323,49 @@ const observer = new MutationObserver(() => {
   feed.scrollTop = feed.scrollHeight;
 });
 observer.observe(feed, { childList: true, subtree: true });
+
+// Agent input panel — click tile to select agent, send input via API
+let selectedAgent = null;
+const agentPanel = document.getElementById('agent-input-panel');
+const agentLabel = document.getElementById('agent-target-label');
+const agentInput = document.getElementById('agent-input-text');
+const agentSendBtn = document.getElementById('agent-input-send');
+
+document.getElementById('agents').addEventListener('click', function(e) {
+  const tile = e.target.closest('.tile');
+  if (!tile || tile.classList.contains('empty')) return;
+  const name = tile.dataset.agent;
+  if (!name) return;
+
+  // Toggle selection
+  document.querySelectorAll('.tile.selected').forEach(t => t.classList.remove('selected'));
+  if (selectedAgent === name) {
+    selectedAgent = null;
+    agentPanel.classList.remove('active');
+    return;
+  }
+  selectedAgent = name;
+  tile.classList.add('selected');
+  agentLabel.textContent = '→ ' + name;
+  agentPanel.classList.add('active');
+  agentInput.focus();
+});
+
+function sendAgentInput() {
+  if (!selectedAgent || !agentInput.value.trim()) return;
+  fetch('/api/agent/' + selectedAgent + '/input', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ text: agentInput.value }),
+  }).then(r => r.json()).then(data => {
+    if (data.ok) agentInput.value = '';
+  });
+}
+
+agentSendBtn.addEventListener('click', sendAgentInput);
+agentInput.addEventListener('keydown', function(e) {
+  if (e.key === 'Enter') { e.preventDefault(); sendAgentInput(); }
+});
 </script>
 
 </body>

--- a/tests/dashboard/test_api.py
+++ b/tests/dashboard/test_api.py
@@ -404,6 +404,34 @@ class TestAdversarialSpawn(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
 
+class TestDashboardTemplateUI(unittest.TestCase):
+    """Verify the dashboard template has required UI elements."""
+
+    def test_template_has_agent_input_panel(self):
+        """Dashboard template contains agent input form (recall#544)."""
+        template_path = Path(__file__).parent.parent.parent / "src" / "synapt" / "dashboard" / "template.html"
+        content = template_path.read_text()
+        self.assertIn("agent-input-panel", content)
+        self.assertIn("agent-input-text", content)
+        self.assertIn("agent-input-send", content)
+        self.assertIn("/api/agent/", content)
+
+    def test_agent_tiles_are_clickable(self):
+        """Agent tile renderer adds clickable class and data-agent attribute."""
+        from synapt.dashboard.app import _render_agent_tile
+        tile_html = _render_agent_tile({
+            "status": "online",
+            "display_name": "Opus",
+            "griptree": "synapt-codex/recall",
+            "agent_id": "s_123",
+            "role": "CTO",
+            "channels": ["dev"],
+            "last_seen": "2026-04-06T17:00:00Z",
+        })
+        self.assertIn("clickable", tile_html)
+        self.assertIn('data-agent="Opus"', tile_html)
+
+
 @pytest.mark.integration
 class TestEndToEnd(unittest.TestCase):
     """End-to-end tests requiring real tmux.


### PR DESCRIPTION
## Summary
P0 bug from Sprint 9 demo: API endpoint existed but HTML template had no input form.

## Changes
- `template.html`: Agent input panel (click tile -> input form, send via API)
- `app.py`: Agent tiles get `clickable` class + `data-agent` attribute
- `test_api.py`: 2 new tests verifying template has input panel and tiles are clickable

## Tests
- 15 pass, 2 skipped (integration)

Closes recall#544