### PR TITLE
feat: implement agent-attributed recall with scoped search

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -150,8 +150,11 @@ class TranscriptChunk:
     byte_offset: int = -1  # Byte position where this turn starts in raw JSONL
     byte_length: int = 0  # Total bytes of raw JSONL entries for this turn
     text: str = ""  # Combined searchable text (built at init)
+    agent_id: str | None = None  # Agent that created this chunk (from SYNAPT_AGENT_ID)
 
     def __post_init__(self):
+        if self.agent_id is None:
+            self.agent_id = os.environ.get("SYNAPT_AGENT_ID")
         if not self.date_text:
             self.date_text = _build_date_text(self.timestamp)
         if not self.text:
@@ -1632,6 +1635,7 @@ class TranscriptIndex:
         max_knowledge: int | None = None,
         min_confidence: float = 0.0,
         context: int = 0,
+        agent_id: str | None = None,
     ) -> str:
         """Search transcripts and return formatted context string.
 
@@ -1686,6 +1690,7 @@ class TranscriptIndex:
             query, max_chunks, max_sessions, after, before,
             half_life, threshold_ratio, depth, include_archived,
             include_historical, now, knowledge_boost, max_knowledge,
+            agent_id,
         )
         cached = self._query_cache.get(cache_key)
         if cached is not None:
@@ -1771,7 +1776,7 @@ class TranscriptIndex:
                 include_historical,
                 emb_weight=emb_weight, knowledge_boost=_knowledge_boost,
                 now=now, max_knowledge=max_knowledge,
-                intent=intent,
+                intent=intent, agent_id=agent_id,
             )
         else:
             result = self._global_lookup(
@@ -1782,6 +1787,7 @@ class TranscriptIndex:
                 emb_weight=emb_weight, knowledge_boost=_knowledge_boost,
                 now=now, max_knowledge=max_knowledge,
                 intent=intent, min_confidence=min_confidence, context=context,
+                agent_id=agent_id,
             )
 
         # Cache the result (LRU eviction when full)
@@ -1813,6 +1819,7 @@ class TranscriptIndex:
         intent: str = "",
         min_confidence: float = 0.0,
         context: int = 0,
+        agent_id: str | None = None,
     ) -> str:
         """Score all chunks globally, return top-K."""
         if self._db and (self._rowid_to_idx or self._db.knowledge_count() > 0):
@@ -1824,11 +1831,12 @@ class TranscriptIndex:
                 emb_weight=emb_weight, knowledge_boost=knowledge_boost,
                 now=now, max_knowledge=max_knowledge, intent=intent,
                 min_confidence=min_confidence, context=context,
+                agent_id=agent_id,
             )
         return self._global_lookup_bm25(
             query, query_tokens, max_chunks, max_tokens, date_filter,
             half_life, threshold_ratio, depth,
-            emb_weight=emb_weight, now=now,
+            emb_weight=emb_weight, now=now, agent_id=agent_id,
         )
 
     def _global_lookup_fts(
@@ -1851,6 +1859,7 @@ class TranscriptIndex:
         intent: str = "",
         min_confidence: float = 0.0,
         context: int = 0,
+        agent_id: str | None = None,
     ) -> str:
         """Global lookup using FTS5 (SQLite backend)."""
         # Extract entities once and share across knowledge + FTS search
@@ -1981,16 +1990,22 @@ class TranscriptIndex:
                         fts_results.append((rowid, score * t3_discount_single))
                         seen_rowids.add(rowid)
 
-        # Convert rowids to chunk indices, applying date and depth filters
+        # Convert rowids to chunk indices, applying date, depth, and agent filters
         candidates: list[tuple[int, float]] = []
+        _agent_filter = agent_id not in (None, "*")
         for rowid, score in fts_results:
             idx = self._rowid_to_idx.get(rowid)
             if idx is None:
                 continue
             if date_filter is not None and idx not in date_filter:
                 continue
+            chunk = self._get_chunk(idx)
             # In summary mode, only include journal chunks (turn_index == -1)
-            if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
+            if depth == "summary" and chunk.turn_index >= 0:
+                continue
+            # Agent scoping: when agent_id is set, only return chunks owned
+            # by this agent or legacy chunks (agent_id=None)
+            if _agent_filter and chunk.agent_id is not None and chunk.agent_id != agent_id:
                 continue
             candidates.append((idx, score))
 
@@ -2030,7 +2045,10 @@ class TranscriptIndex:
                         continue
                     if date_filter is not None and idx not in date_filter:
                         continue
-                    if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
+                    emb_chunk = self._get_chunk(idx)
+                    if depth == "summary" and emb_chunk.turn_index >= 0:
+                        continue
+                    if _agent_filter and emb_chunk.agent_id is not None and emb_chunk.agent_id != agent_id:
                         continue
                     emb_ranked_ref.append((idx, sim))
                     emb_ranked.append((idx, sim))
@@ -2105,6 +2123,7 @@ class TranscriptIndex:
             query=query,
             max_knowledge=max_knowledge,
             intent=intent,
+            agent_id=agent_id,
         )
 
     def _concise_lookup(
@@ -2215,6 +2234,7 @@ class TranscriptIndex:
         depth: str = "full",
         emb_weight: float = 1.0,
         now: datetime | None = None,
+        agent_id: str | None = None,
     ) -> str:
         """Global lookup using in-memory BM25 (legacy fallback)."""
         # BM25 path has no cluster FTS — concise mode requires FTS5
@@ -2232,6 +2252,12 @@ class TranscriptIndex:
         if date_filter is not None:
             for i in range(len(scores)):
                 if i not in date_filter:
+                    scores[i] = 0.0
+
+        # Agent scoping: zero out chunks not owned by this agent
+        if agent_id not in (None, "*"):
+            for i, chunk in enumerate(self.chunks):
+                if chunk.agent_id is not None and chunk.agent_id != agent_id:
                     scores[i] = 0.0
 
         reference_ranked = sorted(
@@ -2301,7 +2327,7 @@ class TranscriptIndex:
         top = self._expand_cross_session(top, max_chunks)
 
         dedup_headroom = _dedup_limit(max_chunks)
-        return self._format_results(top[:dedup_headroom], max_tokens, query=query)
+        return self._format_results(top[:dedup_headroom], max_tokens, query=query, agent_id=agent_id)
 
     def _progressive_lookup(
         self,
@@ -2322,6 +2348,7 @@ class TranscriptIndex:
         now: datetime | None = None,
         max_knowledge: int | None = None,
         intent: str = "",
+        agent_id: str | None = None,
     ) -> str:
         """Search sessions newest-first, stop early if enough hits found."""
         # Knowledge results are always searched globally (not per-session)
@@ -2344,12 +2371,14 @@ class TranscriptIndex:
                 now=now,
                 max_knowledge=max_knowledge,
                 intent=intent,
+                agent_id=agent_id,
             )
         return self._progressive_lookup_bm25(
             query, query_tokens, max_chunks, max_tokens, max_sessions,
             date_filter, half_life, threshold_ratio,
             depth=depth,
             now=now,
+            agent_id=agent_id,
         )
 
     def _progressive_lookup_fts(
@@ -2367,11 +2396,13 @@ class TranscriptIndex:
         now: datetime | None = None,
         max_knowledge: int | None = None,
         intent: str = "",
+        agent_id: str | None = None,
     ) -> str:
         """Progressive session search using FTS5 (SQLite backend)."""
         hits: list[tuple[int, float]] = []
         sessions_searched = 0
         BM25_THRESHOLD = 2.0
+        _agent_filter = agent_id not in (None, "*")
 
         for session_id in self._session_order:
             if sessions_searched >= max_sessions:
@@ -2387,8 +2418,11 @@ class TranscriptIndex:
                     continue
                 if date_filter is not None and idx not in date_filter:
                     continue
+                chunk = self._get_chunk(idx)
                 # In summary mode, skip raw transcript chunks (keep journal only)
-                if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
+                if depth == "summary" and chunk.turn_index >= 0:
+                    continue
+                if _agent_filter and chunk.agent_id is not None and chunk.agent_id != agent_id:
                     continue
                 session_hits.append((idx, score))
 
@@ -2431,7 +2465,10 @@ class TranscriptIndex:
                         continue
                     if date_filter is not None and idx not in date_filter:
                         continue
-                    if depth == "summary" and self._get_chunk(idx).turn_index >= 0:
+                    emb_chunk = self._get_chunk(idx)
+                    if depth == "summary" and emb_chunk.turn_index >= 0:
+                        continue
+                    if _agent_filter and emb_chunk.agent_id is not None and emb_chunk.agent_id != agent_id:
                         continue
                     emb_ranked_ref.append((idx, sim))
                     emb_ranked.append((idx, sim))
@@ -2471,6 +2508,7 @@ class TranscriptIndex:
             query=query,
             max_knowledge=max_knowledge,
             intent=intent,
+            agent_id=agent_id,
         )
 
     def _progressive_lookup_bm25(
@@ -2485,6 +2523,7 @@ class TranscriptIndex:
         threshold_ratio: float,
         depth: str = "full",
         now: datetime | None = None,
+        agent_id: str | None = None,
     ) -> str:
         """Progressive session search using in-memory BM25 (legacy fallback)."""
         bm25_scores = self._bm25.score(query_tokens)
@@ -2493,6 +2532,12 @@ class TranscriptIndex:
         if depth == "summary":
             for i, chunk in enumerate(self.chunks):
                 if chunk.turn_index >= 0:
+                    bm25_scores[i] = 0.0
+
+        # Agent scoping: zero out chunks not owned by this agent
+        if agent_id not in (None, "*"):
+            for i, chunk in enumerate(self.chunks):
+                if chunk.agent_id is not None and chunk.agent_id != agent_id:
                     bm25_scores[i] = 0.0
 
         reference_scores = list(bm25_scores)
@@ -2548,6 +2593,7 @@ class TranscriptIndex:
         return self._format_results(
             hits[:max_chunks], max_tokens,
             query=query,
+            agent_id=agent_id,
         )
 
     def _search_knowledge(
@@ -2958,6 +3004,7 @@ class TranscriptIndex:
         query: str = "",
         max_knowledge: int | None = None,
         intent: str = "",
+        agent_id: str | None = None,
     ) -> str:
         """Format ranked chunk indices into a context string.
 
@@ -3058,6 +3105,9 @@ class TranscriptIndex:
                     if i in ranked_indices:
                         continue
                     chunk = self._get_chunk(i)
+                    # Agent scoping: skip source chunks from other agents
+                    if agent_id not in (None, "*") and chunk.agent_id is not None and chunk.agent_id != agent_id:
+                        continue
                     full_text = (chunk.user_text or "") + " " + (chunk.assistant_text or "")
                     snippet = full_text[begin:end].strip()
                     if not snippet:
@@ -3092,6 +3142,9 @@ class TranscriptIndex:
                             continue
                         chunk = self._get_chunk(i)
                         if chunk.turn_index < 0:
+                            continue
+                        # Agent scoping: skip source chunks from other agents
+                        if agent_id not in (None, "*") and chunk.agent_id is not None and chunk.agent_id != agent_id:
                             continue
                         chunk_toks = set(_tokenize(chunk.text))
                         overlap = len(chunk_toks & match_toks)

--- a/src/synapt/recall/storage.py
+++ b/src/synapt/recall/storage.py
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS chunks (
     transcript_path TEXT NOT NULL DEFAULT '',
     byte_offset INTEGER NOT NULL DEFAULT -1,
     byte_length INTEGER NOT NULL DEFAULT 0,
+    agent_id TEXT,
     embedding BLOB
 );
 
@@ -532,6 +533,7 @@ class RecallDB:
             "transcript_path": "TEXT NOT NULL DEFAULT ''",
             "byte_offset": "INTEGER NOT NULL DEFAULT -1",
             "byte_length": "INTEGER NOT NULL DEFAULT 0",
+            "agent_id": "TEXT",
         }
         for col_name, col_def in new_cols.items():
             if col_name not in cols:
@@ -841,8 +843,8 @@ class RecallDB:
                 "INSERT INTO chunks "
                 "(id, session_id, timestamp, turn_index, user_text, assistant_text, "
                 " tools_used, files_touched, tool_content, date_text, "
-                " transcript_path, byte_offset, byte_length, embedding) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " transcript_path, byte_offset, byte_length, agent_id, embedding) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     chunk.id,
                     chunk.session_id,
@@ -857,6 +859,7 @@ class RecallDB:
                     chunk.transcript_path,
                     chunk.byte_offset,
                     chunk.byte_length,
+                    chunk.agent_id,
                     emb_blob,
                 ),
             )
@@ -880,7 +883,8 @@ class RecallDB:
         rows = self._conn.execute(
             "SELECT id, session_id, timestamp, turn_index, "
             "user_text, assistant_text, tools_used, files_touched, "
-            "tool_content, date_text, transcript_path, byte_offset, byte_length "
+            "tool_content, date_text, transcript_path, byte_offset, byte_length, "
+            "agent_id "
             "FROM chunks ORDER BY rowid"
         ).fetchall()
 
@@ -900,6 +904,7 @@ class RecallDB:
                 transcript_path=r["transcript_path"] or "",
                 byte_offset=r["byte_offset"] if r["byte_offset"] is not None else -1,
                 byte_length=r["byte_length"] if r["byte_length"] is not None else 0,
+                agent_id=r["agent_id"],
             ))
         return chunks
 

--- a/tests/recall/test_attribution.py
+++ b/tests/recall/test_attribution.py
@@ -206,7 +206,7 @@ class TestScopedSearch(unittest.TestCase):
         results = index.lookup("API design", agent_id="opus")
 
         # Should find opus's chunks about API design
-        result_text = " ".join(r for r in results if isinstance(r, str))
+        result_text = results.lower() if isinstance(results, str) else " ".join(results)
         self.assertIn("registration", result_text.lower())
 
         # Should NOT include sentinel's or atlas's raw transcripts
@@ -219,7 +219,7 @@ class TestScopedSearch(unittest.TestCase):
         results = index.lookup("API")
 
         # Should find results from all agents
-        result_text = " ".join(r for r in results if isinstance(r, str))
+        result_text = results.lower() if isinstance(results, str) else " ".join(results)
         # At minimum, should have content from multiple agents
         self.assertTrue(len(results) > 0)
 
@@ -228,7 +228,7 @@ class TestScopedSearch(unittest.TestCase):
         index = self._make_index_with_attributed_chunks()
         results = index.lookup("API", agent_id="sentinel")
 
-        result_text = " ".join(r for r in results if isinstance(r, str))
+        result_text = results.lower() if isinstance(results, str) else " ".join(results)
         # Should find sentinel's security review
         self.assertIn("sanitization", result_text.lower())
         # Should NOT find opus's design or atlas's caching work
@@ -241,7 +241,7 @@ class TestScopedSearch(unittest.TestCase):
         results = index.lookup("project structure", agent_id="opus")
 
         # Legacy chunk (no agent_id) should be visible
-        result_text = " ".join(r for r in results if isinstance(r, str))
+        result_text = results.lower() if isinstance(results, str) else " ".join(results)
         self.assertIn("monorepo", result_text.lower())
 
     def test_knowledge_nodes_always_included(self):
@@ -250,7 +250,7 @@ class TestScopedSearch(unittest.TestCase):
         results = index.lookup("API conventions", agent_id="atlas")
 
         # atlas didn't create this knowledge node, but it's shared
-        result_text = " ".join(r for r in results if isinstance(r, str))
+        result_text = results.lower() if isinstance(results, str) else " ".join(results)
         self.assertIn("conventions", result_text.lower())
 
     def test_wildcard_agent_searches_all_transcripts(self):


### PR DESCRIPTION
## Summary

- Implements the full attribution contract from TDD specs (PR #617)
- `agent_id` field on `TranscriptChunk` with `SYNAPT_AGENT_ID` env var pickup
- SQLite schema migration adds `agent_id TEXT` column to existing databases
- Scoped `lookup(agent_id=...)` filters across all 4 search paths (FTS global/progressive, BM25 global/progressive)
- Agent filtering at 3 levels: candidate selection, embedding search, and knowledge source expansion
- Knowledge nodes remain org-shared regardless of agent_id filter
- Legacy chunks (agent_id=None) visible to all agents
- Wildcard `agent_id="*"` and `agent_id=None` preserve backward compatibility
- Fixed test string-iteration bug: `" ".join(r for r in string)` iterates chars, not words

## Files changed

- `src/synapt/recall/core.py` — TranscriptChunk.agent_id field, __post_init__ env pickup, lookup() agent_id parameter threaded through all search/format paths
- `src/synapt/recall/storage.py` — chunks table schema, save_chunks/load_chunks agent_id, ALTER TABLE migration
- `tests/recall/test_attribution.py` — Fixed result_text extraction (string iteration → direct string check)

## Test plan

- [x] 12/12 attribution tests pass
- [x] Full suite green: 1831 passed, 0 failed
- [x] Scoped search excludes other agents' transcripts
- [x] Legacy chunks visible to all agents
- [x] Knowledge nodes always included (org-shared)
- [x] Backward compatible: no agent_id = search all

🤖 Generated with [Claude Code](https://claude.com/claude-code)