### PR TITLE
fix: correct Codex plugin scaffold layout

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "synapt plugins",
+  "name": "synapt-plugins",
   "interface": {
     "displayName": "synapt Plugins"
   },

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "synapt plugins",
+  "interface": {
+    "displayName": "synapt Plugins"
+  },
+  "plugins": [
+    {
+      "name": "synapt-recall",
+      "source": {
+        "source": "local",
+        "path": "./codex-plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,8 +1,7 @@
 {
-  "name": "synapt-codex-plugin",
+  "name": "synapt-recall",
   "version": "0.1.0",
   "description": "Codex plugin scaffold for synapt recall MCP access.",
-  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "synapt Recall",
     "shortDescription": "Local-first memory and recall for Codex.",


### PR DESCRIPTION
Premium boundary: core OSS. This PR only fixes the public Codex plugin packaging layout for the existing recall MCP scaffold.

Follow-up to #717.

## What changed
- move the marketplace manifest to `.agents/plugins/marketplace.json`
- add the plugin manifest at `codex-plugin/.codex-plugin/plugin.json`
- remove the incorrect `codex-plugin/marketplace.json` location

## Validation
```bash
python3 - <<'PY'
import json
from pathlib import Path
for path in [Path(".agents/plugins/marketplace.json"), Path("codex-plugin/.codex-plugin/plugin.json"), Path("codex-plugin/.mcp.json")]:
    json.loads(path.read_text())
    print(path, "ok")
PY
```