### PR TITLE
fix: agent posts show wrong name when sharing griptree

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1430,16 +1430,21 @@ def channel_post(
     pin: bool = False,
     attachment_paths: list[str] | None = None,
     channels_dir: Path | None = None,
+    display_name: str | None = None,
 ) -> str:
     """Post a message to a channel. If pin=True, also pin the message.
 
     ``channels_dir`` overrides the JSONL write location so messages can be
     posted to cross-project channels (e.g. from the dashboard switching views).
     DB operations (presence, pins) always use the local gripspace.
+
+    ``display_name`` overrides the presence DB lookup so callers (e.g. MCP
+    tool handler) can pass the agent's declared name directly.  Fixes
+    identity confusion when multiple agents share the same griptree.
     """
     aid = agent_name or _agent_id(project_dir)
     now = _now_iso()
-    display = _resolve_display_name_for(aid, project_dir)
+    display = display_name or _resolve_display_name_for(aid, project_dir)
 
     msg = ChannelMessage(
         timestamp=now, from_agent=aid, from_display=display, channel=channel,
@@ -1968,11 +1973,12 @@ def channel_directive(
     agent_name: str | None = None,
     project_dir: Path | None = None,
     remind: bool = False,
+    display_name: str | None = None,
 ) -> str:
     """Post a directive message targeted at a specific agent."""
     aid = agent_name or _agent_id(project_dir)
     now = _now_iso()
-    display = _resolve_display_name(project_dir)
+    display = display_name or _resolve_display_name(project_dir)
 
     msg = ChannelMessage(
         timestamp=now, from_agent=aid, from_display=display, channel=channel,
@@ -2090,13 +2096,14 @@ def channel_broadcast(
     message: str,
     agent_name: str | None = None,
     project_dir: Path | None = None,
+    display_name: str | None = None,
 ) -> str:
     """Post a message to ALL active channels."""
     channels = channel_list_channels(project_dir)
     if not channels:
         return "No channels to broadcast to."
     for ch in channels:
-        channel_post(ch, message, agent_name=agent_name, project_dir=project_dir)
+        channel_post(ch, message, agent_name=agent_name, project_dir=project_dir, display_name=display_name)
     return f"Broadcast to {len(channels)} channel(s): {', '.join(f'#{c}' for c in channels)}"
 
 

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1941,7 +1941,7 @@ def recall_channel(
             if not message:
                 return "Error: message is required for 'post' action."
             attachment_list = [p.strip() for p in attachments.split(";")] if attachments else None
-            return channel_post(channel=channel, message=message, pin=pin, attachment_paths=attachment_list)
+            return channel_post(channel=channel, message=message, pin=pin, attachment_paths=attachment_list, display_name=name)
 
         if action == "read":
             return channel_read(channel=channel, limit=limit, show_pins=show_pins, detail=detail)
@@ -1979,7 +1979,7 @@ def recall_channel(
                 return "Error: message is required for 'directive' action."
             if not to:
                 return "Error: 'to' (target agent) is required for 'directive' action."
-            return channel_directive(channel=channel, message=message, to=to)
+            return channel_directive(channel=channel, message=message, to=to, display_name=name)
 
         if action == "mute":
             if not target:
@@ -1999,7 +1999,7 @@ def recall_channel(
         if action == "broadcast":
             if not message:
                 return "Error: message is required for 'broadcast' action."
-            return channel_broadcast(message=message)
+            return channel_broadcast(message=message, display_name=name)
 
         if action == "board":
             return channel_board(channel=channel, message=message)


### PR DESCRIPTION
## Summary
- `recall_channel(action="post", name="Sentinel")` was ignoring the `name` param — posts used the presence DB lookup which returns the last joiner's name when agents share a griptree
- Added `display_name` parameter to `channel_post()`, `channel_directive()`, and `channel_broadcast()`
- MCP handler now forwards `name` to all three functions

**Root cause**: `server.py` line 1944 called `channel_post()` without passing `name`. The display name fell back to `_resolve_display_name_for(agent_id)` which looks up the presence table — but agents sharing a griptree share the same `agent_id`, so the last joiner's display name won for everyone.

## Test plan
- [x] 182 channel tests pass
- [ ] Start two agents in the same griptree, both post to #dev with different names → each post shows the correct name
- [ ] Directive and broadcast also show correct sender name

🤖 Generated with [Claude Code](https://claude.com/claude-code)