### PR TITLE
docs: add Google ADK quickstart (Story 10)

### DIFF
--- a/docs/integrations/google-adk-quickstart.md
+++ b/docs/integrations/google-adk-quickstart.md
@@ -1,0 +1,104 @@
+# Google ADK quickstart
+
+Premium boundary: core OSS. This document covers the public `synapt server` MCP surface and how to consume it from Google ADK.
+
+## Compatibility result
+
+`synapt server` works with Google ADK's MCP client surface.
+
+Verified locally on April 19, 2026 with:
+
+- `google-adk==1.31.0`
+- `mcp==1.27.0`
+- local stdio connection through `google.adk.tools.mcp_tool.McpToolset`
+
+What was exercised:
+
+- ADK discovered 29 tools from `synapt server`
+- tool discovery included core recall operations such as `recall_search`, `recall_save`, and `recall_channel`
+- direct execution of `recall_quick` through the ADK MCP wrapper succeeded
+
+What was not fully exercised here:
+
+- Google Cloud API Registry deployment
+- Application Default Credentials against a real registered MCP server in Google Cloud
+
+The ADK `ApiRegistry` connector exists in the package and is the right distribution path for a hosted deployment, but it requires a Google Cloud project, a registered MCP server, and ADC with the relevant registry permissions.
+
+## Local quickstart
+
+1. Create and activate a virtual environment.
+
+```bash
+cd synapt
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+2. Install `synapt` and Google ADK.
+
+```bash
+python -m pip install -U pip
+python -m pip install -e ".[test]" google-adk
+```
+
+3. Run the compatibility probe.
+
+```bash
+python scripts/google_adk_probe.py
+```
+
+Expected result:
+
+- ADK lists the available `synapt` tools
+- `recall_quick` executes successfully through the MCP wrapper
+
+## Minimal ADK agent example
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+root_agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name="synapt_agent",
+    instruction="Use recall tools when they help answer the user.",
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="synapt",
+                    args=["server"],
+                ),
+                timeout=20.0,
+            )
+        )
+    ],
+)
+```
+
+## Cloud API Registry path
+
+For Google Cloud deployment, ADK exposes `ApiRegistry` as the registry-backed connector:
+
+```python
+from google.adk.integrations.api_registry import ApiRegistry
+
+api_registry = ApiRegistry(api_registry_project_id="your-project-id", location="global")
+toolset = api_registry.get_toolset(
+    "projects/your-project-id/locations/global/mcpServers/your-mcp-server-name"
+)
+```
+
+That path was not exercised in this workspace because it depends on:
+
+- a real Google Cloud project
+- a registered MCP server entry in Cloud API Registry
+- Application Default Credentials with registry access
+
+So the current recommendation is:
+
+- use the local stdio connector for development and compatibility testing
+- use `ApiRegistry` only once the hosted MCP deployment exists and ADC can be validated in CI or a staging project

--- a/scripts/google_adk_probe.py
+++ b/scripts/google_adk_probe.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Minimal Google ADK probe against the local synapt MCP server."""
+
+import asyncio
+import uuid
+
+from google.adk.agents import LlmAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from google.adk.tools.tool_context import ToolContext
+from mcp import StdioServerParameters
+
+
+async def main() -> None:
+    toolset = McpToolset(
+        connection_params=StdioConnectionParams(
+            server_params=StdioServerParameters(command="synapt", args=["server"]),
+            timeout=20.0,
+        )
+    )
+    try:
+        tools = await toolset.get_tools()
+        names = [getattr(tool, "name", type(tool).__name__) for tool in tools]
+        print(f"Discovered {len(names)} tools")
+        print(", ".join(names[:20]))
+
+        target = next(tool for tool in tools if getattr(tool, "name", "") == "recall_quick")
+        agent = LlmAgent(model="gemini-2.5-flash", name="probe_agent", instruction="Probe tools")
+        sessions = InMemorySessionService()
+        session = await sessions.create_session(app_name="synapt-adk-probe", user_id="local")
+        context = ToolContext(
+            InvocationContext(
+                invocation_id=str(uuid.uuid4()),
+                agent=agent,
+                session_service=sessions,
+                session=session,
+            )
+        )
+        result = await target.run_async(args={"query": "search"}, tool_context=context)
+        print("recall_quick call succeeded")
+        print(str(result)[:800])
+    finally:
+        await toolset.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Premium boundary: core OSS. This PR validates the public `synapt server` MCP surface against Google ADK and adds a quickstart for ADK users.

Closes #712

## What changed
- add Google ADK quickstart doc
- add reproducible local compatibility probe
- document local stdio validation and hosted `ApiRegistry` path limits

## Validation
```bash
source .venv/bin/activate
python -m py_compile scripts/google_adk_probe.py
python scripts/google_adk_probe.py
```