### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.10.1"
+version = "0.10.2"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"


### PR DESCRIPTION
Sprint 8-11 release. Team-verified e2e demo. All 3 agents signed off.