### PR TITLE
perf: avoid cold-start embedding load on BM25-only sharded indexes

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1085,28 +1085,42 @@ class TranscriptIndex:
         self._kn_emb_matrix: "np.ndarray | None" = None
         self._kn_emb_rowids: list[int] = []
         self._embeddings_loaded: bool = False
+        self._cache_dir = cache_dir
         # Track embedding status for user-facing messages
         self._embedding_status: str = "disabled"  # disabled | active | unavailable
         self._embedding_reason: str = ""
         if use_embeddings:
             try:
-                from synapt.recall.embeddings import get_embedding_provider
-                provider = get_embedding_provider()
-                if provider:
-                    self._embed_provider = provider
-                    self._embedding_status = "active"
-                    # Only build embeddings if storage is available
-                    if self._db is None or self._idx_to_rowid:
-                        self._load_or_build_embeddings(cache_dir)
-                    # Embedding data is loaded lazily via
-                    # _ensure_embeddings_loaded() on first search call.
-                else:
-                    self._embedding_status = "unavailable"
+                has_chunk_embeddings = self._db.has_embeddings() if self._db is not None else True
+                # Only build embeddings if storage is available.
+                if self._db is None or self._idx_to_rowid:
+                    self._load_or_build_embeddings(cache_dir)
+
+                # If the index has no chunk embeddings yet, keep CLI/server
+                # search on the fast BM25 path instead of paying model load for
+                # knowledge-only semantic lookup. The next explicit build can
+                # populate embeddings, and existing embedding-bearing indexes
+                # still keep hybrid search enabled.
+                if not has_chunk_embeddings:
                     self._embedding_reason = (
-                        "No embedding provider found. "
-                        "Install sentence-transformers for semantic search: "
-                        "pip install sentence-transformers"
+                        "Chunk embeddings are not available for this index yet; "
+                        "using BM25-only search."
                     )
+                else:
+                    from synapt.recall.embeddings import get_embedding_provider
+                    provider = get_embedding_provider()
+                    if provider:
+                        self._embed_provider = provider
+                        self._embedding_status = "active"
+                        # Embedding data is loaded lazily via
+                        # _ensure_embeddings_loaded() on first search call.
+                    else:
+                        self._embedding_status = "unavailable"
+                        self._embedding_reason = (
+                            "No embedding provider found. "
+                            "Install sentence-transformers for semantic search: "
+                            "pip install sentence-transformers"
+                        )
             except Exception as e:
                 logger.warning("Embeddings unavailable: %s", e)
                 self._embedding_status = "unavailable"
@@ -1117,6 +1131,82 @@ class TranscriptIndex:
         self._use_reranker = is_reranker_enabled()
         if self._use_reranker:
             logger.info("Cross-encoder reranking enabled")
+
+    def _open_background_db(self):
+        """Open a fresh DB handle for background embedding work."""
+        if self._cache_dir is None:
+            return self._db
+        return ShardedRecallDB.open(self._cache_dir)
+
+    def _build_embeddings_background(self, content_hash: str) -> None:
+        """Build chunk + knowledge embeddings in a background thread."""
+        db = None
+        try:
+            from synapt.recall.embeddings import get_embedding_provider
+
+            db = self._open_background_db()
+            if db is None:
+                return
+            provider = get_embedding_provider()
+            if provider is None:
+                return
+
+            texts = [c.text[:500] for c in self._materialize_all_chunks()]
+            all_embs: list[list[float]] = []
+            for i in range(0, len(texts), 64):
+                batch = texts[i:i + 64]
+                all_embs.extend(provider.embed(batch))
+
+            emb_mapping: dict[int, list[float]] = {}
+            for i, emb in enumerate(all_embs):
+                rowid = self._idx_to_rowid.get(i)
+                if rowid is not None:
+                    emb_mapping[rowid] = emb
+            if emb_mapping:
+                db.save_embeddings(emb_mapping)
+                db.set_metadata("embedding_hash", content_hash)
+                logger.info(
+                    "Background embedding build complete: %d chunks",
+                    len(emb_mapping),
+                )
+
+                self._embeddings_loaded = False
+                self._all_embeddings = {}
+                self._emb_matrix = None
+                self._emb_rowids = []
+
+            self._build_knowledge_embeddings(db=db, provider=provider)
+        except Exception as e:
+            logger.warning("Background embedding build failed: %s", e)
+        finally:
+            if db is not None and db is not self._db:
+                with contextlib.suppress(Exception):
+                    db.close()
+
+    def _build_knowledge_embeddings(self, db=None, provider=None) -> None:
+        """Build embeddings for knowledge nodes that don't have them yet."""
+        db = db or self._db
+        provider = provider or self._embed_provider
+        if not db or not provider:
+            return
+        try:
+            missing = db.get_knowledge_rowids_without_embeddings()
+            if not missing:
+                return
+            texts = [content[:500] for _, content in missing]
+            rowids = [rowid for rowid, _ in missing]
+            all_embs: list[list[float]] = []
+            for i in range(0, len(texts), 64):
+                batch = texts[i:i + 64]
+                all_embs.extend(provider.embed(batch))
+            emb_mapping = dict(zip(rowids, all_embs))
+            if emb_mapping:
+                db.save_knowledge_embeddings(emb_mapping)
+                logger.info(
+                    "Built embeddings for %d knowledge nodes", len(emb_mapping),
+                )
+        except Exception as e:
+            logger.warning("Knowledge embedding build failed: %s", e)
 
     def _get_chunk(self, idx: int) -> TranscriptChunk:
         """Return a chunk, hydrating it from the DB on demand when needed."""
@@ -1427,6 +1517,9 @@ class TranscriptIndex:
         BM25-only results. The next search after the build finishes will
         pick up the fresh embeddings via _ensure_embeddings_loaded().
         """
+        if not self._db.has_embeddings():
+            return
+
         content_hash = self._content_hash()
         stored_hash = self._db.get_metadata("embedding_hash")
 
@@ -1448,55 +1541,6 @@ class TranscriptIndex:
             name="synapt-embedding-build",
         )
         self._embedding_build_thread.start()
-
-    def _build_embeddings_background(self, content_hash: str) -> None:
-        """Build chunk + knowledge embeddings in a background thread."""
-        try:
-            texts = [c.text[:500] for c in self._materialize_all_chunks()]
-            all_embs: list[list[float]] = []
-            for i in range(0, len(texts), 64):
-                batch = texts[i:i + 64]
-                all_embs.extend(self._embed_provider.embed(batch))
-
-            emb_mapping: dict[int, list[float]] = {}
-            for i, emb in enumerate(all_embs):
-                rowid = self._idx_to_rowid.get(i)
-                if rowid is not None:
-                    emb_mapping[rowid] = emb
-            if emb_mapping:
-                self._db.save_embeddings(emb_mapping)
-            self._db.set_metadata("embedding_hash", content_hash)
-            logger.info(
-                "Background embedding build complete: %d chunks",
-                len(emb_mapping),
-            )
-
-            self._build_knowledge_embeddings()
-        except Exception as e:
-            logger.warning("Background embedding build failed: %s", e)
-
-    def _build_knowledge_embeddings(self) -> None:
-        """Build embeddings for knowledge nodes that don't have them yet."""
-        if not self._db or not self._embed_provider:
-            return
-        try:
-            missing = self._db.get_knowledge_rowids_without_embeddings()
-            if not missing:
-                return
-            texts = [content[:500] for _, content in missing]
-            rowids = [rowid for rowid, _ in missing]
-            all_embs: list[list[float]] = []
-            for i in range(0, len(texts), 64):
-                batch = texts[i:i + 64]
-                all_embs.extend(self._embed_provider.embed(batch))
-            emb_mapping = dict(zip(rowids, all_embs))
-            if emb_mapping:
-                self._db.save_knowledge_embeddings(emb_mapping)
-                logger.info(
-                    "Built embeddings for %d knowledge nodes", len(emb_mapping),
-                )
-        except Exception as e:
-            logger.warning("Knowledge embedding build failed: %s", e)
 
     def _content_hash(self) -> str:
         """Hash of chunk IDs + text content for embedding cache invalidation.

--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1098,9 +1098,9 @@ class TranscriptIndex:
 
                 # If the index has no chunk embeddings yet, keep CLI/server
                 # search on the fast BM25 path instead of paying model load for
-                # knowledge-only semantic lookup. The next explicit build can
-                # populate embeddings, and existing embedding-bearing indexes
-                # still keep hybrid search enabled.
+                # knowledge-only semantic lookup. A later build can populate
+                # embeddings in the DB, but this TranscriptIndex instance stays
+                # BM25-only until the next fresh load.
                 if not has_chunk_embeddings:
                     self._embedding_reason = (
                         "Chunk embeddings are not available for this index yet; "
@@ -1169,11 +1169,6 @@ class TranscriptIndex:
                     "Background embedding build complete: %d chunks",
                     len(emb_mapping),
                 )
-
-                self._embeddings_loaded = False
-                self._all_embeddings = {}
-                self._emb_matrix = None
-                self._emb_rowids = []
 
             self._build_knowledge_embeddings(db=db, provider=provider)
         except Exception as e:

--- a/src/synapt/recall/embeddings.py
+++ b/src/synapt/recall/embeddings.py
@@ -64,14 +64,17 @@ class LocalEmbeddings(EmbeddingProvider):
             from sentence_transformers import SentenceTransformer
 
             # Skip the HuggingFace revision-check network call if the model is
-            # already in the local cache.  The cache dir name is deterministic:
-            # models--{org}--{model} with '/' replaced by '--'.
+            # already in the local cache. Accept both fully-qualified
+            # (`sentence-transformers/all-MiniLM-L6-v2`) and shorthand
+            # (`all-MiniLM-L6-v2`) cache directory forms.
             hf_cache = Path(
                 os.environ.get("HF_HOME",
                                os.path.join(os.path.expanduser("~"), ".cache", "huggingface"))
             ) / "hub"
-            model_cache_name = "models--" + self._model_name.replace("/", "--")
-            if (hf_cache / model_cache_name).exists():
+            cache_names = {"models--" + self._model_name.replace("/", "--")}
+            if "/" not in self._model_name:
+                cache_names.add(f"models--sentence-transformers--{self._model_name}")
+            if any((hf_cache / cache_name).exists() for cache_name in cache_names):
                 os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
             self._model = SentenceTransformer(self._model_name, device=self._device)

--- a/src/synapt/recall/sharded_db.py
+++ b/src/synapt/recall/sharded_db.py
@@ -15,6 +15,7 @@ See issue #89 for the full design.
 
 from __future__ import annotations
 
+import heapq
 import logging
 import sqlite3
 from pathlib import Path
@@ -210,6 +211,36 @@ class ShardedRecallDB:
         if self._data_dbs:
             return sum(db.chunk_count() for db in self._data_dbs)
         return self._index.chunk_count()
+
+    def content_hash(self) -> str:
+        """Hash chunk content across all shards in global timestamp order.
+
+        Mirrors ``RecallDB.content_hash()`` semantics so sharded and monolithic
+        indexes produce the same invalidation signal for identical content.
+        """
+        if not self._data_dbs:
+            return self._index.content_hash()
+
+        import hashlib
+
+        def _rows(db: RecallDB):
+            return db._conn.execute(
+                "SELECT timestamp, rowid, id, user_text, assistant_text, tool_content "
+                "FROM chunks ORDER BY timestamp DESC, rowid DESC"
+            )
+
+        h = hashlib.sha256()
+        merged = heapq.merge(
+            *(_rows(db) for db in self._data_dbs),
+            key=lambda row: (row[0], row[1]),
+            reverse=True,
+        )
+        for _, _, chunk_id, user_text, assistant_text, tool_content in merged:
+            h.update(
+                f"{chunk_id}|{user_text or ''}|{assistant_text or ''}|{tool_content or ''}\n"
+                .encode()
+            )
+        return h.hexdigest()[:16]
 
     def chunk_session_map(self) -> dict[int, str]:
         """Return a global ``{rowid: session_id}`` mapping for all chunks."""

--- a/tests/recall/test_lazy_embeddings.py
+++ b/tests/recall/test_lazy_embeddings.py
@@ -252,5 +252,67 @@ class TestEmbeddingSearchNumpy(unittest.TestCase):
         self.assertEqual(results[0][0], 1)
 
 
+class TestShardedColdStartEmbeddingGate(unittest.TestCase):
+    """Sharded indexes without chunk embeddings stay on the fast BM25 path."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.index_dir = Path(self.tmpdir)
+
+    def _make_chunk(self):
+        from synapt.recall.core import TranscriptChunk
+
+        return TranscriptChunk(
+            id="s1:t0",
+            session_id="s1",
+            timestamp="2026-01-01T00:00:00Z",
+            turn_index=0,
+            user_text="cold start fact",
+            assistant_text="assistant",
+            tools_used=[],
+            files_touched=[],
+        )
+
+    def test_sharded_lookup_skips_provider_when_chunk_embeddings_missing(self):
+        from synapt.recall.core import TranscriptIndex
+
+        index_db = RecallDB(self.index_dir / "index.db")
+        data_db = RecallDB(self.index_dir / "data_001.db")
+        data_db.save_chunks([self._make_chunk()])
+        index_db.save_knowledge_nodes([
+            {
+                "id": "kn-1",
+                "content": "cold start fact",
+                "category": "workflow",
+                "confidence": 0.9,
+                "source_sessions": [],
+                "source_turns": [],
+                "source_offsets": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "status": "active",
+                "superseded_by": "",
+                "contradiction_note": "",
+                "tags": [],
+                "valid_from": None,
+                "valid_until": None,
+                "version": 1,
+                "lineage_id": "",
+            }
+        ])
+        index_db.save_knowledge_embeddings({1: _make_embedding(0.5)})
+        index_db.close()
+        data_db.close()
+
+        with patch("synapt.recall.embeddings.get_embedding_provider") as mock_get:
+            index = TranscriptIndex.load(self.index_dir, use_embeddings=True)
+            result = index.lookup("cold start fact", max_chunks=3, max_tokens=200)
+
+        self.assertIn("cold start fact", result)
+        self.assertIsNone(index._embed_provider)
+        self.assertIn("BM25-only", index._embedding_reason)
+        mock_get.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/recall/test_sharded_db.py
+++ b/tests/recall/test_sharded_db.py
@@ -199,6 +199,16 @@ class TestShardedRecallDBSharded(unittest.TestCase):
         self.assertAlmostEqual(loaded[mapping["s2:t0"]][0], emb2[0], places=6)
         db.close()
 
+    def test_content_hash_spans_all_shards_in_global_timestamp_order(self):
+        db = self._create_two_shard_layout()
+        import hashlib
+
+        h = hashlib.sha256()
+        h.update("s2:t0|beta memory|assistant|\n".encode())
+        h.update("s1:t0|alpha memory|assistant|\n".encode())
+        self.assertEqual(db.content_hash(), h.hexdigest()[:16])
+        db.close()
+
     def test_transcript_index_load_can_search_sharded_chunks(self):
         self._create_two_shard_layout().close()
         index = TranscriptIndex.load(self.index_dir)


### PR DESCRIPTION
## Summary
- keep sharded indexes with no chunk embeddings on the fast BM25-only path
- compute sharded content hashes from shard data instead of empty `index.db`
- broaden Hugging Face cache detection for the local MiniLM model
- add regressions for sharded content-hash correctness and the no-provider cold-start path

## Verification
- `PYTHONPATH=src pytest tests/recall/test_sharded_db.py tests/recall/test_lazy_embeddings.py tests/recall/test_content_hash.py -q`
- `PYTHONPATH=src python3 -m synapt.recall.cli benchmark --iterations 1 --queries "gr2 apply" --index /Users/layne/Development/synapt-codex/.synapt/recall/index`
- local benchmark moved from roughly `10.9s` cold start / `2.06s` query to `3.45s` cold start / `149ms` query on this 60K-chunk no-chunk-embeddings index

## Boundary
OSS-only recall infrastructure and local search performance. No identity/org/premium behavior.