### PR TITLE
feat: recall_career OSS stub + plugin seam (Story 11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ synapt-convert = "synapt._models.convert:main"
 
 [project.entry-points."synapt.plugins"]
 x = "synapt.x.server"
+persistent = "synapt.persistent.server"
 # External plugins register via their own pyproject.toml. Example:
 # repair = "synapt_repair.server"
 

--- a/src/synapt/persistent/__init__.py
+++ b/src/synapt/persistent/__init__.py
@@ -1,0 +1,4 @@
+"""synapt.persistent — OSS stubs for persistent agent memory.
+
+Premium replaces these stubs via the synapt.plugins entry point system.
+"""

--- a/src/synapt/persistent/server.py
+++ b/src/synapt/persistent/server.py
@@ -1,0 +1,50 @@
+"""OSS stubs for persistent-agent career memory tools.
+
+Premium overrides these via the synapt.plugins entry point. When premium
+is installed, its register_tools replaces these stubs with the real
+implementation backed by career.db.
+"""
+
+from __future__ import annotations
+
+PLUGIN_NAME = "persistent"
+PLUGIN_VERSION = "0.1.0"
+
+_PREMIUM_MSG = (
+    "recall_career requires premium. "
+    "Install synapt-private to unlock persistent agent memory."
+)
+
+
+def recall_career(
+    action: str = "search",
+    query: str = "",
+    lesson: str = "",
+    scope: str = "agent",
+    source_project: str = "",
+    lesson_id: str = "",
+    agent_name: str | None = None,
+    project_dir: str = "",
+) -> str:
+    """Manage career lessons learned across projects (premium stub).
+
+    Career memory stores durable lessons that persist across projects and
+    sessions. Lessons have three scopes: project (local), team (org-shared),
+    and agent (personal career knowledge).
+
+    Args:
+        action: "search", "list", "save", "retract".
+        query: Search query for "search" action.
+        lesson: Lesson text for "save" action.
+        scope: "project", "team", or "agent" (default "agent").
+        source_project: Project that generated the lesson.
+        lesson_id: Lesson ID for "retract" action.
+        agent_name: Agent identity (resolved from env if omitted).
+        project_dir: Project directory for scope resolution.
+    """
+    return _PREMIUM_MSG
+
+
+def register_tools(mcp) -> None:
+    """Register career memory stubs on the MCP server."""
+    mcp.tool()(recall_career)

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -16,6 +16,7 @@ Provides fifteen tools via the Model Context Protocol:
   - recall_enrich: Enrich chunks with LLM-generated summaries
   - recall_consolidate: Extract durable knowledge from journal entries
   - recall_contradict: Manage pending knowledge contradictions
+  - recall_career: Manage career lessons (premium stub)
 
 Can run standalone (synapt-server) or be composed into the
 unified synapt server via register_tools(mcp).
@@ -2085,6 +2086,40 @@ def _with_directive_check(fn):
     return wrapper
 
 
+def recall_career(
+    action: str = "search",
+    query: str = "",
+    lesson: str = "",
+    scope: str = "agent",
+    source_project: str = "",
+    lesson_id: str = "",
+    agent_name: str | None = None,
+    project_dir: str = "",
+) -> str:
+    """Manage career lessons learned across projects.
+
+    Career memory stores durable lessons that persist across projects and
+    sessions. Lessons have three scopes: project (local), team (org-shared),
+    and agent (personal career knowledge).
+
+    This is an OSS stub. Install synapt-private for full career memory.
+
+    Args:
+        action: "search", "list", "save", "retract".
+        query: Search query for "search" action.
+        lesson: Lesson text for "save" action.
+        scope: "project", "team", or "agent" (default "agent").
+        source_project: Project that generated the lesson.
+        lesson_id: Lesson ID for "retract" action.
+        agent_name: Agent identity (resolved from env if omitted).
+        project_dir: Project directory for scope resolution.
+    """
+    return (
+        "recall_career requires premium. "
+        "Install synapt-private to unlock persistent agent memory."
+    )
+
+
 def recall_reload() -> str:
     """Restart the MCP server to pick up code changes after pip install.
 
@@ -2138,6 +2173,7 @@ def register_tools(mcp) -> None:
     mcp.tool()(_with_directive_check(recall_context))
     mcp.tool()(_with_directive_check(recall_timeline))
     mcp.tool()(_with_directive_check(recall_channel))
+    mcp.tool()(recall_career)
     mcp.tool()(recall_reload)
 
 

--- a/tests/test_career_tool_stub.py
+++ b/tests/test_career_tool_stub.py
@@ -1,0 +1,174 @@
+"""Tests for recall_career OSS stub — Story 11.
+
+The OSS recall_career tool is a no-op stub that returns a premium-required
+message for all actions. Premium replaces it via the plugin entry point seam.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+from synapt.plugins import LoadedPlugin, register_plugins
+from synapt.recall.server import recall_career, register_tools
+
+
+class TestRecallCareerStub:
+    """recall_career OSS stub returns premium-required for all actions."""
+
+    def test_search_action_returns_premium_message(self):
+        result = recall_career(action="search", query="testing lessons")
+        assert "premium" in result.lower()
+
+    def test_list_action_returns_premium_message(self):
+        result = recall_career(action="list")
+        assert "premium" in result.lower()
+
+    def test_save_action_returns_premium_message(self):
+        result = recall_career(
+            action="save",
+            lesson="Always validate inputs",
+            scope="agent",
+            source_project="recall",
+        )
+        assert "premium" in result.lower()
+
+    def test_retract_action_returns_premium_message(self):
+        result = recall_career(action="retract", lesson_id="abc123")
+        assert "premium" in result.lower()
+
+    def test_unknown_action_returns_premium_message(self):
+        result = recall_career(action="unknown_action")
+        assert "premium" in result.lower()
+
+    def test_returns_string(self):
+        result = recall_career(action="list")
+        assert isinstance(result, str)
+
+    def test_default_action_is_search(self):
+        result = recall_career()
+        assert "premium" in result.lower()
+
+    def test_message_includes_tool_name(self):
+        result = recall_career(action="search")
+        assert "recall_career" in result
+
+
+class TestRecallCareerRegistration:
+    """recall_career is registered as an MCP tool via register_tools."""
+
+    def test_career_registered_in_mcp(self):
+        mcp = MagicMock()
+        register_tools(mcp)
+        registered_names = {
+            call.args[0].__name__
+            for call in mcp.tool.return_value.call_args_list
+            if call.args
+        }
+        assert "recall_career" in registered_names
+
+
+class TestRecallCareerSignature:
+    """recall_career accepts the documented parameters."""
+
+    def test_accepts_action_param(self):
+        recall_career(action="search")
+
+    def test_accepts_query_param(self):
+        recall_career(action="search", query="test")
+
+    def test_accepts_lesson_param(self):
+        recall_career(action="save", lesson="test lesson")
+
+    def test_accepts_scope_param(self):
+        recall_career(action="save", scope="team")
+
+    def test_accepts_source_project_param(self):
+        recall_career(action="save", source_project="recall")
+
+    def test_accepts_lesson_id_param(self):
+        recall_career(action="retract", lesson_id="abc123")
+
+    def test_accepts_agent_name_param(self):
+        recall_career(action="search", agent_name="apollo")
+
+    def test_accepts_project_dir_param(self):
+        recall_career(action="search", project_dir="/tmp/project")
+
+    def test_all_params_together(self):
+        result = recall_career(
+            action="save",
+            query="test",
+            lesson="learned something",
+            scope="agent",
+            source_project="grip",
+            lesson_id="",
+            agent_name="apollo",
+            project_dir="/tmp",
+        )
+        assert isinstance(result, str)
+
+
+class TestPersistentPluginSeam:
+    """The synapt.persistent.server module provides the plugin seam."""
+
+    def test_persistent_module_is_importable(self):
+        import synapt.persistent.server as career_plugin
+        assert hasattr(career_plugin, "register_tools")
+        assert callable(career_plugin.register_tools)
+
+    def test_persistent_module_has_recall_career(self):
+        import synapt.persistent.server as career_plugin
+        assert hasattr(career_plugin, "recall_career")
+        assert callable(career_plugin.recall_career)
+
+    def test_persistent_stub_returns_premium_message(self):
+        import synapt.persistent.server as career_plugin
+        result = career_plugin.recall_career(action="search", query="test")
+        assert "premium" in result.lower()
+        assert "recall_career" in result
+
+    def test_persistent_register_tools_registers_career(self):
+        import synapt.persistent.server as career_plugin
+        captured = []
+
+        class FakeMCP:
+            def tool(self):
+                def decorator(fn):
+                    captured.append(fn)
+                    return fn
+                return decorator
+
+        career_plugin.register_tools(FakeMCP())
+        names = {fn.__name__ for fn in captured}
+        assert "recall_career" in names
+
+    def test_persistent_stub_has_action_api(self):
+        import synapt.persistent.server as career_plugin
+        sig = inspect.signature(career_plugin.recall_career)
+        assert "action" in sig.parameters
+        assert "query" in sig.parameters
+        assert "agent_name" in sig.parameters
+        assert "project_dir" in sig.parameters
+        assert "scope" in sig.parameters
+
+    def test_persistent_plugin_registers_through_loader(self):
+        import synapt.persistent.server as career_plugin
+        calls = []
+
+        class FakeMCP:
+            def tool(self):
+                def decorator(fn):
+                    calls.append(fn.__name__)
+                    return fn
+                return decorator
+
+        plugin = LoadedPlugin("persistent", "", career_plugin, "persistent")
+        registered = register_plugins(FakeMCP(), [plugin])
+        assert [p.name for p in registered] == ["persistent"]
+        assert "recall_career" in calls
+
+    def test_persistent_module_has_plugin_metadata(self):
+        import synapt.persistent.server as career_plugin
+        assert career_plugin.PLUGIN_NAME == "persistent"
+        assert career_plugin.PLUGIN_VERSION == "0.1.0"


### PR DESCRIPTION
## Summary
- Add `recall_career` as an OSS no-op stub to the MCP server that returns "career memory requires premium"
- Create `synapt.persistent.server` module as the plugin seam for premium override
- Register the persistent plugin via entry point in pyproject.toml
- 25 tests covering stub behavior, MCP registration, parameter contract, and plugin loader integration
- Satisfies Sentinel's TDD spec from recall#740 (all 3 tests pass)

## Details

The stub accepts the full action-based API: `action`, `query`, `lesson`, `scope`, `source_project`, `lesson_id`, `agent_name`, `project_dir`. All actions return the premium-required message.

Two registration paths:
1. **Direct** in `recall/server.py` `register_tools()` (always available in any server mode)
2. **Plugin** via `synapt.persistent.server` entry point (discoverable by plugin loader, overridable by premium)

When `synapt-private` is installed, its `persistent` plugin re-registers `recall_career` with the real career.db-backed implementation.

## Premium boundary
Core OSS: plugin seam infrastructure. No identity resolution, no career.db, no org semantics.

## Test plan
- [x] 25 tests pass (`pytest tests/test_career_tool_stub.py -v`)
- [x] Sentinel's recall#740 spec (3 tests) passes against this implementation
- [x] Full test suite: 2046 passed, 0 failures
- [x] No regressions in existing tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)