### PR TITLE
fix(mcp): correct server.json validation errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.13.0"
+version = "0.13.1"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/schema/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.synapt-dev/recall",
   "description": "Persistent conversational memory for AI coding assistants.",
   "repository": {
@@ -11,7 +11,10 @@
     {
       "registryType": "pypi",
       "identifier": "synapt",
-      "version": "0.13.0"
+      "version": "0.13.0",
+      "transport": {
+        "type": "stdio"
+      }
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/schema/server.json",
   "name": "io.github.synapt-dev/recall",
-  "description": "Persistent conversational memory for AI coding assistants. Search past sessions, preserve decisions, coordinate agents.",
+  "description": "Persistent conversational memory for AI coding assistants.",
   "repository": {
     "url": "https://github.com/synapt-dev/recall",
     "source": "github"
@@ -9,7 +9,7 @@
   "version": "0.13.0",
   "packages": [
     {
-      "registry_type": "pypi",
+      "registryType": "pypi",
       "identifier": "synapt",
       "version": "0.13.0"
     }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/synapt-dev/recall",
     "source": "github"
   },
-  "version": "0.13.0",
+  "version": "0.13.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "synapt",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"


### PR DESCRIPTION
## Summary

Unblocks the MCP Registry submission for \`io.github.synapt-dev/recall\`. Four serial fixes caught by \`mcp-publisher --dry-run\`:

1. **description**: shortened to fit 100-char limit (was 120+)
2. **registryType**: camelCase rename (was \`registry_type\`)
3. **$schema URL**: updated to versioned URL at \`static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json\` (legacy URL rejected)
4. **packages[0].transport.type**: set to \`stdio\` (now required; synapt MCP server runs as a stdio child process per \`src/synapt/server.py:12\`)

Plus one version bump to clear ownership validation:

5. **bump 0.13.0 → 0.13.1**: the registry validates ownership by checking the published PyPI README for an \`mcp-name\` marker. The marker was added in #728 but after 0.13.0 had shipped to PyPI (packages are immutable). We need to republish with the marker in place.

## Test plan

- [x] \`mcp-publisher publish --dry-run\` clears schema + transport errors
- [ ] After merge to sprint-26, ceremony to main, publish 0.13.1 to PyPI
- [ ] Re-run \`mcp-publisher publish\` (not dry-run) — ownership validation should pass against published 0.13.1

## Boundary

Premium boundary: OSS (recall repo — MCP registry metadata + version bump; no identity/org semantics).

Part of Sprint 26 Story 5 (MCP Registry publish).