### PR TITLE
feat: add MCP registry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.synapt-dev/recall -->
 <p align="center">
   <img src="assets/banner.png" alt="Synapt" width="100%">
 </p>

--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/schema/server.json",
+  "name": "io.github.synapt-dev/recall",
+  "description": "Persistent conversational memory for AI coding assistants. Search past sessions, preserve decisions, coordinate agents.",
+  "repository": {
+    "url": "https://github.com/synapt-dev/recall",
+    "source": "github"
+  },
+  "version": "0.13.0",
+  "packages": [
+    {
+      "registry_type": "pypi",
+      "identifier": "synapt",
+      "version": "0.13.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `server.json` with MCP registry schema for automated discovery
- Add `<!-- mcp-name: io.github.synapt-dev/recall -->` HTML comment to README.md top

Story 5, Sprint 26.

Premium boundary: recall repo is OSS (registry metadata for public package discovery).

## Test plan
- [x] `server.json` validates against MCP registry schema
- [x] HTML comment is first line of README.md, before banner image
- [x] Package identifier matches PyPI name (`synapt`)
- [x] Version matches current release (`0.13.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)