### PR TITLE
fix: align SynaptSession with OpenAI SessionABC

### DIFF
--- a/src/synapt/integrations/openai_agents.py
+++ b/src/synapt/integrations/openai_agents.py
@@ -23,6 +23,11 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+try:  # pragma: no cover - optional dependency surface
+    from agents.memory.session import SessionABC
+except ImportError:  # pragma: no cover
+    SessionABC = object  # type: ignore[assignment,misc]
+
 _DEFAULT_DB_DIR = Path.home() / ".synapt" / "integrations"
 
 _SCHEMA = """\
@@ -37,7 +42,7 @@ CREATE INDEX IF NOT EXISTS idx_agent_items_session
 """
 
 
-class SynaptSession:
+class SynaptSession(SessionABC):
     """OpenAI Agents SDK Session backed by SQLite with recall integration.
 
     Implements the Session protocol: get_items, add_items, pop_item,

--- a/tests/integrations/test_openai_agents_adapter.py
+++ b/tests/integrations/test_openai_agents_adapter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 pytest.importorskip("pytest_asyncio")
+agents_session = pytest.importorskip("agents.memory.session")
 
 
 @pytest.fixture
@@ -28,6 +29,11 @@ def session_b(tmp_path: Path):
 
 
 class TestSessionProtocolContract:
+
+    def test_implements_session_abc(self):
+        from synapt.integrations.openai_agents import SynaptSession
+
+        assert issubclass(SynaptSession, agents_session.SessionABC)
 
     @pytest.mark.asyncio
     async def test_empty_on_init(self, session):


### PR DESCRIPTION
## Summary
- make `SynaptSession` inherit the OpenAI Agents SDK `SessionABC` when available
- keep the same async session behavior and sqlite-backed storage
- add a regression test for the harness type check

## Testing
- `PYTHONPATH=/tmp/recall-s27-sentinel/src /tmp/s27-openai-venv/bin/python -m pytest -q tests/integrations/test_openai_agents_adapter.py`
- fresh-runtime smoke in a clean venv: `OPENAI_OK`

## Boundary
- OSS-only adapter compatibility fix; no premium code or identity/org semantics changed.