### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.12.1"
+version = "0.13.0"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"


### PR DESCRIPTION
## Summary
- Bump version 0.12.1 -> 0.13.0 for Sprint 25 release
- Sprint 25 shipped the `src/synapt/integrations/` module with LangChain, CrewAI, and OpenAI Agents SDK adapters, plus Codex plugin scaffold, n8n community node, Google ADK quickstart, and README integration badges

## Premium boundary
Core OSS (version metadata only).

## Test plan
- [ ] `grep __version__` matches 0.13.0
- [ ] CI passes