### PR TITLE
feat: n8n community node scaffold (Story 11)

### DIFF
--- a/n8n-nodes/credentials/SynaptApi.credentials.ts
+++ b/n8n-nodes/credentials/SynaptApi.credentials.ts
@@ -1,0 +1,28 @@
+import {
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class SynaptApi implements ICredentialType {
+	name = 'synaptApi';
+	displayName = 'Synapt API';
+	documentationUrl = 'https://synapt.dev/guide.html';
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Server URL',
+			name: 'serverUrl',
+			type: 'string',
+			default: 'http://localhost:8417',
+			placeholder: 'http://localhost:8417',
+			description: 'URL of the synapt recall MCP server (HTTP transport)',
+		},
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description: 'Optional API key for authenticated synapt instances',
+		},
+	];
+}

--- a/n8n-nodes/index.ts
+++ b/n8n-nodes/index.ts
@@ -1,0 +1,4 @@
+export { SynaptSearch } from './nodes/Synapt/SynaptSearch.node';
+export { SynaptSave } from './nodes/Synapt/SynaptSave.node';
+export { SynaptContext } from './nodes/Synapt/SynaptContext.node';
+export { SynaptApi } from './credentials/SynaptApi.credentials';

--- a/n8n-nodes/nodes/Synapt/SynaptContext.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptContext.node.ts
@@ -5,6 +5,10 @@ import {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 
+// TODO: synapt server currently exposes stdio MCP transport only.
+// These nodes are scaffolded against a planned HTTP transport endpoint.
+// See: https://github.com/synapt-dev/recall/issues for tracking.
+
 export class SynaptContext implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Synapt Context',
@@ -12,7 +16,7 @@ export class SynaptContext implements INodeType {
 		icon: 'file:synapt.svg',
 		group: ['transform'],
 		version: 1,
-		description: 'Retrieve project context, file history, or timeline from recall memory',
+		description: 'Retrieve file history, timeline, or drill into a search result from recall memory',
 		defaults: {
 			name: 'Synapt Context',
 		},
@@ -29,34 +33,46 @@ export class SynaptContext implements INodeType {
 				displayName: 'Operation',
 				name: 'operation',
 				type: 'options',
-				default: 'context',
+				default: 'files',
 				noDataExpression: true,
 				options: [
 					{
-						name: 'Get Context',
-						value: 'context',
-						description: 'Retrieve recent project context and session summaries',
-					},
-					{
 						name: 'File History',
 						value: 'files',
-						description: 'Get the history of a specific file across sessions',
+						description: 'Find past sessions that touched a specific file',
 					},
 					{
 						name: 'Timeline',
 						value: 'timeline',
-						description: 'View a timeline of recent recall activity',
+						description: 'View chronological timeline of work arcs',
+					},
+					{
+						name: 'Drill Down',
+						value: 'context',
+						description: 'Get full transcript for a chunk or cluster from a search result',
 					},
 				],
 			},
 			{
-				displayName: 'File Path',
-				name: 'filePath',
+				displayName: 'File Pattern',
+				name: 'pattern',
 				type: 'string',
 				default: '',
 				required: true,
 				placeholder: 'src/auth.py',
-				description: 'Path to the file to look up',
+				description: 'File path or partial path to search for (supports partial matching)',
+				displayOptions: {
+					show: {
+						operation: ['files'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Chunks',
+				name: 'maxChunks',
+				type: 'number',
+				default: 10,
+				description: 'Maximum number of result chunks to return',
 				displayOptions: {
 					show: {
 						operation: ['files'],
@@ -67,8 +83,64 @@ export class SynaptContext implements INodeType {
 				displayName: 'Max Tokens',
 				name: 'maxTokens',
 				type: 'number',
-				default: 2000,
+				default: 1500,
 				description: 'Token budget for returned context',
+				displayOptions: {
+					show: {
+						operation: ['files'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Results',
+				name: 'maxResults',
+				type: 'number',
+				default: 10,
+				description: 'Maximum number of timeline arcs to return',
+				displayOptions: {
+					show: {
+						operation: ['timeline'],
+					},
+				},
+			},
+			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				placeholder: 'auth refactor',
+				description: 'Optional text query to filter timeline arcs',
+				displayOptions: {
+					show: {
+						operation: ['timeline'],
+					},
+				},
+			},
+			{
+				displayName: 'Chunk ID',
+				name: 'chunkId',
+				type: 'string',
+				default: '',
+				placeholder: 'a1b2c3d4:t5',
+				description: 'Chunk identifier from a search result to drill into',
+				displayOptions: {
+					show: {
+						operation: ['context'],
+					},
+				},
+			},
+			{
+				displayName: 'Cluster ID',
+				name: 'clusterId',
+				type: 'string',
+				default: '',
+				placeholder: 'clust-abcd1234',
+				description: 'Cluster identifier to show all member chunks (takes precedence over Chunk ID)',
+				displayOptions: {
+					show: {
+						operation: ['context'],
+					},
+				},
 			},
 		],
 	};
@@ -81,25 +153,35 @@ export class SynaptContext implements INodeType {
 			const credentials = await this.getCredentials('synaptApi');
 			const serverUrl = credentials.serverUrl as string;
 			const operation = this.getNodeParameter('operation', i) as string;
-			const maxTokens = this.getNodeParameter('maxTokens', i) as number;
 
 			let tool: string;
 			let args: Record<string, unknown>;
 
 			switch (operation) {
 				case 'files': {
-					const filePath = this.getNodeParameter('filePath', i) as string;
+					const pattern = this.getNodeParameter('pattern', i) as string;
+					const maxChunks = this.getNodeParameter('maxChunks', i) as number;
+					const maxTokens = this.getNodeParameter('maxTokens', i) as number;
 					tool = 'recall_files';
-					args = { path: filePath, max_tokens: maxTokens };
+					args = { pattern, max_chunks: maxChunks, max_tokens: maxTokens };
 					break;
 				}
-				case 'timeline':
+				case 'timeline': {
+					const maxResults = this.getNodeParameter('maxResults', i) as number;
+					const query = this.getNodeParameter('query', i) as string;
 					tool = 'recall_timeline';
-					args = { max_tokens: maxTokens };
+					args = { max_results: maxResults, ...(query ? { query } : {}) };
 					break;
-				default:
+				}
+				default: {
+					const chunkId = this.getNodeParameter('chunkId', i) as string;
+					const clusterId = this.getNodeParameter('clusterId', i) as string;
 					tool = 'recall_context';
-					args = { max_tokens: maxTokens };
+					args = {
+						...(clusterId ? { cluster_id: clusterId } : {}),
+						...(chunkId ? { chunk_id: chunkId } : {}),
+					};
+				}
 			}
 
 			const response = await this.helpers.httpRequest({

--- a/n8n-nodes/nodes/Synapt/SynaptContext.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptContext.node.ts
@@ -1,0 +1,120 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+export class SynaptContext implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Synapt Context',
+		name: 'synaptContext',
+		icon: 'file:synapt.svg',
+		group: ['transform'],
+		version: 1,
+		description: 'Retrieve project context, file history, or timeline from recall memory',
+		defaults: {
+			name: 'Synapt Context',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'synaptApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				default: 'context',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Get Context',
+						value: 'context',
+						description: 'Retrieve recent project context and session summaries',
+					},
+					{
+						name: 'File History',
+						value: 'files',
+						description: 'Get the history of a specific file across sessions',
+					},
+					{
+						name: 'Timeline',
+						value: 'timeline',
+						description: 'View a timeline of recent recall activity',
+					},
+				],
+			},
+			{
+				displayName: 'File Path',
+				name: 'filePath',
+				type: 'string',
+				default: '',
+				required: true,
+				placeholder: 'src/auth.py',
+				description: 'Path to the file to look up',
+				displayOptions: {
+					show: {
+						operation: ['files'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Tokens',
+				name: 'maxTokens',
+				type: 'number',
+				default: 2000,
+				description: 'Token budget for returned context',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const results: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const credentials = await this.getCredentials('synaptApi');
+			const serverUrl = credentials.serverUrl as string;
+			const operation = this.getNodeParameter('operation', i) as string;
+			const maxTokens = this.getNodeParameter('maxTokens', i) as number;
+
+			let tool: string;
+			let args: Record<string, unknown>;
+
+			switch (operation) {
+				case 'files': {
+					const filePath = this.getNodeParameter('filePath', i) as string;
+					tool = 'recall_files';
+					args = { path: filePath, max_tokens: maxTokens };
+					break;
+				}
+				case 'timeline':
+					tool = 'recall_timeline';
+					args = { max_tokens: maxTokens };
+					break;
+				default:
+					tool = 'recall_context';
+					args = { max_tokens: maxTokens };
+			}
+
+			const response = await this.helpers.httpRequest({
+				method: 'POST',
+				url: `${serverUrl}/mcp/call`,
+				body: { tool, arguments: args },
+				headers: {
+					'Content-Type': 'application/json',
+					...(credentials.apiKey ? { Authorization: `Bearer ${credentials.apiKey}` } : {}),
+				},
+			});
+
+			results.push({ json: response });
+		}
+
+		return [results];
+	}
+}

--- a/n8n-nodes/nodes/Synapt/SynaptSave.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptSave.node.ts
@@ -5,6 +5,10 @@ import {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 
+// TODO: synapt server currently exposes stdio MCP transport only.
+// These nodes are scaffolded against a planned HTTP transport endpoint.
+// See: https://github.com/synapt-dev/recall/issues for tracking.
+
 export class SynaptSave implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Synapt Save',

--- a/n8n-nodes/nodes/Synapt/SynaptSave.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptSave.node.ts
@@ -1,0 +1,111 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+export class SynaptSave implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Synapt Save',
+		name: 'synaptSave',
+		icon: 'file:synapt.svg',
+		group: ['output'],
+		version: 1,
+		subtitle: '={{$parameter["category"]}}',
+		description: 'Save a fact, decision, or convention as a durable recall knowledge node',
+		defaults: {
+			name: 'Synapt Save',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'synaptApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Content',
+				name: 'content',
+				type: 'string',
+				default: '',
+				required: true,
+				typeOptions: { rows: 4 },
+				placeholder: 'Always use UTC timestamps in API responses',
+				description: 'The knowledge to persist in recall',
+			},
+			{
+				displayName: 'Category',
+				name: 'category',
+				type: 'options',
+				default: 'workflow',
+				options: [
+					{ name: 'Convention', value: 'convention' },
+					{ name: 'Decision', value: 'decision' },
+					{ name: 'Fact', value: 'fact' },
+					{ name: 'Workflow', value: 'workflow' },
+				],
+				description: 'Knowledge category for retrieval filtering',
+			},
+			{
+				displayName: 'Confidence',
+				name: 'confidence',
+				type: 'number',
+				default: 0.8,
+				typeOptions: {
+					minValue: 0,
+					maxValue: 1,
+					numberStepSize: 0.1,
+				},
+				description: 'Confidence score for the knowledge node (0.0 to 1.0)',
+			},
+			{
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'string',
+				default: '',
+				placeholder: 'api, auth, deployment',
+				description: 'Comma-separated tags for the knowledge node',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const results: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const credentials = await this.getCredentials('synaptApi');
+			const serverUrl = credentials.serverUrl as string;
+			const content = this.getNodeParameter('content', i) as string;
+			const category = this.getNodeParameter('category', i) as string;
+			const confidence = this.getNodeParameter('confidence', i) as number;
+			const tagsRaw = this.getNodeParameter('tags', i) as string;
+			const tags = tagsRaw ? tagsRaw.split(',').map((t) => t.trim()).filter(Boolean) : null;
+
+			const response = await this.helpers.httpRequest({
+				method: 'POST',
+				url: `${serverUrl}/mcp/call`,
+				body: {
+					tool: 'recall_save',
+					arguments: {
+						content,
+						category,
+						confidence,
+						...(tags ? { tags } : {}),
+					},
+				},
+				headers: {
+					'Content-Type': 'application/json',
+					...(credentials.apiKey ? { Authorization: `Bearer ${credentials.apiKey}` } : {}),
+				},
+			});
+
+			results.push({ json: response });
+		}
+
+		return [results];
+	}
+}

--- a/n8n-nodes/nodes/Synapt/SynaptSearch.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptSearch.node.ts
@@ -1,0 +1,88 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+export class SynaptSearch implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Synapt Search',
+		name: 'synaptSearch',
+		icon: 'file:synapt.svg',
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{$parameter["query"]}}',
+		description: 'Search recall memory for past sessions, decisions, and context',
+		defaults: {
+			name: 'Synapt Search',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'synaptApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				required: true,
+				placeholder: 'how did we fix the auth bug',
+				description: 'Semantic search query against recall memory',
+			},
+			{
+				displayName: 'Max Chunks',
+				name: 'maxChunks',
+				type: 'number',
+				default: 5,
+				description: 'Maximum number of context chunks to return',
+			},
+			{
+				displayName: 'Max Tokens',
+				name: 'maxTokens',
+				type: 'number',
+				default: 1500,
+				description: 'Token budget for returned context',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const results: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const credentials = await this.getCredentials('synaptApi');
+			const serverUrl = credentials.serverUrl as string;
+			const query = this.getNodeParameter('query', i) as string;
+			const maxChunks = this.getNodeParameter('maxChunks', i) as number;
+			const maxTokens = this.getNodeParameter('maxTokens', i) as number;
+
+			const response = await this.helpers.httpRequest({
+				method: 'POST',
+				url: `${serverUrl}/mcp/call`,
+				body: {
+					tool: 'recall_search',
+					arguments: {
+						query,
+						max_chunks: maxChunks,
+						max_tokens: maxTokens,
+					},
+				},
+				headers: {
+					'Content-Type': 'application/json',
+					...(credentials.apiKey ? { Authorization: `Bearer ${credentials.apiKey}` } : {}),
+				},
+			});
+
+			results.push({ json: response });
+		}
+
+		return [results];
+	}
+}

--- a/n8n-nodes/nodes/Synapt/SynaptSearch.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptSearch.node.ts
@@ -5,6 +5,10 @@ import {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 
+// TODO: synapt server currently exposes stdio MCP transport only.
+// These nodes are scaffolded against a planned HTTP transport endpoint.
+// See: https://github.com/synapt-dev/recall/issues for tracking.
+
 export class SynaptSearch implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Synapt Search',

--- a/n8n-nodes/nodes/Synapt/synapt.svg
+++ b/n8n-nodes/nodes/Synapt/synapt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#7c5cbf"/>
+  <text x="32" y="42" font-family="system-ui, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">S</text>
+</svg>

--- a/n8n-nodes/package.json
+++ b/n8n-nodes/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "n8n-nodes-synapt",
+  "version": "0.1.0",
+  "description": "n8n community nodes for synapt recall: search memory, save knowledge, and retrieve context across AI agent workflows.",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "synapt",
+    "recall",
+    "memory",
+    "ai-agents"
+  ],
+  "license": "MIT",
+  "homepage": "https://synapt.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/synapt-dev/recall.git",
+    "directory": "n8n-nodes"
+  },
+  "author": {
+    "name": "synapt",
+    "url": "https://synapt.dev"
+  },
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc && gulp build:icons",
+    "dev": "tsc --watch",
+    "lint": "eslint nodes credentials --ext .ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "credentials": [
+      "dist/credentials/SynaptApi.credentials.js"
+    ],
+    "nodes": [
+      "dist/nodes/Synapt/SynaptSearch.node.js",
+      "dist/nodes/Synapt/SynaptSave.node.js",
+      "dist/nodes/Synapt/SynaptContext.node.js"
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "gulp": "^4.0.0",
+    "n8n-workflow": "^1.0.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "^1.0.0"
+  }
+}

--- a/n8n-nodes/tsconfig.json
+++ b/n8n-nodes/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "commonjs",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "declaration": true,
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "nodes/**/*.ts",
+    "credentials/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary

- Scaffold `n8n-nodes-synapt` community node package under `n8n-nodes/`
- Three nodes: **SynaptSearch** (semantic search), **SynaptSave** (persist knowledge), **SynaptContext** (context/file history/timeline)
- Credentials type for server URL + optional API key
- Package uses `n8n-community-node-package` keyword for n8n marketplace discovery
- Nodes call the synapt recall MCP server via HTTP transport (`/mcp/call`)

Picking up from Atlas (on ADK compatibility work).

## Premium boundary

Premium boundary: OSS (n8n integration nodes wrapping public recall search/save/context APIs).

## Test plan

- [ ] Verify `package.json` has correct `n8n` field pointing to node/credential dist paths
- [ ] Verify node TypeScript compiles against `n8n-workflow` types
- [ ] Verify credential fields match synapt server HTTP transport config
- [ ] Verify each node maps to the correct recall MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)