### PR TITLE
docs: integration badges + framework quickstarts (Story 15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://pypi.org/project/synapt/"><img src="https://img.shields.io/pypi/v/synapt?color=7c5cbf" alt="PyPI"></a>
   <a href="https://pypi.org/project/synapt/"><img src="https://img.shields.io/pypi/pyversions/synapt?color=00e5cc" alt="Python"></a>
-  <a href="https://github.com/laynepenney/recall/blob/main/LICENSE"><img src="https://img.shields.io/github/license/laynepenney/recall" alt="License"></a>
+  <a href="https://github.com/synapt-dev/recall/blob/main/LICENSE"><img src="https://img.shields.io/github/license/synapt-dev/recall" alt="License"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 </p>
 
 <p align="center">
+  <img src="https://img.shields.io/badge/LangChain-ready-1C3C3C?logo=langchain&logoColor=white" alt="LangChain">
+  <img src="https://img.shields.io/badge/CrewAI-ready-FF6B35?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0id2hpdGUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjYiLz48L3N2Zz4=&logoColor=white" alt="CrewAI">
+  <img src="https://img.shields.io/badge/OpenAI_Agents-ready-412991?logo=openai&logoColor=white" alt="OpenAI Agents">
+  <img src="https://img.shields.io/badge/Claude_Code-ready-D97706?logo=anthropic&logoColor=white" alt="Claude Code">
+  <img src="https://img.shields.io/badge/Codex_CLI-ready-412991?logo=openai&logoColor=white" alt="Codex CLI">
+</p>
+
+<p align="center">
   Memory and coordination infrastructure for AI coding teams.<br>
   Search past sessions, preserve decisions, coordinate agents, and ship from one persistent system of record.
 </p>
@@ -121,6 +129,102 @@ If your client accepts stdio MCP definitions directly, use:
   }
 }
 ```
+
+## Framework integrations
+
+synapt plugs into popular agent frameworks as a drop-in memory backend. Each adapter wraps recall's search and save API for the framework's native session interface.
+
+### LangChain
+
+`SynaptChatMessageHistory` implements LangChain's `BaseChatMessageHistory`. Messages are stored in SQLite with WAL mode; recall search and knowledge persistence are one method call away.
+
+```bash
+pip install synapt langchain-core
+```
+
+```python
+from synapt.integrations.langchain import SynaptChatMessageHistory
+
+history = SynaptChatMessageHistory(session_id="user-123")
+history.add_messages([HumanMessage(content="hello")])
+print(history.messages)
+
+# Semantic search across all indexed sessions
+results = history.search("deployment config")
+
+# Persist a decision as a durable knowledge node
+history.save_to_recall("Always use UTC timestamps", category="convention")
+```
+
+Works with `RunnableWithMessageHistory`, `ConversationChain`, and any LangChain component that accepts a `BaseChatMessageHistory`.
+
+### OpenAI Agents SDK
+
+`SynaptSession` implements the Agents SDK `Session` protocol. Items are stored as JSON dicts in SQLite; async throughout.
+
+```bash
+pip install synapt openai-agents
+```
+
+```python
+from synapt.integrations.openai_agents import SynaptSession
+
+session = SynaptSession(session_id="agent-run-42")
+await session.add_items([{"role": "user", "content": "hello"}])
+items = await session.get_items(limit=10)
+
+# Bridge to recall search
+results = session.search("prior error handling decisions")
+```
+
+### CrewAI
+
+`SynaptMemory` provides long-term memory storage for CrewAI crews, backed by recall's hybrid search.
+
+```bash
+pip install synapt crewai
+```
+
+```python
+from synapt.integrations.crewai import SynaptMemory
+
+memory = SynaptMemory()
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, write_task],
+    memory=memory,
+)
+crew.kickoff()
+```
+
+### Claude Code (plugin)
+
+Install the synapt plugin to give Claude Code persistent memory across sessions. The plugin auto-starts the recall MCP server and installs recall skills.
+
+```bash
+claude plugin add synapt-recall
+```
+
+Once installed, Claude Code gains `recall_search`, `recall_save`, `recall_journal`, and 20+ other recall tools automatically. No manual MCP configuration needed.
+
+### Codex CLI
+
+Codex CLI connects to synapt via MCP. Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.synapt]
+command = "synapt"
+args = ["server"]
+```
+
+Then initialize:
+
+```bash
+pip install synapt
+synapt init
+```
+
+The `dev-loop` skill is installed automatically, giving Codex recall search, channel coordination, and journal access.
 
 ## What `synapt init` does
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ pip install synapt langchain-core
 ```
 
 ```python
+from langchain_core.messages import HumanMessage
 from synapt.integrations.langchain import SynaptChatMessageHistory
 
 history = SynaptChatMessageHistory(session_id="user-123")
@@ -182,7 +183,7 @@ results = session.search("prior error handling decisions")
 `SynaptMemory` provides long-term memory storage for CrewAI crews, backed by recall's hybrid search.
 
 ```bash
-pip install synapt crewai
+pip install synapt[crewai]
 ```
 
 ```python
@@ -197,19 +198,27 @@ crew = Crew(
 crew.kickoff()
 ```
 
-### Claude Code (plugin)
+### Claude Code
 
-Install the synapt plugin to give Claude Code persistent memory across sessions. The plugin auto-starts the recall MCP server and installs recall skills.
+Register the recall MCP server and initialize the project:
 
 ```bash
-claude plugin add synapt-recall
+pip install synapt
+claude mcp add synapt -- synapt server
+synapt init
 ```
 
-Once installed, Claude Code gains `recall_search`, `recall_save`, `recall_journal`, and 20+ other recall tools automatically. No manual MCP configuration needed.
+Claude Code gains `recall_search`, `recall_save`, `recall_journal`, and 20+ other recall tools automatically. `synapt init` also installs session hooks for automatic transcript archiving.
 
 ### Codex CLI
 
-Codex CLI connects to synapt via MCP. Add to `~/.codex/config.toml`:
+Install synapt and register the MCP server:
+
+```bash
+pip install synapt
+```
+
+Add to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.synapt]
@@ -217,14 +226,13 @@ command = "synapt"
 args = ["server"]
 ```
 
-Then initialize:
+Then initialize the project:
 
 ```bash
-pip install synapt
 synapt init
 ```
 
-The `dev-loop` skill is installed automatically, giving Codex recall search, channel coordination, and journal access.
+`synapt init` installs the `dev-loop` skill automatically, giving Codex recall search, channel coordination, and journal access.
 
 ## What `synapt init` does
 


### PR DESCRIPTION
## Summary

- Added shields.io integration badges for LangChain, CrewAI, OpenAI Agents, Claude Code, and Codex CLI
- New "Framework integrations" section with per-platform quickstart: install command, working code snippet, and what you get, each under 3 minutes
- Covers all five Sprint 25 distribution targets

## Premium boundary

Premium boundary: OSS (README documentation for public integrations).

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify code examples match actual adapter APIs
- [ ] Confirm no premium features are exposed in quickstart snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)