### PR TITLE
chore: update stale laynepenney refs in live project files

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,12 +22,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: ".github/contributors/cla-signatures.json"
-          path-to-document: "https://github.com/laynepenney/recall/blob/main/CLA.md"
+          path-to-document: "https://github.com/synapt-dev/recall/blob/main/CLA.md"
           branch: "main"
           allowlist: dependabot[bot],renovate[bot],github-actions[bot],claude
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
           custom-notsigned-prcomment: |
-            Thank you for your contribution! Before we can merge this PR, we need you to sign our [Contributor License Agreement](https://github.com/laynepenney/recall/blob/main/CLA.md).
+            Thank you for your contribution! Before we can merge this PR, we need you to sign our [Contributor License Agreement](https://github.com/synapt-dev/recall/blob/main/CLA.md).
 
             To sign, please comment on this PR with the following exact text:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 ## Getting started
 
 ```bash
-git clone https://github.com/laynepenney/recall.git
-cd synapt
+git clone https://github.com/synapt-dev/recall.git
+cd recall
 pip install -e ".[test]"
 pytest tests/ -v
 ```

--- a/scripts/sprint_metrics.py
+++ b/scripts/sprint_metrics.py
@@ -10,7 +10,7 @@ are not captured here — those would need channel JSONL parsing for
 "approved"/"LGTM" signals.
 
 Usage:
-    python scripts/sprint_metrics.py [--sprint 4] [--repo laynepenney/synapt]
+    python scripts/sprint_metrics.py [--sprint 4] [--repo synapt-dev/recall]
     python scripts/sprint_metrics.py --prs 471,472,475,477,478,479,481
     python scripts/sprint_metrics.py --prs 471,472 --channel-dir ~/.synapt/recall/channels
 """
@@ -240,7 +240,7 @@ def format_report(metrics: dict, sprint: str = "") -> str:
 
 def main():
     parser = argparse.ArgumentParser(description="Sprint metrics")
-    parser.add_argument("--repo", default="laynepenney/synapt")
+    parser.add_argument("--repo", default="synapt-dev/recall")
     parser.add_argument("--prs", help="Comma-separated PR numbers")
     parser.add_argument("--sprint", default="")
     parser.add_argument("--channel-dir", help="Path to channel JSONL dir for claim times")


### PR DESCRIPTION
## Summary

Cleans up three live project files that still referenced the pre-rename repo path (\`laynepenney/synapt\` or \`laynepenney/recall\`) from the 2026-03 org migration (commit \`aec50b0\`).

| File | Fix |
|------|-----|
| \`.github/workflows/cla.yml\` | CLA bot document URL (2 refs). Explains why recent PRs saw the CLA-check link point to the old repo. |
| \`CONTRIBUTING.md\` | \`git clone\` URL + \`cd\` target. |
| \`scripts/sprint_metrics.py\` | \`--repo\` default arg + usage docstring. |

## Out of scope (intentionally)

Historical docs left intact — they document history as it was:
- \`docs/agent-madness-submission.md\`
- \`docs/blog/*.md\` and \`docs/blog/*.html\`
- \`docs/marketing/linkedin-*.md\`
- \`docs/index.html\`, \`docs/guide.html\`

Rewriting published/historical artifacts is worse than letting them stand.

## Test plan

- [x] \`grep -r laynepenney\` confirms only historical docs remain
- [x] CLA bot URL now points to the canonical repo — next PR's CLA check should link correctly

## Boundary

Premium boundary: OSS (recall repo — contributor onboarding + internal script metadata).