### PR TITLE
fix: dashboard shows dead agents as online (stale PIDs)

### DIFF
--- a/src/synapt/dashboard/app.py
+++ b/src/synapt/dashboard/app.py
@@ -72,6 +72,15 @@ def _agent_color(name: str) -> str:
     return _agent_color_cache[name]
 
 
+def _is_pid_alive(pid: int) -> bool:
+    """Check if a process with the given PID is still running."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
 def _combined_agents_json() -> list[dict]:
     """Return agents from both team.db (process tracking) and channel presence.
 
@@ -107,6 +116,12 @@ def _combined_agents_json() -> list[dict]:
             for agent in registered:
                 name = agent.get("display_name", "")
                 status = agent.get("status") or "offline"
+                # Verify PID is alive — team.db status can be stale if the
+                # process exited without updating the DB (crash, kill, etc.)
+                pid = agent.get("pid")
+                if status in ("running", "online") and pid:
+                    if not _is_pid_alive(pid):
+                        status = "offline"
                 if status in ("offline", "stopped") and name not in agents_by_name:
                     continue  # Don't show offline agents that aren't in presence
                 if name not in agents_by_name:


### PR DESCRIPTION
## Summary
- Dashboard's `_combined_agents_json()` blindly trusted team.db `status` column — agents that crashed/exited without updating the DB stayed "online" forever
- Added `_is_pid_alive(pid)` check using `os.kill(pid, 0)` before trusting team.db status
- Dead PIDs → status downgraded to "offline" → agent hidden from dashboard
- Verified: 9 stale agents from Conversa + Synapt orgs now correctly filtered

**Root cause**: `gr spawn` writes PIDs and status to `~/.synapt/orgs/<org>/team.db`. When sessions end (kill, crash, tmux detach) the DB isn't updated. The dashboard scanned all org team.db files and showed every agent with `status='online'` regardless of actual process state.

Fixes #586. Closes #587 (duplicate).

## Test plan
- [x] Verified locally: stale Conversa agents (anchor, forge, atlas, opus) and Synapt agents (apollo, sentinel, test) no longer appear
- [ ] Start `gr spawn`, verify agents show as online
- [ ] Kill an agent process, verify it disappears from dashboard on next poll (5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)