### PR TITLE
fix: literal \\n in channel messages instead of newlines

### DIFF
--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -985,6 +985,12 @@ def _append_message(
     When ``channels_dir`` is provided it overrides the normal path resolution
     so the message lands in the correct cross-project channel directory.
     """
+    # Unescape literal \n and \t that LLM tool calls often produce.
+    # MCP arguments are JSON strings, but models sometimes double-escape
+    # newlines (sending "\\n" instead of "\n"), resulting in literal
+    # backslash-n in the body.  Fixes recall#493.
+    if msg.body:
+        msg.body = msg.body.replace("\\n", "\n").replace("\\t", "\t")
     if not msg.id:
         msg.id = _generate_msg_id(msg.timestamp, msg.from_agent, msg.body)
     if channels_dir is not None:


### PR DESCRIPTION
## Summary
- LLM tool calls double-escape newlines: `"\\n"` in JSON arrives as literal backslash-n instead of actual newline
- Added unescape in `_append_message()` for `\n` and `\t` before writing to JSONL
- 73 existing messages in #dev were affected

Fixes #493

## Test plan
- [x] 182 channel tests pass
- [x] Verified: message with literal `\n` now stores and displays as actual newlines
- [ ] Post a multi-line message via MCP tool → renders with real line breaks in dashboard and `channel_read`

🤖 Generated with [Claude Code](https://claude.com/claude-code)