### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.11.0"
+version = "0.11.1"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"


### PR DESCRIPTION
## Summary
- Bump version from 0.11.0 to 0.11.1 for Sprint 15 ceremony release

## Files changed
- `pyproject.toml` — version field
- `src/synapt/__init__.py` — `__version__` constant