### PR TITLE
release: Sprint 15 ceremony (v0.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to synapt are documented here.
 
+## [0.11.0] — 2026-04-09
+
+### Added
+- **Agent-attributed recall** — `TranscriptChunk` now carries an optional `agent_id` field, auto-populated from `SYNAPT_AGENT_ID` env var. Scoped search via `lookup(agent_id="opus")` returns only that agent's transcripts plus legacy chunks and shared knowledge nodes. Wildcard `agent_id="*"` searches all. (#618)
+- **ActionRegistry for plugin-aware channel dispatch** — new `synapt.recall.actions` module replaces the monolithic if/elif dispatcher in `recall_channel()`. OSS registers 13 base actions; premium plugin can register additional actions or override existing ones at import time. Three-tier status model (available/locked/unknown) for action discovery. (#621, #622)
+- **Structured channel message types** — messages can carry a `msg_type` field (status, claim, pr, code, message) for filtering on read. (#444)
+
+### Improved
+- **Channel dispatch** — `recall_channel()` now routes through the shared ActionRegistry instead of a 150-line hard-coded switch. Net -128 lines in server.py.
+- **SQLite schema migration** — `agent_id TEXT` column added transparently to existing databases via `_migrate_chunks_table()`.
+
 ## [0.6.1] — 2026-03-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.11.0"
+version = "0.11.1"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.10.2"
+version = "0.11.0"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/src/synapt/dashboard/app.py
+++ b/src/synapt/dashboard/app.py
@@ -234,7 +234,10 @@ def _render_message(msg: dict) -> str:
         )
     color = _agent_color(name)
     _MD.reset()
-    body_html = _MD.convert(body)
+    # Escape leading '#' not followed by space — prevents markdown
+    # from turning "#celebrate" into an <h1> heading. (recall#630)
+    body_escaped = re.sub(r'^(#{1,6})(?=[^ #])', r'\\\1', body, flags=re.MULTILINE)
+    body_html = _MD.convert(body_escaped)
     # Color @mentions — skip content inside <code> and <pre> tags
     def _color_mentions(html: str) -> str:
         parts = re.split(r'(<code.*?>.*?</code>|<pre.*?>.*?</pre>)', html, flags=re.DOTALL)

--- a/src/synapt/recall/actions.py
+++ b/src/synapt/recall/actions.py
@@ -225,7 +225,7 @@ def _handle_search(**kwargs: Any) -> str:
     message = kwargs.get("message")
     if not message:
         return "Error: query is required for 'search' action."
-    results = channel_search(message)
+    results = channel_search(message, agent_id=kwargs.get("name"))
     if not results:
         return "No matching channel messages."
     lines = ["## Channel search results"]

--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -1448,6 +1448,88 @@ def channel_leave(
     return f"Left #{channel}"
 
 
+# ---------------------------------------------------------------------------
+# DM (direct message) channels -- private 1:1 agent-to-agent messaging
+# ---------------------------------------------------------------------------
+
+
+def resolve_dm_channel(agent_a: str, agent_b: str) -> str:
+    """Return the canonical DM channel name for two agents.
+
+    The name is always ``dm:{sorted_first}:{sorted_second}`` so both
+    directions resolve to the same channel.  Self-DMs are rejected.
+    Agent names must be non-empty and must not contain colons (which
+    would break the channel name parsing).
+    """
+    if not agent_a or not agent_b:
+        raise ValueError("Agent names must be non-empty")
+    if ":" in agent_a or ":" in agent_b:
+        raise ValueError(
+            f"Agent names must not contain colons: {agent_a!r}, {agent_b!r}"
+        )
+    if agent_a == agent_b:
+        raise ValueError(f"An agent cannot DM itself: {agent_a!r}")
+    first, second = sorted([agent_a, agent_b])
+    return f"dm:{first}:{second}"
+
+
+def resolve_dm_channel_from_shorthand(channel: str, sender: str) -> str:
+    """Resolve a shorthand like ``dm:atlas`` into the canonical DM channel.
+
+    The shorthand encodes only the *recipient*; the sender is supplied
+    separately so the canonical sorted-pair name can be computed.
+    """
+    if not channel.startswith("dm:"):
+        raise ValueError(f"Not a DM shorthand: {channel!r}")
+    parts = channel.split(":")
+    if len(parts) != 2:
+        raise ValueError(
+            f"DM shorthand must be 'dm:<recipient>', got: {channel!r}"
+        )
+    recipient = parts[1]
+    return resolve_dm_channel(sender, recipient)
+
+
+def is_dm_channel(channel: str) -> bool:
+    """Return True if *channel* is a DM channel (``dm:<a>:<b>``)."""
+    parts = channel.split(":")
+    return len(parts) == 3 and parts[0] == "dm"
+
+
+def dm_participants(channel: str) -> tuple[str, str]:
+    """Extract the two participant names from a DM channel name.
+
+    Raises ValueError if *channel* is not a valid DM channel.
+    """
+    if not is_dm_channel(channel):
+        raise ValueError(f"Not a DM channel: {channel!r}")
+    parts = channel.split(":")
+    return (parts[1], parts[2])
+
+
+def is_dm_participant(channel: str, agent_id: str) -> bool:
+    """Return True if *agent_id* is one of the two DM participants."""
+    if not is_dm_channel(channel):
+        return False
+    a, b = dm_participants(channel)
+    return agent_id in (a, b)
+
+
+def list_dm_channels(
+    agent_id: str, project_dir: Path | None = None,
+) -> list[str]:
+    """Return all DM channel names that *agent_id* participates in."""
+    ch_dir = _channels_dir(project_dir)
+    if not ch_dir.exists():
+        return []
+    result = []
+    for p in ch_dir.glob("*.jsonl"):
+        name = p.stem
+        if is_dm_channel(name) and is_dm_participant(name, agent_id):
+            result.append(name)
+    return sorted(result)
+
+
 def channel_post(
     channel: str,
     message: str,
@@ -2412,12 +2494,17 @@ def channel_claim_intent(
 
 
 def channel_list_channels(project_dir: Path | None = None) -> list[str]:
-    """Return list of all channel names (from JSONL files)."""
+    """Return list of all public channel names (from JSONL files).
+
+    DM channels (``dm:*``) are excluded from the global list.
+    Use :func:`list_dm_channels` to discover an agent's DM conversations.
+    """
     ch_dir = _channels_dir(project_dir)
     if not ch_dir.exists():
         return []
     return sorted(
         p.stem for p in ch_dir.glob("*.jsonl")
+        if not is_dm_channel(p.stem)
     )
 
 
@@ -2549,6 +2636,7 @@ def channel_search(
     max_results: int = 10,
     msg_type: str | None = None,
     project_dir: Path | None = None,
+    agent_id: str | None = None,
 ) -> list[dict]:
     """Search all channels for messages matching a query.
 
@@ -2558,6 +2646,9 @@ def channel_search(
         msg_type: Optional filter by message type (e.g. "directive",
                   "message", "join", "leave"). When set, only messages
                   of that type are searched.
+        agent_id: When provided, DM channels are included only if
+                  the agent is a participant.  Without this, DM
+                  channels are excluded from search results.
 
     Returns a list of dicts with channel, message_id, from, timestamp, body,
     type, and a match_score (number of query terms found).
@@ -2569,8 +2660,20 @@ def channel_search(
     # When filtering by type with no query, match all messages of that type
     match_all = not terms
 
+    # Build the list of channels to search: public channels + agent's DMs
+    ch_dir = _channels_dir(project_dir)
+    all_channels: list[str] = []
+    if ch_dir.exists():
+        for p in ch_dir.glob("*.jsonl"):
+            name = p.stem
+            if is_dm_channel(name):
+                if agent_id and is_dm_participant(name, agent_id):
+                    all_channels.append(name)
+            else:
+                all_channels.append(name)
+
     results: list[dict] = []
-    for ch in channel_list_channels(project_dir):
+    for ch in all_channels:
         path = _channel_path(ch, project_dir)
         for msg in _read_messages(path):
             # Type filter
@@ -2598,8 +2701,8 @@ def channel_search(
                 "score": score,
             })
 
-    # Sort by score descending, then timestamp descending
-    results.sort(key=lambda r: (-r["score"], r["timestamp"]), reverse=False)
+    # Sort by score descending, then timestamp descending (newest first)
+    results.sort(key=lambda r: (r["score"], r["timestamp"]), reverse=True)
     return results[:max_results]
 
 

--- a/src/synapt/recall/channel.py
+++ b/src/synapt/recall/channel.py
@@ -177,9 +177,27 @@ def _channels_dir(project_dir: Path | None = None) -> Path:
     return _local_channels_dir(project_dir)
 
 
+def _channel_to_filename(channel: str) -> str:
+    """Encode a channel name for use as a filename (Windows-safe)."""
+    return channel.replace(":", "--")
+
+
+def _filename_to_channel(stem: str) -> str:
+    """Decode a filename stem back to a channel name."""
+    return stem.replace("--", ":")
+
+
 def _channel_path(channel: str, project_dir: Path | None = None) -> Path:
     """Return the JSONL log path for a channel."""
-    return _channels_dir(project_dir) / f"{channel}.jsonl"
+    ch_dir = _channels_dir(project_dir)
+    safe_name = _channel_to_filename(channel)
+    new_path = ch_dir / f"{safe_name}.jsonl"
+    # Migrate legacy colon-format files (not valid on Windows)
+    if ":" in channel and not new_path.exists():
+        old_path = ch_dir / f"{channel}.jsonl"
+        if old_path.exists():
+            old_path.rename(new_path)
+    return new_path
 
 
 def _db_path(project_dir: Path | None = None) -> Path:
@@ -1008,7 +1026,7 @@ def _append_message(
     if not msg.id:
         msg.id = _generate_msg_id(msg.timestamp, msg.from_agent, msg.body)
     if channels_dir is not None:
-        path = channels_dir / f"{msg.channel}.jsonl"
+        path = channels_dir / f"{_channel_to_filename(msg.channel)}.jsonl"
     else:
         path = _channel_path(msg.channel, project_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1524,7 +1542,7 @@ def list_dm_channels(
         return []
     result = []
     for p in ch_dir.glob("*.jsonl"):
-        name = p.stem
+        name = _filename_to_channel(p.stem)
         if is_dm_channel(name) and is_dm_participant(name, agent_id):
             result.append(name)
     return sorted(result)
@@ -2503,8 +2521,8 @@ def channel_list_channels(project_dir: Path | None = None) -> list[str]:
     if not ch_dir.exists():
         return []
     return sorted(
-        p.stem for p in ch_dir.glob("*.jsonl")
-        if not is_dm_channel(p.stem)
+        _filename_to_channel(p.stem) for p in ch_dir.glob("*.jsonl")
+        if not is_dm_channel(_filename_to_channel(p.stem))
     )
 
 
@@ -2601,7 +2619,7 @@ def channel_messages_json(
     ``channels_dir`` overrides path resolution for cross-project reads.
     ``msg_type`` filters to messages of a specific type (e.g. "status", "claim", "pr").
     """
-    path = (channels_dir / f"{channel}.jsonl") if channels_dir else _channel_path(channel, project_dir)
+    path = (channels_dir / f"{_channel_to_filename(channel)}.jsonl") if channels_dir else _channel_path(channel, project_dir)
     if not path.exists():
         return []
     messages = _read_messages(path, since=since)
@@ -2665,7 +2683,7 @@ def channel_search(
     all_channels: list[str] = []
     if ch_dir.exists():
         for p in ch_dir.glob("*.jsonl"):
-            name = p.stem
+            name = _filename_to_channel(p.stem)
             if is_dm_channel(name):
                 if agent_id and is_dm_participant(name, agent_id):
                     all_channels.append(name)

--- a/tests/recall/test_dm_channels.py
+++ b/tests/recall/test_dm_channels.py
@@ -1,0 +1,302 @@
+"""Tests for direct messages between agents — private 1:1 channels.
+
+TDD spec for recall#488 (DMs between agents). These tests define
+the contract for private agent-to-agent messaging via the dm: channel prefix.
+
+All tests are expected to FAIL until the implementation lands.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestDMChannelNaming(unittest.TestCase):
+    """DM channels should use a canonical sorted-pair naming scheme."""
+
+    def test_dm_channel_name_is_sorted_pair(self):
+        """dm:atlas from opus should resolve to the same channel as dm:opus from atlas."""
+        from synapt.recall.channel import resolve_dm_channel
+
+        # Both directions should produce the same canonical name
+        name_a = resolve_dm_channel("opus", "atlas")
+        name_b = resolve_dm_channel("atlas", "opus")
+        self.assertEqual(name_a, name_b)
+
+    def test_dm_channel_name_format(self):
+        """DM channel names should follow dm:{agent_a}:{agent_b} (sorted)."""
+        from synapt.recall.channel import resolve_dm_channel
+
+        name = resolve_dm_channel("opus", "atlas")
+        self.assertEqual(name, "dm:atlas:opus")
+
+    def test_dm_channel_name_is_deterministic(self):
+        """Same pair always produces the same channel name."""
+        from synapt.recall.channel import resolve_dm_channel
+
+        results = {resolve_dm_channel("sentinel", "opus") for _ in range(10)}
+        self.assertEqual(len(results), 1)
+
+    def test_dm_self_is_rejected(self):
+        """An agent cannot DM itself."""
+        from synapt.recall.channel import resolve_dm_channel
+
+        with self.assertRaises(ValueError):
+            resolve_dm_channel("opus", "opus")
+
+
+class TestDMPostAndRead(unittest.TestCase):
+    """DMs should use the same post/read mechanics as regular channels."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._env_patch = patch.dict(os.environ, {
+            "SYNAPT_PROJECT_DIR": self.tmpdir,
+        })
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_post_to_dm_channel(self):
+        """Posting to dm:atlas should create a message in the DM channel."""
+        from synapt.recall.channel import channel_post, resolve_dm_channel
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        result = channel_post(
+            channel=dm_channel,
+            message="thoughts on the worktree model?",
+            display_name="opus",
+        )
+        self.assertIsInstance(result, str)
+        self.assertNotIn("error", result.lower())
+
+    def test_read_dm_channel(self):
+        """Reading a DM channel should return messages between the two agents."""
+        from synapt.recall.channel import channel_post, channel_read, resolve_dm_channel
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        channel_post(
+            channel=dm_channel,
+            message="design review?",
+            display_name="opus",
+        )
+        result = channel_read(channel=dm_channel, limit=10)
+        self.assertIn("design review", result.lower())
+
+    def test_dm_shorthand_resolves_to_canonical(self):
+        """action='post', channel='dm:atlas' should resolve via the sender's identity."""
+        from synapt.recall.channel import resolve_dm_channel_from_shorthand
+
+        # When opus types channel="dm:atlas", we need to resolve that
+        # to the canonical dm:atlas:opus channel name
+        resolved = resolve_dm_channel_from_shorthand("dm:atlas", sender="opus")
+        self.assertEqual(resolved, "dm:atlas:opus")
+
+    def test_dm_shorthand_symmetric(self):
+        """dm:opus from atlas resolves to the same channel as dm:atlas from opus."""
+        from synapt.recall.channel import resolve_dm_channel_from_shorthand
+
+        a = resolve_dm_channel_from_shorthand("dm:atlas", sender="opus")
+        b = resolve_dm_channel_from_shorthand("dm:opus", sender="atlas")
+        self.assertEqual(a, b)
+
+
+class TestDMPrivacy(unittest.TestCase):
+    """DMs should only be readable by the two participants."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._env_patch = patch.dict(os.environ, {
+            "SYNAPT_PROJECT_DIR": self.tmpdir,
+        })
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_dm_not_visible_in_channel_list_for_non_participants(self):
+        """DM channels should not appear in channel_list_channels for non-participants."""
+        from synapt.recall.channel import (
+            channel_list_channels,
+            channel_post,
+            resolve_dm_channel,
+        )
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        channel_post(channel=dm_channel, message="private msg", display_name="opus")
+
+        # sentinel is not a participant — DM should not appear in their list
+        channels = channel_list_channels()
+        dm_channels = [c for c in channels if c.startswith("dm:")]
+        # DMs should either not appear at all in the global list,
+        # or be filtered when queried by a non-participant
+        # Implementation may choose either approach
+        self.assertTrue(
+            len(dm_channels) == 0 or dm_channel not in dm_channels,
+            "DM channel should not be visible to non-participants in channel list"
+        )
+
+    def test_dm_readable_by_participant(self):
+        """A DM participant should be able to read their DM channel."""
+        from synapt.recall.channel import (
+            channel_post,
+            channel_read,
+            is_dm_participant,
+            resolve_dm_channel,
+        )
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        channel_post(channel=dm_channel, message="secret plan", display_name="opus")
+
+        self.assertTrue(is_dm_participant(dm_channel, "opus"))
+        self.assertTrue(is_dm_participant(dm_channel, "atlas"))
+        self.assertFalse(is_dm_participant(dm_channel, "sentinel"))
+
+    def test_dm_not_in_global_unread(self):
+        """DMs should not appear in the global unread check for non-participants."""
+        from synapt.recall.channel import (
+            channel_post,
+            resolve_dm_channel,
+        )
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        channel_post(channel=dm_channel, message="private", display_name="opus")
+
+        # Non-participant unread should not include this DM
+        # (exact API depends on how unread is scoped — may need agent_id param)
+
+
+class TestDMDiscovery(unittest.TestCase):
+    """Agents should be able to discover their own DM conversations."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._env_patch = patch.dict(os.environ, {
+            "SYNAPT_PROJECT_DIR": self.tmpdir,
+        })
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_list_my_dms(self):
+        """An agent should be able to list their active DM conversations."""
+        from synapt.recall.channel import (
+            channel_post,
+            list_dm_channels,
+            resolve_dm_channel,
+        )
+
+        dm1 = resolve_dm_channel("opus", "atlas")
+        dm2 = resolve_dm_channel("opus", "sentinel")
+        channel_post(channel=dm1, message="hello atlas", display_name="opus")
+        channel_post(channel=dm2, message="hello sentinel", display_name="opus")
+
+        # opus should see both DM channels
+        opus_dms = list_dm_channels(agent_id="opus")
+        self.assertEqual(len(opus_dms), 2)
+
+        # atlas should see only their DM with opus
+        atlas_dms = list_dm_channels(agent_id="atlas")
+        self.assertEqual(len(atlas_dms), 1)
+        self.assertIn(dm1, atlas_dms)
+
+    def test_list_dms_returns_empty_for_no_conversations(self):
+        """An agent with no DMs should get an empty list."""
+        from synapt.recall.channel import list_dm_channels
+
+        dms = list_dm_channels(agent_id="apollo")
+        self.assertEqual(len(dms), 0)
+
+
+class TestDMChannelDetection(unittest.TestCase):
+    """The system should be able to distinguish DM channels from regular channels."""
+
+    def test_is_dm_channel(self):
+        """Channels prefixed with dm: should be detected as DM channels."""
+        from synapt.recall.channel import is_dm_channel
+
+        self.assertTrue(is_dm_channel("dm:atlas:opus"))
+        self.assertTrue(is_dm_channel("dm:opus:sentinel"))
+        self.assertFalse(is_dm_channel("dev"))
+        self.assertFalse(is_dm_channel("general"))
+        self.assertFalse(is_dm_channel("dm-discussion"))
+
+    def test_dm_participants_from_channel_name(self):
+        """Should extract the two participant names from a DM channel name."""
+        from synapt.recall.channel import dm_participants
+
+        a, b = dm_participants("dm:atlas:opus")
+        self.assertEqual({a, b}, {"atlas", "opus"})
+
+    def test_dm_participants_invalid_channel_raises(self):
+        """Extracting participants from a non-DM channel should raise."""
+        from synapt.recall.channel import dm_participants
+
+        with self.assertRaises(ValueError):
+            dm_participants("dev")
+
+
+class TestDMInRecallSearch(unittest.TestCase):
+    """DM content should be searchable by participants but not by others."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._env_patch = patch.dict(os.environ, {
+            "SYNAPT_PROJECT_DIR": self.tmpdir,
+        })
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_dm_content_searchable_by_participant(self):
+        """DM messages should appear in channel_search for participants."""
+        from synapt.recall.channel import (
+            channel_post,
+            channel_search,
+            resolve_dm_channel,
+        )
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        channel_post(
+            channel=dm_channel,
+            message="the worktree migration needs atomic swaps",
+            display_name="opus",
+        )
+
+        results = channel_search("worktree migration", agent_id="opus")
+        bodies = [r["body"] for r in results]
+        self.assertTrue(
+            any("worktree migration" in b.lower() for b in bodies),
+            "DM content should be searchable by participant"
+        )
+
+    def test_dm_content_not_searchable_by_non_participant(self):
+        """DM messages should NOT appear in channel_search for non-participants."""
+        from synapt.recall.channel import (
+            channel_post,
+            channel_search,
+            resolve_dm_channel,
+        )
+
+        dm_channel = resolve_dm_channel("opus", "atlas")
+        channel_post(
+            channel=dm_channel,
+            message="secret licensing discussion about vendor X",
+            display_name="opus",
+        )
+
+        results = channel_search("secret licensing", agent_id="sentinel")
+        bodies = [r["body"] for r in results] if results else []
+        self.assertFalse(
+            any("secret licensing" in b.lower() for b in bodies),
+            "DM content should NOT be searchable by non-participants"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Sprint 15 ceremony release: DM channels, hashtag fix, version bump to 0.11.1.

### PRs included
- #631 — fix: preserve hashtag prefix in channel messages
- #632 — test: TDD specs for direct messages between agents (recall#488)
- #635 — feat: DM channels for private agent messaging (recall#488)
- #641 — chore: bump version to 0.11.1

### Highlights
- **DM channels**: Private agent-to-agent messaging via `dm:{sorted_a}:{sorted_b}` naming convention. Includes `resolve_dm_channel`, `is_dm_channel`, `dm_participants`, `is_dm_participant`, `list_dm_channels`, `resolve_dm_channel_from_shorthand`. DMs filtered from `channel_list_channels`, searchable only by participants.
- **Hashtag fix**: Channel names with `#` prefix now preserved correctly in messages.
- **Search sort fix**: Results now sort newest-first within same relevance score.

### Test results
- 1901 passed, 5 pre-existing failures (dashboard deps), 15 pre-existing errors (benchmark deps)
- 0 new failures, 0 new lint issues
- All 18 DM TDD specs passing

### Retro
All three agents (Opus, Apollo, Atlas) posted retro sections on #dev.

## Test plan
- [x] Full test suite: 1901 passed
- [x] DM channel tests: 18/18 passing
- [x] Lint check: 0 new issues
- [x] Version bump verified: 0.11.1