### PR TITLE
fix: add manifest mock to 3 stale test helpers (stops test noise in #dev)

### DIFF
--- a/tests/recall/test_presence_collision.py
+++ b/tests/recall/test_presence_collision.py
@@ -25,11 +25,31 @@ from synapt.recall.channel import (
 
 
 def _patch_data_dir(tmpdir):
+    """Return a combined patcher for project_data_dir + disable global store."""
     data_dir = Path(tmpdir) / "project" / ".synapt" / "recall"
-    return patch(
+    patcher_data = patch(
         "synapt.recall.channel.project_data_dir",
         return_value=data_dir,
     )
+    patcher_manifest = patch(
+        "synapt.recall.channel._read_manifest_url",
+        return_value=None,
+    )
+
+    class _CombinedPatcher:
+        def start(self):
+            patcher_data.start()
+            patcher_manifest.start()
+        def stop(self):
+            patcher_manifest.stop()
+            patcher_data.stop()
+        def __enter__(self):
+            self.start()
+            return self
+        def __exit__(self, *args):
+            self.stop()
+
+    return _CombinedPatcher()
 
 
 class TestPresenceCollision(unittest.TestCase):

--- a/tests/recall/test_wake.py
+++ b/tests/recall/test_wake.py
@@ -17,12 +17,31 @@ from synapt.recall.wake import WakeConsumer, _coalesce_wakes
 
 
 def _patch_data_dir(tmpdir):
-    """Return a patcher for project_data_dir targeting a temp directory."""
+    """Return a combined patcher for project_data_dir + disable global store."""
     data_dir = Path(tmpdir) / "project" / ".synapt" / "recall"
-    return patch(
+    patcher_data = patch(
         "synapt.recall.channel.project_data_dir",
         return_value=data_dir,
     )
+    patcher_manifest = patch(
+        "synapt.recall.channel._read_manifest_url",
+        return_value=None,
+    )
+
+    class _CombinedPatcher:
+        def start(self):
+            patcher_data.start()
+            patcher_manifest.start()
+        def stop(self):
+            patcher_manifest.stop()
+            patcher_data.stop()
+        def __enter__(self):
+            self.start()
+            return self
+        def __exit__(self, *args):
+            self.stop()
+
+    return _CombinedPatcher()
 
 
 class TestCoalesceWakes(unittest.TestCase):

--- a/tests/recall/test_wake_bridge.py
+++ b/tests/recall/test_wake_bridge.py
@@ -18,11 +18,31 @@ from synapt.recall.wake_bridge import (
 
 
 def _patch_data_dir(tmpdir):
+    """Return a combined patcher for project_data_dir + disable global store."""
     data_dir = Path(tmpdir) / "project" / ".synapt" / "recall"
-    return patch(
+    patcher_data = patch(
         "synapt.recall.channel.project_data_dir",
         return_value=data_dir,
     )
+    patcher_manifest = patch(
+        "synapt.recall.channel._read_manifest_url",
+        return_value=None,
+    )
+
+    class _CombinedPatcher:
+        def start(self):
+            patcher_data.start()
+            patcher_manifest.start()
+        def stop(self):
+            patcher_manifest.stop()
+            patcher_data.stop()
+        def __enter__(self):
+            self.start()
+            return self
+        def __exit__(self, *args):
+            self.stop()
+
+    return _CombinedPatcher()
 
 
 class FakeAdapter:


### PR DESCRIPTION
## Summary
3 test files had stale `_patch_data_dir` helpers that only mocked `project_data_dir` but not `_read_manifest_url`. This caused tests to hit the real global channel store, writing garbage messages to #dev.

## Root cause
Sprint 8 fix (#526) updated `_patch_data_dir` in `test_channel.py` but 3 other copies were missed:
- `test_wake.py`
- `test_wake_bridge.py`
- `test_presence_collision.py`

## Fix
All 3 now use the CombinedPatcher pattern that mocks both `project_data_dir` and `_read_manifest_url`.

## Tests
- 220 pass across all 4 affected files