### PR TITLE
security: gate register_agent() behind org entitlement check

### DIFF
--- a/src/synapt/recall/registry.py
+++ b/src/synapt/recall/registry.py
@@ -91,6 +91,30 @@ def _open_db(org_id: str, db_path: Path | None = None) -> sqlite3.Connection:
     return conn
 
 
+def _check_org_entitlement(org_id: str, db_path: Path | None = None) -> None:
+    """Verify the caller is entitled to register agents in this org.
+
+    Entitlement is established by any of:
+    - db_path explicitly passed (test/internal use, caller owns the path)
+    - SYNAPT_AGENT_ID env var is set (process was spawned by gr spawn)
+    - org directory already contains a team.db (org was initialized by gr)
+
+    Raises PermissionError if none of these conditions hold.
+    Security: recall#530.
+    """
+    if db_path is not None:
+        return
+    if os.environ.get("SYNAPT_AGENT_ID"):
+        return
+    team_db = _team_db_path(org_id)
+    if team_db.exists():
+        return
+    raise PermissionError(
+        f"Cannot register agent in org '{org_id}': no entitlement. "
+        f"Use `gr spawn` to create agents, or initialize the org first."
+    )
+
+
 def register_agent(
     org_id: str,
     display_name: str,
@@ -100,7 +124,9 @@ def register_agent(
     """Register a new agent in the org. Returns the assigned agent_id.
 
     Raises sqlite3.IntegrityError if display_name is already taken in this org.
+    Raises PermissionError if the caller lacks org entitlement (recall#530).
     """
+    _check_org_entitlement(org_id, db_path)
     conn = _open_db(org_id, db_path)
     try:
         now = datetime.now(timezone.utc).isoformat()

--- a/tests/recall/test_channel_scoping.py
+++ b/tests/recall/test_channel_scoping.py
@@ -580,5 +580,65 @@ class TestBackwardCompat(unittest.TestCase):
         self.assertEqual(result, self._local_dir / "channels")
 
 
+class TestOrgEntitlementCheck(unittest.TestCase):
+    """Tests for register_agent() entitlement gate (recall#530)."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir)
+
+    def test_db_path_bypasses_entitlement(self):
+        """Explicit db_path (test/internal use) always succeeds."""
+        db = Path(self._tmpdir) / "team.db"
+        _create_team_db(db, "test-org")
+        agent_id = register_agent("test-org", "TestAgent", db_path=db)
+        self.assertIsNotNone(agent_id)
+
+    def test_env_var_grants_entitlement(self):
+        """SYNAPT_AGENT_ID env var (set by gr spawn) grants access."""
+        # Create the org dir so _open_db can write
+        org_dir = Path(self._tmpdir) / "orgs" / "test-org"
+        org_dir.mkdir(parents=True)
+        with patch("synapt.recall.registry._team_db_path",
+                    return_value=org_dir / "team.db"):
+            with patch.dict(os.environ, {"SYNAPT_AGENT_ID": "opus-001"}):
+                agent_id = register_agent("test-org", "TestAgent")
+        self.assertIsNotNone(agent_id)
+
+    def test_existing_team_db_grants_entitlement(self):
+        """If team.db already exists (org initialized by gr), allow registration."""
+        org_dir = Path(self._tmpdir) / "orgs" / "test-org"
+        org_dir.mkdir(parents=True)
+        db = org_dir / "team.db"
+        _create_team_db(db, "test-org")
+        with patch("synapt.recall.registry._team_db_path", return_value=db):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("SYNAPT_AGENT_ID", None)
+                agent_id = register_agent("test-org", "NewAgent")
+        self.assertIsNotNone(agent_id)
+
+    def test_no_entitlement_raises_permission_error(self):
+        """Rogue process without entitlement cannot register agents."""
+        nonexistent_db = Path(self._tmpdir) / "orgs" / "rogue-org" / "team.db"
+        with patch("synapt.recall.registry._team_db_path", return_value=nonexistent_db):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("SYNAPT_AGENT_ID", None)
+                with self.assertRaises(PermissionError) as ctx:
+                    register_agent("rogue-org", "EvilAgent")
+        self.assertIn("no entitlement", str(ctx.exception))
+
+    def test_entitlement_error_names_org(self):
+        """Error message includes the org_id for debugging."""
+        nonexistent_db = Path(self._tmpdir) / "no-org" / "team.db"
+        with patch("synapt.recall.registry._team_db_path", return_value=nonexistent_db):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("SYNAPT_AGENT_ID", None)
+                with self.assertRaises(PermissionError) as ctx:
+                    register_agent("secret-org-42", "Intruder")
+        self.assertIn("secret-org-42", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `register_agent()` previously wrote to org `team.db` without verifying the caller had any relationship to the org
- Adds `_check_org_entitlement()` gate that verifies one of three conditions: explicit `db_path` (tests), `SYNAPT_AGENT_ID` env var (gr spawn), or existing `team.db` (initialized org)
- Raises `PermissionError` with org_id in the message if none hold

## Changes
- `registry.py`: Added `_check_org_entitlement()`, called at top of `register_agent()`
- `test_channel_scoping.py`: 5 new tests covering all entitlement paths + rejection + error message content

**Premium boundary**: OSS recall infrastructure. Identity is premium, but the entitlement check lives at the registry boundary in OSS to prevent unauthorized writes regardless of which layer calls it.

## Test plan
- [x] Explicit db_path bypasses check (tests still pass)
- [x] SYNAPT_AGENT_ID env var grants access
- [x] Existing team.db grants access (org already initialized)
- [x] Missing entitlement raises PermissionError
- [x] Error message includes org_id
- [x] All existing registry/scoping/process-tracking tests pass (36 passed)
- [x] Full suite: 1981 passed, 19 skipped, 0 failures

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)