### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.11.1"
+version = "0.12.0"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"


### PR DESCRIPTION
Version bump for v0.12.0 release. Tag already pushed; this PR syncs main.

Premium boundary: core OSS (version metadata only).