### PR TITLE
fix: align CrewAI TDD specs with storage-backend API

### DIFF
--- a/tests/integrations/test_crewai_adapter.py
+++ b/tests/integrations/test_crewai_adapter.py
@@ -20,12 +20,12 @@ def test_crewai_adapter_instantiates_and_matches_memory_interface(tmp_path):
     SynaptMemory = _adapter_cls()
 
     memory = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-1",
+        path=tmp_path / "crewai.jsonl",
+        root_scope="/crew/session-1",
     )
 
     assert isinstance(memory, CrewAIMemory)
-    assert memory.session_id == "crew-session-1"
+    assert memory.root_scope == "/crew/session-1"
     assert memory.recall("anything", limit=3) == []
 
 
@@ -33,8 +33,7 @@ def test_crewai_adapter_remember_and_recall_round_trip(tmp_path):
     SynaptMemory = _adapter_cls()
 
     memory = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-1",
+        path=tmp_path / "crewai.jsonl",
     )
 
     record = memory.remember(
@@ -50,42 +49,40 @@ def test_crewai_adapter_remember_and_recall_round_trip(tmp_path):
     assert matches[0].record.content == "The customer prefers JSON payloads and terse summaries."
 
 
-def test_crewai_adapter_persists_session_state_and_isolates_other_sessions(tmp_path):
+def test_crewai_adapter_persists_and_isolates_by_scope(tmp_path):
     SynaptMemory = _adapter_cls()
 
     first = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-1",
+        path=tmp_path / "crewai.jsonl",
+        root_scope="/crew/session-1",
     )
     first.remember("Escalations for Acme should go to Dana first.")
 
     reloaded = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-1",
+        path=tmp_path / "crewai.jsonl",
+        root_scope="/crew/session-1",
     )
-    other_session = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-2",
+    other_scope = SynaptMemory(
+        path=tmp_path / "other.jsonl",
+        root_scope="/crew/session-2",
     )
 
-    same_session_matches = reloaded.recall("Who handles Acme escalations?", limit=3)
-    other_session_matches = other_session.recall("Who handles Acme escalations?", limit=3)
+    same_scope_matches = reloaded.recall("Who handles Acme escalations?", limit=3)
+    other_scope_matches = other_scope.recall("Who handles Acme escalations?", limit=3)
 
-    assert same_session_matches
-    assert same_session_matches[0].record.content == "Escalations for Acme should go to Dana first."
-    assert other_session_matches == []
+    assert same_scope_matches
+    assert same_scope_matches[0].record.content == "Escalations for Acme should go to Dana first."
+    assert other_scope_matches == []
 
 
-def test_crewai_adapter_reset_clears_only_the_current_session(tmp_path):
+def test_crewai_adapter_reset_clears_only_own_storage(tmp_path):
     SynaptMemory = _adapter_cls()
 
     first = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-1",
+        path=tmp_path / "alpha.jsonl",
     )
     second = SynaptMemory(
-        db_path=tmp_path / "recall.db",
-        session_id="crew-session-2",
+        path=tmp_path / "beta.jsonl",
     )
 
     first.remember("Alpha crew owns incident response.")

--- a/tests/integrations/test_crewai_adapter.py
+++ b/tests/integrations/test_crewai_adapter.py
@@ -51,19 +51,20 @@ def test_crewai_adapter_remember_and_recall_round_trip(tmp_path):
 
 def test_crewai_adapter_persists_and_isolates_by_scope(tmp_path):
     SynaptMemory = _adapter_cls()
+    shared_path = tmp_path / "crewai.jsonl"
 
     first = SynaptMemory(
-        path=tmp_path / "crewai.jsonl",
+        path=shared_path,
         root_scope="/crew/session-1",
     )
     first.remember("Escalations for Acme should go to Dana first.")
 
     reloaded = SynaptMemory(
-        path=tmp_path / "crewai.jsonl",
+        path=shared_path,
         root_scope="/crew/session-1",
     )
     other_scope = SynaptMemory(
-        path=tmp_path / "other.jsonl",
+        path=shared_path,
         root_scope="/crew/session-2",
     )
 
@@ -75,14 +76,17 @@ def test_crewai_adapter_persists_and_isolates_by_scope(tmp_path):
     assert other_scope_matches == []
 
 
-def test_crewai_adapter_reset_clears_only_own_storage(tmp_path):
+def test_crewai_adapter_reset_clears_only_own_scope(tmp_path):
     SynaptMemory = _adapter_cls()
+    shared_path = tmp_path / "crewai.jsonl"
 
     first = SynaptMemory(
-        path=tmp_path / "alpha.jsonl",
+        path=shared_path,
+        root_scope="/crew/alpha",
     )
     second = SynaptMemory(
-        path=tmp_path / "beta.jsonl",
+        path=shared_path,
+        root_scope="/crew/beta",
     )
 
     first.remember("Alpha crew owns incident response.")


### PR DESCRIPTION
## Summary
- Updated TDD specs to use `path` and `root_scope` instead of `db_path` and `session_id`
- Tests now match the actual CrewAI adapter API (storage-backend pattern with scopes)
- All 4 CrewAI tests pass; full suite 2029 passed, 0 failed

Premium boundary: core OSS (test corrections for integration adapters).

Closes ceremony blocker: CrewAI TDD specs assumed a `session_id`-based API, but CrewAI's Memory class uses `root_scope` for isolation. Tests updated to match framework contract while preserving test intent.