### PR TITLE
feat: DM channels for private agent messaging (recall#488)

### DIFF
--- a/src/synapt/recall/actions.py
+++ b/src/synapt/recall/actions.py
@@ -225,7 +225,7 @@ def _handle_search(**kwargs: Any) -> str:
     message = kwargs.get("message")
     if not message:
         return "Error: query is required for 'search' action."
-    results = channel_search(message)
+    results = channel_search(message, agent_id=kwargs.get("name"))
     if not results:
         return "No matching channel messages."
     lines = ["## Channel search results"]

--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1448,6 +1448,80 @@ def channel_leave(
     return f"Left #{channel}"
 
 
+# ---------------------------------------------------------------------------
+# DM (direct message) channels -- private 1:1 agent-to-agent messaging
+# ---------------------------------------------------------------------------
+
+
+def resolve_dm_channel(agent_a: str, agent_b: str) -> str:
+    """Return the canonical DM channel name for two agents.
+
+    The name is always ``dm:{sorted_first}:{sorted_second}`` so both
+    directions resolve to the same channel.  Self-DMs are rejected.
+    """
+    if agent_a == agent_b:
+        raise ValueError(f"An agent cannot DM itself: {agent_a!r}")
+    first, second = sorted([agent_a, agent_b])
+    return f"dm:{first}:{second}"
+
+
+def resolve_dm_channel_from_shorthand(channel: str, sender: str) -> str:
+    """Resolve a shorthand like ``dm:atlas`` into the canonical DM channel.
+
+    The shorthand encodes only the *recipient*; the sender is supplied
+    separately so the canonical sorted-pair name can be computed.
+    """
+    if not channel.startswith("dm:"):
+        raise ValueError(f"Not a DM shorthand: {channel!r}")
+    parts = channel.split(":")
+    if len(parts) != 2:
+        raise ValueError(
+            f"DM shorthand must be 'dm:<recipient>', got: {channel!r}"
+        )
+    recipient = parts[1]
+    return resolve_dm_channel(sender, recipient)
+
+
+def is_dm_channel(channel: str) -> bool:
+    """Return True if *channel* is a DM channel (``dm:<a>:<b>``)."""
+    parts = channel.split(":")
+    return len(parts) == 3 and parts[0] == "dm"
+
+
+def dm_participants(channel: str) -> tuple[str, str]:
+    """Extract the two participant names from a DM channel name.
+
+    Raises ValueError if *channel* is not a valid DM channel.
+    """
+    if not is_dm_channel(channel):
+        raise ValueError(f"Not a DM channel: {channel!r}")
+    parts = channel.split(":")
+    return (parts[1], parts[2])
+
+
+def is_dm_participant(channel: str, agent_id: str) -> bool:
+    """Return True if *agent_id* is one of the two DM participants."""
+    if not is_dm_channel(channel):
+        return False
+    a, b = dm_participants(channel)
+    return agent_id in (a, b)
+
+
+def list_dm_channels(
+    agent_id: str, project_dir: Path | None = None,
+) -> list[str]:
+    """Return all DM channel names that *agent_id* participates in."""
+    ch_dir = _channels_dir(project_dir)
+    if not ch_dir.exists():
+        return []
+    result = []
+    for p in ch_dir.glob("*.jsonl"):
+        name = p.stem
+        if is_dm_channel(name) and is_dm_participant(name, agent_id):
+            result.append(name)
+    return sorted(result)
+
+
 def channel_post(
     channel: str,
     message: str,
@@ -2412,12 +2486,17 @@ def channel_claim_intent(
 
 
 def channel_list_channels(project_dir: Path | None = None) -> list[str]:
-    """Return list of all channel names (from JSONL files)."""
+    """Return list of all public channel names (from JSONL files).
+
+    DM channels (``dm:*``) are excluded from the global list.
+    Use :func:`list_dm_channels` to discover an agent's DM conversations.
+    """
     ch_dir = _channels_dir(project_dir)
     if not ch_dir.exists():
         return []
     return sorted(
         p.stem for p in ch_dir.glob("*.jsonl")
+        if not is_dm_channel(p.stem)
     )
 
 
@@ -2549,6 +2628,7 @@ def channel_search(
     max_results: int = 10,
     msg_type: str | None = None,
     project_dir: Path | None = None,
+    agent_id: str | None = None,
 ) -> list[dict]:
     """Search all channels for messages matching a query.
 
@@ -2558,6 +2638,9 @@ def channel_search(
         msg_type: Optional filter by message type (e.g. "directive",
                   "message", "join", "leave"). When set, only messages
                   of that type are searched.
+        agent_id: When provided, DM channels are included only if
+                  the agent is a participant.  Without this, DM
+                  channels are excluded from search results.
 
     Returns a list of dicts with channel, message_id, from, timestamp, body,
     type, and a match_score (number of query terms found).
@@ -2569,8 +2652,20 @@ def channel_search(
     # When filtering by type with no query, match all messages of that type
     match_all = not terms
 
+    # Build the list of channels to search: public channels + agent's DMs
+    ch_dir = _channels_dir(project_dir)
+    all_channels: list[str] = []
+    if ch_dir.exists():
+        for p in ch_dir.glob("*.jsonl"):
+            name = p.stem
+            if is_dm_channel(name):
+                if agent_id and is_dm_participant(name, agent_id):
+                    all_channels.append(name)
+            else:
+                all_channels.append(name)
+
     results: list[dict] = []
-    for ch in channel_list_channels(project_dir):
+    for ch in all_channels:
         path = _channel_path(ch, project_dir)
         for msg in _read_messages(path):
             # Type filter
@@ -2598,8 +2693,8 @@ def channel_search(
                 "score": score,
             })
 
-    # Sort by score descending, then timestamp descending
-    results.sort(key=lambda r: (-r["score"], r["timestamp"]), reverse=False)
+    # Sort by score descending, then timestamp descending (newest first)
+    results.sort(key=lambda r: (r["score"], r["timestamp"]), reverse=True)
     return results[:max_results]
 
 

--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1458,7 +1458,15 @@ def resolve_dm_channel(agent_a: str, agent_b: str) -> str:
 
     The name is always ``dm:{sorted_first}:{sorted_second}`` so both
     directions resolve to the same channel.  Self-DMs are rejected.
+    Agent names must be non-empty and must not contain colons (which
+    would break the channel name parsing).
     """
+    if not agent_a or not agent_b:
+        raise ValueError("Agent names must be non-empty")
+    if ":" in agent_a or ":" in agent_b:
+        raise ValueError(
+            f"Agent names must not contain colons: {agent_a!r}, {agent_b!r}"
+        )
     if agent_a == agent_b:
         raise ValueError(f"An agent cannot DM itself: {agent_a!r}")
     first, second = sorted([agent_a, agent_b])


### PR DESCRIPTION
## Summary

- Implements direct message channels based on Sentinel's TDD specs (#632)
- Adds 7 new functions to `channel.py`: `resolve_dm_channel`, `resolve_dm_channel_from_shorthand`, `is_dm_channel`, `dm_participants`, `is_dm_participant`, `list_dm_channels`
- Updates `channel_list_channels` to filter DM channels from the global listing
- Adds `agent_id` parameter to `channel_search` for DM privacy scoping
- Fixes pre-existing sort bug in `channel_search` (was oldest-first within same score, now newest-first as documented)

## Design

DM channels use canonical sorted-pair naming: `dm:atlas:opus` (never `dm:opus:atlas`). Privacy is enforced via naming convention; access control is a string parse, not a database query. This keeps it in the bare-metal primitive tier for OSS.

Shorthand resolution: `dm:atlas` from sender `opus` resolves to `dm:atlas:opus`.

## Test plan

- [x] 18/18 DM tests passing (`tests/recall/test_dm_channels.py`)
- [x] 1901 full suite tests passing, no regressions
- [ ] Verify DM post/read via MCP tool (`recall_channel action=post channel=dm:atlas:opus`)