### PR TITLE
feat: add CrewAI memory adapter (Story 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ hf = ["huggingface_hub>=0.20"]
 onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
+crewai = ["crewai>=1.4.0"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4"]
 dev = ["watchfiles>=0.20"]
 test = [

--- a/src/synapt/integrations/crewai.py
+++ b/src/synapt/integrations/crewai.py
@@ -5,9 +5,6 @@ import math
 from pathlib import Path
 from typing import Any
 
-from synapt.recall.core import project_data_dir
-from synapt.recall.server import recall_save
-
 try:
     from crewai.memory import Memory
     from crewai.memory.storage.backend import MemoryRecord, ScopeInfo
@@ -23,13 +20,27 @@ def _require_crewai() -> None:
         raise ImportError("Install synapt[crewai] to use the CrewAI adapter") from _IMPORT_ERROR
 
 
+def _storage_path(project_dir: str | Path | None, path: str | Path | None) -> Path:
+    if path:
+        return Path(path).resolve()
+    from synapt.recall.core import project_data_dir
+
+    root = project_data_dir(Path(project_dir) if project_dir else None) / "crewai-memory.jsonl"
+    return root.resolve()
+
+
+def _recall_save(**kwargs: Any) -> str:
+    from synapt.recall.server import recall_save
+
+    return recall_save(**kwargs)
+
+
 class SynaptStorage:
     """CrewAI storage backend backed by local recall persistence."""
 
     def __init__(self, project_dir: str | Path | None = None, path: str | Path | None = None) -> None:
         _require_crewai()
-        root = Path(path) if path else project_data_dir(Path(project_dir) if project_dir else None) / "crewai-memory.jsonl"
-        self.path = root.resolve()
+        self.path = _storage_path(project_dir, path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def _load(self) -> list[MemoryRecord]:
@@ -61,7 +72,7 @@ class SynaptStorage:
         saved = {r.id: r for r in self._load()}
         for record in records:
             saved[record.id] = record
-            recall_save(
+            _recall_save(
                 content=record.content,
                 category=record.categories[0] if record.categories else "workflow",
                 confidence=record.importance,
@@ -86,7 +97,7 @@ class SynaptStorage:
             doomed = (record_ids and record.id in record_ids) or (older_than and record.created_at < older_than) or (not record_ids and self._match(record, scope_prefix, categories, metadata_filter))
             if doomed:
                 removed += 1
-                recall_save(node_id=record.id, retract=True)
+                _recall_save(node_id=record.id, retract=True)
             else:
                 keep.append(record)
         self._write(keep)
@@ -138,4 +149,3 @@ def SynaptMemory(*, project_dir: str | Path | None = None, path: str | Path | No
     """Build a CrewAI Memory instance backed by synapt."""
     _require_crewai()
     return Memory(storage=SynaptStorage(project_dir=project_dir, path=path), **kwargs)
-

--- a/src/synapt/integrations/crewai.py
+++ b/src/synapt/integrations/crewai.py
@@ -116,7 +116,15 @@ class SynaptStorage:
 
     def get_scope_info(self, scope: str) -> ScopeInfo:
         records = [r for r in self._load() if r.scope.startswith(scope)]
-        child_scopes = sorted({"/" + "/".join(parts[: len(scope.strip("/").split("/")) + 1]) for r in records for parts in [r.scope.strip("/").split("/")] if len(parts) > len(scope.strip("/").split("/"))})
+        depth = 0 if scope == "/" else len([part for part in scope.strip("/").split("/") if part])
+        child_scopes = sorted(
+            {
+                "/" + "/".join(parts[: depth + 1])
+                for r in records
+                for parts in [[part for part in r.scope.strip("/").split("/") if part]]
+                if len(parts) > depth
+            }
+        )
         return ScopeInfo(path=scope, record_count=len(records), categories=sorted({c for r in records for c in r.categories}), oldest_record=min((r.created_at for r in records), default=None), newest_record=max((r.created_at for r in records), default=None), child_scopes=child_scopes)
 
     def list_scopes(self, parent: str = "/") -> list[str]:

--- a/src/synapt/integrations/crewai.py
+++ b/src/synapt/integrations/crewai.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from synapt.recall.core import project_data_dir
+from synapt.recall.server import recall_save
+
+try:
+    from crewai.memory import Memory
+    from crewai.memory.storage.backend import MemoryRecord, ScopeInfo
+except ImportError as exc:  # pragma: no cover
+    Memory = MemoryRecord = ScopeInfo = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+def _require_crewai() -> None:
+    if _IMPORT_ERROR is not None:  # pragma: no cover
+        raise ImportError("Install synapt[crewai] to use the CrewAI adapter") from _IMPORT_ERROR
+
+
+class SynaptStorage:
+    """CrewAI storage backend backed by local recall persistence."""
+
+    def __init__(self, project_dir: str | Path | None = None, path: str | Path | None = None) -> None:
+        _require_crewai()
+        root = Path(path) if path else project_data_dir(Path(project_dir) if project_dir else None) / "crewai-memory.jsonl"
+        self.path = root.resolve()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> list[MemoryRecord]:
+        if not self.path.exists():
+            return []
+        return [MemoryRecord.model_validate(json.loads(line)) for line in self.path.read_text().splitlines() if line.strip()]
+
+    def _write(self, records: list[MemoryRecord]) -> None:
+        text = "\n".join(json.dumps(r.model_dump(mode="json")) for r in records)
+        self.path.write_text(f"{text}\n" if text else "")
+
+    def _match(self, record: MemoryRecord, scope_prefix: str | None, categories: list[str] | None, metadata_filter: dict[str, Any] | None) -> bool:
+        if scope_prefix and not record.scope.startswith(scope_prefix):
+            return False
+        if categories and not set(categories).issubset(set(record.categories)):
+            return False
+        if metadata_filter and any(record.metadata.get(k) != v for k, v in metadata_filter.items()):
+            return False
+        return True
+
+    def _score(self, left: list[float] | None, right: list[float]) -> float:
+        if not left:
+            return 0.0
+        dot = sum(a * b for a, b in zip(left, right))
+        norm = math.sqrt(sum(a * a for a in left)) * math.sqrt(sum(b * b for b in right))
+        return dot / norm if norm else 0.0
+
+    def save(self, records: list[MemoryRecord]) -> None:
+        saved = {r.id: r for r in self._load()}
+        for record in records:
+            saved[record.id] = record
+            recall_save(
+                content=record.content,
+                category=record.categories[0] if record.categories else "workflow",
+                confidence=record.importance,
+                tags=record.categories or None,
+                node_id=record.id,
+            )
+        self._write(sorted(saved.values(), key=lambda r: r.created_at))
+
+    def search(self, query_embedding: list[float], scope_prefix: str | None = None, categories: list[str] | None = None, metadata_filter: dict[str, Any] | None = None, limit: int = 10, min_score: float = 0.0) -> list[tuple[MemoryRecord, float]]:
+        matches = []
+        for record in self._load():
+            if not self._match(record, scope_prefix, categories, metadata_filter):
+                continue
+            score = self._score(record.embedding, query_embedding)
+            if score >= min_score:
+                matches.append((record, score))
+        return sorted(matches, key=lambda item: item[1], reverse=True)[:limit]
+
+    def delete(self, scope_prefix: str | None = None, categories: list[str] | None = None, record_ids: list[str] | None = None, older_than=None, metadata_filter: dict[str, Any] | None = None) -> int:
+        keep, removed = [], 0
+        for record in self._load():
+            doomed = (record_ids and record.id in record_ids) or (older_than and record.created_at < older_than) or (not record_ids and self._match(record, scope_prefix, categories, metadata_filter))
+            if doomed:
+                removed += 1
+                recall_save(node_id=record.id, retract=True)
+            else:
+                keep.append(record)
+        self._write(keep)
+        return removed
+
+    def update(self, record: MemoryRecord) -> None:
+        self.save([record])
+
+    def get_record(self, record_id: str) -> MemoryRecord | None:
+        return next((r for r in self._load() if r.id == record_id), None)
+
+    def list_records(self, scope_prefix: str | None = None, limit: int = 200, offset: int = 0) -> list[MemoryRecord]:
+        records = [r for r in self._load() if self._match(r, scope_prefix, None, None)]
+        records.sort(key=lambda r: r.created_at, reverse=True)
+        return records[offset : offset + limit]
+
+    def get_scope_info(self, scope: str) -> ScopeInfo:
+        records = [r for r in self._load() if r.scope.startswith(scope)]
+        child_scopes = sorted({"/" + "/".join(parts[: len(scope.strip("/").split("/")) + 1]) for r in records for parts in [r.scope.strip("/").split("/")] if len(parts) > len(scope.strip("/").split("/"))})
+        return ScopeInfo(path=scope, record_count=len(records), categories=sorted({c for r in records for c in r.categories}), oldest_record=min((r.created_at for r in records), default=None), newest_record=max((r.created_at for r in records), default=None), child_scopes=child_scopes)
+
+    def list_scopes(self, parent: str = "/") -> list[str]:
+        return self.get_scope_info(parent).child_scopes
+
+    def list_categories(self, scope_prefix: str | None = None) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for record in self.list_records(scope_prefix=scope_prefix):
+            for category in record.categories:
+                counts[category] = counts.get(category, 0) + 1
+        return counts
+
+    def count(self, scope_prefix: str | None = None) -> int:
+        return len(self.list_records(scope_prefix=scope_prefix))
+
+    def reset(self, scope_prefix: str | None = None) -> None:
+        self.delete(scope_prefix=scope_prefix)
+
+    async def asave(self, records: list[MemoryRecord]) -> None:
+        self.save(records)
+
+    async def asearch(self, query_embedding: list[float], scope_prefix: str | None = None, categories: list[str] | None = None, metadata_filter: dict[str, Any] | None = None, limit: int = 10, min_score: float = 0.0) -> list[tuple[MemoryRecord, float]]:
+        return self.search(query_embedding, scope_prefix, categories, metadata_filter, limit, min_score)
+
+    async def adelete(self, scope_prefix: str | None = None, categories: list[str] | None = None, record_ids: list[str] | None = None, older_than=None, metadata_filter: dict[str, Any] | None = None) -> int:
+        return self.delete(scope_prefix, categories, record_ids, older_than, metadata_filter)
+
+
+def SynaptMemory(*, project_dir: str | Path | None = None, path: str | Path | None = None, **kwargs: Any) -> Memory:
+    """Build a CrewAI Memory instance backed by synapt."""
+    _require_crewai()
+    return Memory(storage=SynaptStorage(project_dir=project_dir, path=path), **kwargs)
+

--- a/tests/integrations/test_crewai_integration.py
+++ b/tests/integrations/test_crewai_integration.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-crewai = pytest.importorskip("crewai")
+pytest.importorskip("crewai")
 from crewai.memory.storage.backend import MemoryRecord
 
 from synapt.integrations import crewai as synapt_crewai
@@ -13,11 +13,11 @@ from synapt.integrations import crewai as synapt_crewai
 def test_synapt_storage_saves_and_searches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     saved: list[tuple[str, str, bool]] = []
 
-    def fake_recall_save(content: str = "", category: str = "workflow", confidence: float = 0.8, tags=None, source_sessions=None, source_turns=None, node_id: str | None = None, retract: bool = False) -> str:
-        saved.append((node_id or "", content, retract))
+    def fake_recall_save(**kwargs) -> str:
+        saved.append((kwargs.get("node_id", ""), kwargs.get("content", ""), kwargs.get("retract", False)))
         return "ok"
 
-    monkeypatch.setattr(synapt_crewai, "recall_save", fake_recall_save)
+    monkeypatch.setattr(synapt_crewai, "_recall_save", fake_recall_save)
     storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
     record = MemoryRecord(content="CrewAI adapter stored in recall", scope="/crew/test", categories=["integration"], metadata={"kind": "note"}, importance=0.9, embedding=[1.0, 0.0])
 
@@ -32,12 +32,12 @@ def test_synapt_storage_saves_and_searches(tmp_path: Path, monkeypatch: pytest.M
 def test_synapt_storage_delete_retracts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     retracted: list[str] = []
 
-    def fake_recall_save(content: str = "", category: str = "workflow", confidence: float = 0.8, tags=None, source_sessions=None, source_turns=None, node_id: str | None = None, retract: bool = False) -> str:
-        if retract and node_id:
-            retracted.append(node_id)
+    def fake_recall_save(**kwargs) -> str:
+        if kwargs.get("retract") and kwargs.get("node_id"):
+            retracted.append(kwargs["node_id"])
         return "ok"
 
-    monkeypatch.setattr(synapt_crewai, "recall_save", fake_recall_save)
+    monkeypatch.setattr(synapt_crewai, "_recall_save", fake_recall_save)
     storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
     record = MemoryRecord(content="delete me", embedding=[0.0, 1.0])
     storage.save([record])

--- a/tests/integrations/test_crewai_integration.py
+++ b/tests/integrations/test_crewai_integration.py
@@ -45,3 +45,17 @@ def test_synapt_storage_delete_retracts(tmp_path: Path, monkeypatch: pytest.Monk
     assert storage.delete(record_ids=[record.id]) == 1
     assert retracted == [record.id]
     assert storage.count() == 0
+
+
+def test_list_scopes_returns_immediate_children(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(synapt_crewai, "_recall_save", lambda **kwargs: "ok")
+    storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
+    storage.save(
+        [
+            MemoryRecord(content="alpha", scope="/crew/test", embedding=[1.0, 0.0]),
+            MemoryRecord(content="beta", scope="/ops/runbook", embedding=[0.0, 1.0]),
+        ]
+    )
+
+    assert storage.list_scopes("/") == ["/crew", "/ops"]
+    assert storage.list_scopes("/crew") == ["/crew/test"]

--- a/tests/test_crewai_integration.py
+++ b/tests/test_crewai_integration.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+crewai = pytest.importorskip("crewai")
+from crewai.memory.storage.backend import MemoryRecord
+
+from synapt.integrations import crewai as synapt_crewai
+
+
+def test_synapt_storage_saves_and_searches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    saved: list[tuple[str, str, bool]] = []
+
+    def fake_recall_save(content: str = "", category: str = "workflow", confidence: float = 0.8, tags=None, source_sessions=None, source_turns=None, node_id: str | None = None, retract: bool = False) -> str:
+        saved.append((node_id or "", content, retract))
+        return "ok"
+
+    monkeypatch.setattr(synapt_crewai, "recall_save", fake_recall_save)
+    storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
+    record = MemoryRecord(content="CrewAI adapter stored in recall", scope="/crew/test", categories=["integration"], metadata={"kind": "note"}, importance=0.9, embedding=[1.0, 0.0])
+
+    storage.save([record])
+    results = storage.search([1.0, 0.0], scope_prefix="/crew", categories=["integration"], metadata_filter={"kind": "note"})
+
+    assert saved == [(record.id, record.content, False)]
+    assert len(results) == 1
+    assert results[0][0].id == record.id
+
+
+def test_synapt_storage_delete_retracts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    retracted: list[str] = []
+
+    def fake_recall_save(content: str = "", category: str = "workflow", confidence: float = 0.8, tags=None, source_sessions=None, source_turns=None, node_id: str | None = None, retract: bool = False) -> str:
+        if retract and node_id:
+            retracted.append(node_id)
+        return "ok"
+
+    monkeypatch.setattr(synapt_crewai, "recall_save", fake_recall_save)
+    storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
+    record = MemoryRecord(content="delete me", embedding=[0.0, 1.0])
+    storage.save([record])
+
+    assert storage.delete(record_ids=[record.id]) == 1
+    assert retracted == [record.id]
+    assert storage.count() == 0


### PR DESCRIPTION
Premium boundary: recall is OSS because this adapter wraps existing public recall APIs and adds no identity or org behavior.

Closes #708

## Summary
- add CrewAI memory adapter at `src/synapt/integrations/crewai.py`
- publish `synapt[crewai]` extra in `pyproject.toml`
- add focused integration tests for save/search/delete behavior

## Validation
- `PYTHONPATH=src python3 -m py_compile src/synapt/integrations/crewai.py tests/test_crewai_integration.py`
- `PYTHONPATH=src python3 -m pytest -q tests/test_crewai_integration.py`