### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.12.0"
+version = "0.12.1"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"


### PR DESCRIPTION
## Summary

- Bump version 0.12.0 -> 0.12.1 for v0.12.1 release
- Includes recall#697: fix dashboard agent discovery from tmux windows

**Premium boundary:** OSS infrastructure (version metadata only).