### PR TITLE
feat: inject onboarding preamble at session start

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -1704,6 +1704,17 @@ def cmd_hook(args: argparse.Namespace) -> None:
         project = Path.cwd().resolve()
         transcript_all = project_transcript_dirs(project)
 
+        # 0. Onboarding preamble — tell the agent how to catch up
+        print("SessionStart:compact hook success: "
+              "You have synapt recall — persistent memory across sessions. "
+              "Get up to speed before acting:\n"
+              "  1. Read the context below (journal, knowledge, reminders, #dev unread)\n"
+              "  2. recall_quick '<topic>' — fast check before making decisions\n"
+              "  3. recall_search '<query>' — find past decisions, conventions, rationale\n"
+              "  4. recall_channel read #dev — current team status, assignments, blockers\n"
+              "  5. recall_journal — what happened in recent sessions\n"
+              "Do not start work until you understand the current state.")
+
         # 0a. Stale MCP server warning — surface prominently so agent acts (#428)
         try:
             from synapt.recall.server import _check_version_stale


### PR DESCRIPTION
## Summary
- Adds a compact onboarding block as the first output of the `session-start` hook
- Tells agents HOW to use recall to get up to speed before acting
- 6 lines: read context below, then recall_quick, recall_search, recall_channel, recall_journal

## Why
The hook dumps data (journal entries, knowledge nodes, reminders, #dev unread) but never explains the workflow. Fresh agents or agents restarting after a crash see data without context on how to use it. Layne's directive: agents need to use recall to understand how we do things before starting work.

## Output
```
SessionStart:compact hook success: You have synapt recall — persistent memory across sessions. Get up to speed before acting:
  1. Read the context below (journal, knowledge, reminders, #dev unread)
  2. recall_quick '<topic>' — fast check before making decisions
  3. recall_search '<query>' — find past decisions, conventions, rationale
  4. recall_channel read #dev — current team status, assignments, blockers
  5. recall_journal — what happened in recent sessions
Do not start work until you understand the current state.
```

## Test plan
- [x] `python3 -m synapt.recall.cli hook session-start` shows preamble as first output
- [ ] Verify preamble appears in new Claude session context injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)