### PR TITLE
fix(pyproject): update Repository URL to synapt-dev org

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ authors = [
 
 [project.urls]
 Homepage = "https://synapt.dev"
-Repository = "https://github.com/laynepenney/recall"
+Repository = "https://github.com/synapt-dev/recall"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]


### PR DESCRIPTION
## Summary

One-line fix to the stale \`Repository\` URL in \`pyproject.toml\`, left over from the 2026-03 repo rename (\`laynepenney/synapt\` → \`synapt-dev/recall\`, commit \`aec50b0\`).

This URL shows up on the PyPI project page and in any tool that reads \`project.urls\`. Getting it fixed before we republish 0.13.1 to PyPI (for Sprint 26 Story 5 MCP registry unblock) so the correct URL ships with that release.

## Test plan

- [x] grep confirms no other \`laynepenney/recall\` references in pyproject.toml
- [x] URL matches the canonical repo (\`github.com/synapt-dev/recall\`)

## Out of scope (tracked for later)

Other stale \`laynepenney\` references remain and can be cleaned up in a separate PR:
- \`.github/workflows/cla.yml\` (CLA bot still points at old repo — explains the CLA link in PR checks)
- \`CONTRIBUTING.md\` git clone URL
- \`scripts/sprint_metrics.py\` default repo arg
- Historical \`docs/blog/*\` and \`docs/marketing/*\` references (may be intentional)

## Boundary

Premium boundary: OSS (recall repo — public metadata only).

Part of Sprint 26 Story 5 cleanup.