### PR TITLE
test: add Sprint 25 adapter TDD specs

### DIFF
--- a/tests/integrations/test_crewai_adapter.py
+++ b/tests/integrations/test_crewai_adapter.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+crewai_memory = pytest.importorskip("crewai.memory")
+crewai_types = pytest.importorskip("crewai.memory.types")
+
+CrewAIMemory = crewai_memory.Memory
+MemoryMatch = crewai_types.MemoryMatch
+MemoryRecord = crewai_types.MemoryRecord
+
+
+def _adapter_cls():
+    from synapt.integrations.crewai import SynaptMemory
+
+    return SynaptMemory
+
+
+def test_crewai_adapter_instantiates_and_matches_memory_interface(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    memory = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+
+    assert isinstance(memory, CrewAIMemory)
+    assert memory.session_id == "crew-session-1"
+    assert memory.recall("anything", limit=3) == []
+
+
+def test_crewai_adapter_remember_and_recall_round_trip(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    memory = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+
+    record = memory.remember(
+        "The customer prefers JSON payloads and terse summaries.",
+        metadata={"kind": "preference"},
+    )
+    matches = memory.recall("What output format does the customer prefer?", limit=3)
+
+    assert isinstance(record, MemoryRecord)
+    assert isinstance(matches, list)
+    assert matches
+    assert isinstance(matches[0], MemoryMatch)
+    assert matches[0].record.content == "The customer prefers JSON payloads and terse summaries."
+
+
+def test_crewai_adapter_persists_session_state_and_isolates_other_sessions(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    first = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+    first.remember("Escalations for Acme should go to Dana first.")
+
+    reloaded = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+    other_session = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-2",
+    )
+
+    same_session_matches = reloaded.recall("Who handles Acme escalations?", limit=3)
+    other_session_matches = other_session.recall("Who handles Acme escalations?", limit=3)
+
+    assert same_session_matches
+    assert same_session_matches[0].record.content == "Escalations for Acme should go to Dana first."
+    assert other_session_matches == []
+
+
+def test_crewai_adapter_reset_clears_only_the_current_session(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    first = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+    second = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-2",
+    )
+
+    first.remember("Alpha crew owns incident response.")
+    second.remember("Beta crew owns roadmap planning.")
+
+    first.reset()
+
+    assert first.recall("incident response", limit=3) == []
+    second_matches = second.recall("roadmap planning", limit=3)
+    assert second_matches
+    assert second_matches[0].record.content == "Beta crew owns roadmap planning."

--- a/tests/integrations/test_langchain_adapter.py
+++ b/tests/integrations/test_langchain_adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+langchain_history = pytest.importorskip("langchain_core.chat_history")
+langchain_messages = pytest.importorskip("langchain_core.messages")
+
+BaseChatMessageHistory = langchain_history.BaseChatMessageHistory
+AIMessage = langchain_messages.AIMessage
+HumanMessage = langchain_messages.HumanMessage
+
+
+def _adapter_cls():
+    from synapt.integrations.langchain import SynaptChatMessageHistory
+
+    return SynaptChatMessageHistory
+
+
+def test_langchain_adapter_instantiates_and_matches_interface(tmp_path):
+    SynaptChatMessageHistory = _adapter_cls()
+
+    history = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+
+    assert isinstance(history, BaseChatMessageHistory)
+    assert history.session_id == "thread-1"
+    assert history.messages == []
+
+
+def test_langchain_adapter_round_trips_messages_for_same_session(tmp_path):
+    SynaptChatMessageHistory = _adapter_cls()
+
+    history = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+    history.add_messages(
+        [
+            HumanMessage(content="Remember that Alice prefers concise status updates."),
+            AIMessage(content="Stored. Alice prefers concise status updates."),
+        ]
+    )
+
+    reloaded = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+
+    assert [message.content for message in reloaded.messages] == [
+        "Remember that Alice prefers concise status updates.",
+        "Stored. Alice prefers concise status updates.",
+    ]
+
+
+def test_langchain_adapter_isolates_sessions_and_clear_only_resets_current_session(tmp_path):
+    SynaptChatMessageHistory = _adapter_cls()
+
+    thread_one = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+    thread_two = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-2",
+    )
+
+    thread_one.add_messages([HumanMessage(content="Project Falcon is in design review.")])
+    thread_two.add_messages([HumanMessage(content="Project Zephyr is blocked on legal.")])
+
+    assert [message.content for message in thread_one.messages] == [
+        "Project Falcon is in design review."
+    ]
+    assert [message.content for message in thread_two.messages] == [
+        "Project Zephyr is blocked on legal."
+    ]
+
+    thread_one.clear()
+
+    assert thread_one.messages == []
+    assert [message.content for message in thread_two.messages] == [
+        "Project Zephyr is blocked on legal."
+    ]


### PR DESCRIPTION
## Summary
- add red TDD specs for the LangChain adapter contract
- add red TDD specs for the CrewAI adapter contract
- verify fresh-install setup for `synapt`, `langchain`, and `crewai`

## Boundary
- OSS-only test specs for OSS adapters
- no premium logic or identity/org behavior added

## Validation
- `python3 -m venv /tmp/synapt-install-check && source /tmp/synapt-install-check/bin/activate && python -m pip install synapt`
- `source /tmp/synapt-sprint25-venv/bin/activate && python -m pip install langchain crewai`
- `source /tmp/synapt-sprint25-venv/bin/activate && python -m pip install -e ".[test]" && pytest -q tests/integrations/test_langchain_adapter.py tests/integrations/test_crewai_adapter.py`
- expected red state: `7 failed` with `ModuleNotFoundError: No module named synapt.integrations` because the adapters do not exist yet