### PR TITLE
feat: add langchain-synapt package and langchain extra

### DIFF
--- a/langchain-synapt/README.md
+++ b/langchain-synapt/README.md
@@ -1,0 +1,47 @@
+# langchain-synapt
+
+LangChain chat message history backed by [synapt](https://synapt.dev) recall memory.
+
+## Install
+
+```bash
+pip install langchain-synapt
+```
+
+Or as an extra on the main package:
+
+```bash
+pip install synapt[langchain]
+```
+
+## Usage
+
+```python
+from langchain_core.messages import HumanMessage
+from langchain_synapt import SynaptChatMessageHistory
+
+history = SynaptChatMessageHistory(session_id="user-123")
+history.add_messages([HumanMessage(content="hello")])
+print(history.messages)
+
+# Semantic search across all recall-indexed sessions
+results = history.search("deployment config")
+
+# Persist a decision as a durable knowledge node
+history.save_to_recall("Always use UTC timestamps", category="convention")
+```
+
+`SynaptChatMessageHistory` implements LangChain's `BaseChatMessageHistory` and works with `RunnableWithMessageHistory`, `ConversationChain`, and any component that accepts a chat history backend.
+
+## Features
+
+- SQLite storage with WAL mode for concurrent access
+- Session isolation with multi-session support
+- Semantic search across all recall-indexed sessions
+- Knowledge persistence via recall's durable knowledge nodes
+- Full message metadata preservation (tool calls, response metadata, IDs)
+
+## Links
+
+- [synapt documentation](https://synapt.dev/guide.html)
+- [GitHub](https://github.com/synapt-dev/recall)

--- a/langchain-synapt/pyproject.toml
+++ b/langchain-synapt/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "langchain-synapt"
+version = "0.1.0"
+description = "LangChain chat message history backed by synapt recall"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "synapt[langchain]>=0.13.0",
+]
+authors = [
+    {name = "Layne Penney"},
+]
+
+[project.urls]
+Homepage = "https://synapt.dev"
+Repository = "https://github.com/synapt-dev/recall"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/langchain-synapt/src/langchain_synapt/__init__.py
+++ b/langchain-synapt/src/langchain_synapt/__init__.py
@@ -1,0 +1,24 @@
+"""LangChain integration for synapt recall memory.
+
+Thin wrapper that re-exports SynaptChatMessageHistory from the synapt
+package. Install via ``pip install langchain-synapt`` or
+``pip install synapt[langchain]``.
+
+Usage::
+
+    from langchain_synapt import SynaptChatMessageHistory
+
+    history = SynaptChatMessageHistory(session_id="user-123")
+    history.add_messages([HumanMessage(content="hello")])
+
+    # Semantic search across all recall-indexed sessions
+    results = history.search("deployment config")
+
+    # Persist a decision as a durable knowledge node
+    history.save_to_recall("Always use UTC timestamps", category="convention")
+"""
+
+from synapt.integrations.langchain import SynaptChatMessageHistory
+
+__all__ = ["SynaptChatMessageHistory"]
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Homepage = "https://synapt.dev"
 Repository = "https://github.com/laynepenney/recall"
 
 [project.optional-dependencies]
+langchain = ["langchain-core>=0.2"]
 hf = ["huggingface_hub>=0.20"]
 onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]


### PR DESCRIPTION
## Summary

- Adds `langchain` optional extra to `pyproject.toml` (`pip install synapt[langchain]` pulls in `langchain-core>=0.2`)
- Creates `langchain-synapt/` standalone package that depends on `synapt[langchain]` and re-exports `SynaptChatMessageHistory`
- Two install paths for the same adapter: `pip install synapt[langchain]` or `pip install langchain-synapt`

Both resolve to the existing adapter at `src/synapt/integrations/langchain.py`. The standalone package is a thin wrapper for PyPI discoverability in the LangChain ecosystem.

**Premium boundary**: core OSS (LangChain integration adapter and packaging).

## Test plan

- [x] All 24 existing LangChain adapter tests pass
- [x] `from synapt.integrations.langchain import SynaptChatMessageHistory` works with `pip install synapt[langchain]`
- [x] `from langchain_synapt import SynaptChatMessageHistory` works with `pip install langchain-synapt`
- [ ] Version sanity: `langchain-synapt==0.1.0`, `synapt>=0.13.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)