### PR TITLE
fix: skip HF revision-check when model is cached locally

### DIFF
--- a/src/synapt/recall/embeddings.py
+++ b/src/synapt/recall/embeddings.py
@@ -59,7 +59,21 @@ class LocalEmbeddings(EmbeddingProvider):
     def _ensure_model(self) -> None:
         """Load the model on first use, not at init time."""
         if self._model is None:
+            import os
+            from pathlib import Path
             from sentence_transformers import SentenceTransformer
+
+            # Skip the HuggingFace revision-check network call if the model is
+            # already in the local cache.  The cache dir name is deterministic:
+            # models--{org}--{model} with '/' replaced by '--'.
+            hf_cache = Path(
+                os.environ.get("HF_HOME",
+                               os.path.join(os.path.expanduser("~"), ".cache", "huggingface"))
+            ) / "hub"
+            model_cache_name = "models--" + self._model_name.replace("/", "--")
+            if (hf_cache / model_cache_name).exists():
+                os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
             self._model = SentenceTransformer(self._model_name, device=self._device)
             self._dim_cached = self._model.get_sentence_embedding_dimension()
 


### PR DESCRIPTION
## Problem

`recall build --incremental` downloads from HuggingFace on every run even when the `all-MiniLM-L6-v2` model is already fully cached locally. This adds latency and burns bandwidth unnecessarily.

**Root cause**: `sentence-transformers` / `huggingface_hub` always makes a network call to check for newer model revisions, even when the model is present in the local cache.

## Fix

Before loading the model, check if `~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2` exists. If it does, set `HF_HUB_OFFLINE=1` via `os.environ.setdefault()` to skip the revision check.

Key details:
- `setdefault()` respects user overrides — if `HF_HUB_OFFLINE=0` is already set, we don't clobber it
- Cache dir naming is deterministic: `models--{org}--{model}` with `/` replaced by `--`
- Respects `HF_HOME` env var for non-default cache locations

## Test

```bash
# First run (model cached):
synapt recall build --incremental
# Should complete without any HuggingFace network activity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)