### PR TITLE
fix: suppress live results for historical recall queries

### DIFF
--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -260,15 +260,16 @@ def recall_search(
     max_tokens = _cap_tokens(max_tokens)
     index = _get_index()
 
-    # Always search the live transcript — covers the current session which is
-    # not yet archived.  Live results get ≤1/3 of the total token budget.
-    # Skip entirely when max_tokens=0 to avoid emitting output the caller
-    # did not budget for (the first-chunk guarantee in _format_live_results
-    # still fires at max_tokens=0, producing unexpected output).
+    # Search the live transcript for current-session context.
+    # Skip when: (a) max_tokens=0, (b) `before` is set (the current session
+    # is by definition "now" and cannot satisfy a historical cutoff).
+    # Fixes recall#634: before-filtered queries no longer leak current-session
+    # context that postdates the requested time window.
+    historical_filter = before is not None or after is not None
     from synapt.recall.live import search_live_transcript
     live_budget = min(500, max_tokens // 3)
     live_result = ""
-    if live_budget > 0:
+    if live_budget > 0 and not before:
         live_result = search_live_transcript(
             query,
             index=index,
@@ -290,6 +291,13 @@ def recall_search(
         indexed_budget = max(max_tokens - live_consumed, budget_floor)
 
     if index is None:
+        if historical_filter:
+            index_dir = project_index_dir()
+            return (
+                f"Historical search unavailable: no index found at {index_dir}. "
+                f"Run `synapt recall setup` first. "
+                f"Cannot satisfy date-filtered query without an index."
+            )
         if live_result:
             return live_result
         index_dir = project_index_dir()

--- a/tests/recall/test_live.py
+++ b/tests/recall/test_live.py
@@ -574,6 +574,89 @@ class TestRecallSearchLiveIntegration(unittest.TestCase):
         self.assertIn("Run `synapt recall setup`", result)
 
 
+    def test_before_filter_suppresses_live_results(self):
+        """recall_search with before= should NOT include current-session context."""
+        from synapt.recall.server import recall_search
+
+        with tempfile.TemporaryDirectory() as d:
+            transcript = Path(d) / "session.jsonl"
+            _write_transcript(transcript, "live-session", [
+                {"user": "swift adapter training pipeline", "assistant": "done"},
+            ])
+
+            mock_index = MagicMock()
+            mock_index.sessions = {}
+            mock_index.lookup.return_value = "Past session context:\n--- historical result ---"
+            mock_index._last_diagnostics = None
+
+            with (
+                patch("synapt.recall.server._get_index", return_value=mock_index),
+                patch("synapt.recall.live.latest_transcript_path", return_value=str(transcript)),
+            ):
+                result = recall_search("swift adapter", before="2026-04-09")
+
+        self.assertNotIn("Current session context:", result,
+                         "Live results should be suppressed when before= is set")
+        self.assertIn("Past session context:", result)
+
+    def test_after_filter_still_includes_live_results(self):
+        """recall_search with after= (but no before=) should still include live."""
+        from synapt.recall.server import recall_search
+
+        with tempfile.TemporaryDirectory() as d:
+            transcript = Path(d) / "session.jsonl"
+            _write_transcript(transcript, "live-session", [
+                {"user": "swift adapter training pipeline", "assistant": "done"},
+            ])
+
+            mock_index = MagicMock()
+            mock_index.sessions = {}
+            mock_index.lookup.return_value = "Past session context:\n--- indexed result ---"
+            mock_index._last_diagnostics = None
+
+            with (
+                patch("synapt.recall.server._get_index", return_value=mock_index),
+                patch("synapt.recall.live.latest_transcript_path", return_value=str(transcript)),
+            ):
+                result = recall_search("swift adapter", after="2026-04-01")
+
+        self.assertIn("Current session context:", result,
+                       "Live results should still appear with after= only")
+
+    def test_before_filter_no_index_returns_unavailable(self):
+        """When before= is set but no index exists, return clear error."""
+        from synapt.recall.server import recall_search
+
+        with tempfile.TemporaryDirectory() as d:
+            transcript = Path(d) / "session.jsonl"
+            _write_transcript(transcript, "live-session", [
+                {"user": "swift adapter training pipeline", "assistant": "done"},
+            ])
+
+            with (
+                patch("synapt.recall.server._get_index", return_value=None),
+                patch("synapt.recall.live.latest_transcript_path", return_value=str(transcript)),
+            ):
+                result = recall_search("swift adapter", before="2026-04-09")
+
+        self.assertIn("Historical search unavailable", result,
+                       "Should explain that historical search needs an index")
+        self.assertNotIn("Current session context:", result,
+                         "Should not fall back to live results for historical query")
+
+    def test_after_filter_no_index_returns_unavailable(self):
+        """When after= is set but no index exists, return clear error."""
+        from synapt.recall.server import recall_search
+
+        with (
+            patch("synapt.recall.server._get_index", return_value=None),
+            patch("synapt.recall.live.latest_transcript_path", return_value=None),
+        ):
+            result = recall_search("swift adapter", after="2026-04-01")
+
+        self.assertIn("Historical search unavailable", result)
+
+
 class TestRecallQuickStatusRouting(unittest.TestCase):
 
     def test_pending_query_uses_summary_depth(self):


### PR DESCRIPTION
## Summary
- `recall_search(before=...)` was returning current-session context, misleading callers into thinking a historical query succeeded
- Root cause: `search_live_transcript()` was always called regardless of date filters, and when no index existed, live results were returned as a silent fallback
- Two fixes: (1) skip live search when `before=` is set, (2) return "Historical search unavailable" when index is missing and date filters are active

## Changes
- `server.py`: Gate live search on `not before`, return explicit error for date-filtered queries without an index
- `test_live.py`: 4 new tests covering before/after filter interactions with live search

**Premium boundary**: OSS recall search infrastructure. Fixes a correctness bug in the public recall API.

## Test plan
- [x] `before=` suppresses live results when index exists (returns only indexed)
- [x] `after=` (without `before=`) still includes live results
- [x] `before=` with no index returns "Historical search unavailable" (not live fallback)
- [x] `after=` with no index returns "Historical search unavailable"
- [x] Full suite: 1976 passed, 19 skipped, 0 failures

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)