### PR TITLE
fix: add importorskip for optional integration test deps

### DIFF
--- a/tests/integrations/test_langchain_adapter.py
+++ b/tests/integrations/test_langchain_adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
+langchain_core = pytest.importorskip("langchain_core")
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 

--- a/tests/integrations/test_openai_agents_adapter.py
+++ b/tests/integrations/test_openai_agents_adapter.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pytest_asyncio")
+
 
 @pytest.fixture
 def session(tmp_path: Path):


### PR DESCRIPTION
## Summary
CI doesn't install langchain-core, crewai, or pytest-asyncio. Integration tests now use `pytest.importorskip()` to skip gracefully when optional dependencies are absent.

Premium boundary: core OSS (test infrastructure).

Ceremony blocker: CI was failing on #723 because test collection crashed on missing langchain_core import.