### PR TITLE
feat: scaffold Codex plugin package (Story 6)

### DIFF
--- a/codex-plugin/.mcp.json
+++ b/codex-plugin/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "synapt": {
+      "command": "synapt",
+      "args": [
+        "server"
+      ]
+    }
+  }
+}

--- a/codex-plugin/AGENTS.md
+++ b/codex-plugin/AGENTS.md
@@ -1,0 +1,34 @@
+# synapt Codex Plugin
+
+Use this plugin when Codex should have direct access to synapt recall over MCP.
+
+## What it provides
+
+- local `synapt server` MCP access
+- recall search, save, context, journal, and channel tools
+- no identity or org behavior; this is OSS-only packaging of existing recall primitives
+
+## Install shapes
+
+Plugin form:
+
+```bash
+codex plugin add synapt-dev/recall-plugin
+```
+
+Direct MCP fallback:
+
+```bash
+codex mcp add synapt -- synapt server
+```
+
+## Usage guidance
+
+- prefer `recall_quick` for cheap speculative lookup
+- use `recall_search` for real retrieval
+- use `recall_save` only for durable facts, conventions, or decisions
+- treat `#dev` as shared operational memory when the session is part of team coordination
+
+## Boundary
+
+Premium boundary: this plugin is OSS because it only packages the public synapt MCP server and instructions. Identity, org routing, and premium policy remain outside this scaffold.

--- a/codex-plugin/marketplace.json
+++ b/codex-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "synapt-codex-plugin",
+  "version": "0.1.0",
+  "description": "Codex plugin scaffold for synapt recall MCP access.",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "synapt Recall",
+    "shortDescription": "Local-first memory and recall for Codex.",
+    "longDescription": "Adds the synapt MCP server plus recall-aware instructions so Codex can search, save, and reuse local memory across sessions.",
+    "developerName": "synapt-dev",
+    "category": "Productivity",
+    "capabilities": [
+      "MCP",
+      "Recall",
+      "Local Memory"
+    ]
+  }
+}


### PR DESCRIPTION
Premium boundary: recall is OSS because this scaffold only packages the public synapt MCP server and recall-aware instructions for Codex.

Closes #710

## Summary
- add local `codex-plugin/` scaffold for the future Codex plugin repo
- include `marketplace.json`, `.mcp.json`, and `AGENTS.md`
- document plugin install and direct MCP fallback shapes

## Notes
- this is a local scaffold inside recall for now, not the final standalone repo
- it is intentionally packaging-only: no identity, org, or premium policy behavior