### PR TITLE
feat: fix dashboard tmux agent discovery

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "synapt plugins",
+  "name": "synapt-plugins",
   "interface": {
     "displayName": "synapt Plugins"
   },

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "synapt plugins",
+  "interface": {
+    "displayName": "synapt Plugins"
+  },
+  "plugins": [
+    {
+      "name": "synapt-recall",
+      "source": {
+        "source": "local",
+        "path": "./codex-plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@
 <p align="center">
   <a href="https://pypi.org/project/synapt/"><img src="https://img.shields.io/pypi/v/synapt?color=7c5cbf" alt="PyPI"></a>
   <a href="https://pypi.org/project/synapt/"><img src="https://img.shields.io/pypi/pyversions/synapt?color=00e5cc" alt="Python"></a>
-  <a href="https://github.com/laynepenney/recall/blob/main/LICENSE"><img src="https://img.shields.io/github/license/laynepenney/recall" alt="License"></a>
+  <a href="https://github.com/synapt-dev/recall/blob/main/LICENSE"><img src="https://img.shields.io/github/license/synapt-dev/recall" alt="License"></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/LangChain-ready-1C3C3C?logo=langchain&logoColor=white" alt="LangChain">
+  <img src="https://img.shields.io/badge/CrewAI-ready-FF6B35?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0id2hpdGUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjYiLz48L3N2Zz4=&logoColor=white" alt="CrewAI">
+  <img src="https://img.shields.io/badge/OpenAI_Agents-ready-412991?logo=openai&logoColor=white" alt="OpenAI Agents">
+  <img src="https://img.shields.io/badge/Claude_Code-ready-D97706?logo=anthropic&logoColor=white" alt="Claude Code">
+  <img src="https://img.shields.io/badge/Codex_CLI-ready-412991?logo=openai&logoColor=white" alt="Codex CLI">
 </p>
 
 <p align="center">
@@ -121,6 +129,110 @@ If your client accepts stdio MCP definitions directly, use:
   }
 }
 ```
+
+## Framework integrations
+
+synapt plugs into popular agent frameworks as a drop-in memory backend. Each adapter wraps recall's search and save API for the framework's native session interface.
+
+### LangChain
+
+`SynaptChatMessageHistory` implements LangChain's `BaseChatMessageHistory`. Messages are stored in SQLite with WAL mode; recall search and knowledge persistence are one method call away.
+
+```bash
+pip install synapt langchain-core
+```
+
+```python
+from langchain_core.messages import HumanMessage
+from synapt.integrations.langchain import SynaptChatMessageHistory
+
+history = SynaptChatMessageHistory(session_id="user-123")
+history.add_messages([HumanMessage(content="hello")])
+print(history.messages)
+
+# Semantic search across all indexed sessions
+results = history.search("deployment config")
+
+# Persist a decision as a durable knowledge node
+history.save_to_recall("Always use UTC timestamps", category="convention")
+```
+
+Works with `RunnableWithMessageHistory`, `ConversationChain`, and any LangChain component that accepts a `BaseChatMessageHistory`.
+
+### OpenAI Agents SDK
+
+`SynaptSession` implements the Agents SDK `Session` protocol. Items are stored as JSON dicts in SQLite; async throughout.
+
+```bash
+pip install synapt openai-agents
+```
+
+```python
+from synapt.integrations.openai_agents import SynaptSession
+
+session = SynaptSession(session_id="agent-run-42")
+await session.add_items([{"role": "user", "content": "hello"}])
+items = await session.get_items(limit=10)
+
+# Bridge to recall search
+results = session.search("prior error handling decisions")
+```
+
+### CrewAI
+
+`SynaptMemory` provides long-term memory storage for CrewAI crews, backed by recall's hybrid search.
+
+```bash
+pip install synapt[crewai]
+```
+
+```python
+from synapt.integrations.crewai import SynaptMemory
+
+memory = SynaptMemory()
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, write_task],
+    memory=memory,
+)
+crew.kickoff()
+```
+
+### Claude Code
+
+Register the recall MCP server and initialize the project:
+
+```bash
+pip install synapt
+claude mcp add synapt -- synapt server
+synapt init
+```
+
+Claude Code gains `recall_search`, `recall_save`, `recall_journal`, and 20+ other recall tools automatically. `synapt init` also installs session hooks for automatic transcript archiving.
+
+### Codex CLI
+
+Install synapt and register the MCP server:
+
+```bash
+pip install synapt
+```
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.synapt]
+command = "synapt"
+args = ["server"]
+```
+
+Then initialize the project:
+
+```bash
+synapt init
+```
+
+`synapt init` installs the `dev-loop` skill automatically, giving Codex recall search, channel coordination, and journal access.
 
 ## What `synapt init` does
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "synapt-recall",
+  "version": "0.1.0",
+  "description": "Persistent memory for Claude Code sessions via synapt recall",
+  "author": {
+    "name": "synapt",
+    "url": "https://github.com/synapt-dev"
+  },
+  "homepage": "https://synapt.dev",
+  "repository": "https://github.com/synapt-dev/recall",
+  "license": "MIT",
+  "keywords": ["memory", "recall", "persistent", "context", "sessions"]
+}

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "synapt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "synapt", "synapt", "server"]
+    }
+  }
+}

--- a/claude-plugin/skills/recall/SKILL.md
+++ b/claude-plugin/skills/recall/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: recall
+description: Persistent memory across Claude Code sessions. Search before you act.
+---
+
+# synapt recall
+
+Persistent memory for Claude Code. Search past sessions, save durable knowledge, and maintain context across conversations.
+
+## When to use (do this automatically, without being asked)
+
+- **Before making a design decision**: `recall_search` for prior discussion
+- **When debugging an error**: `recall_search` for past fixes
+- **When user references past work**: `recall_search` immediately
+- **Starting a session**: `recall_journal` to read recent entries
+- **When unsure if something was discussed**: `recall_quick` (fast, cheap)
+- **When you need file history**: `recall_files` for who changed what and why
+
+## Tool selection
+
+| Tool | Use when | Cost |
+|------|----------|------|
+| `recall_quick` | Speculative check, unsure if relevant history exists | ~500 tokens |
+| `recall_search` | Need full transcript chunks with detail | ~2000 tokens |
+| `recall_files` | Need file change history and rationale | ~1500 tokens |
+| `recall_journal` | Reading/writing session notes | ~500 tokens |
+| `recall_save` | Persisting a durable fact, decision, or convention | ~200 tokens |
+| `recall_remind` | Setting cross-session reminders | ~200 tokens |
+
+## Key principle
+
+When in doubt, search. A `recall_quick` check costs ~500 tokens and takes <100ms. Missing relevant past context costs far more in wasted work and repeated mistakes.
+
+## Do NOT search for
+
+- General programming questions or syntax help
+- API docs or library documentation
+- Anything not specific to this project's history

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,8 +1,7 @@
 {
-  "name": "synapt-codex-plugin",
+  "name": "synapt-recall",
   "version": "0.1.0",
   "description": "Codex plugin scaffold for synapt recall MCP access.",
-  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "synapt Recall",
     "shortDescription": "Local-first memory and recall for Codex.",

--- a/codex-plugin/.mcp.json
+++ b/codex-plugin/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "synapt": {
+      "command": "synapt",
+      "args": [
+        "server"
+      ]
+    }
+  }
+}

--- a/codex-plugin/AGENTS.md
+++ b/codex-plugin/AGENTS.md
@@ -1,0 +1,34 @@
+# synapt Codex Plugin
+
+Use this plugin when Codex should have direct access to synapt recall over MCP.
+
+## What it provides
+
+- local `synapt server` MCP access
+- recall search, save, context, journal, and channel tools
+- no identity or org behavior; this is OSS-only packaging of existing recall primitives
+
+## Install shapes
+
+Plugin form:
+
+```bash
+codex plugin add synapt-dev/recall-plugin
+```
+
+Direct MCP fallback:
+
+```bash
+codex mcp add synapt -- synapt server
+```
+
+## Usage guidance
+
+- prefer `recall_quick` for cheap speculative lookup
+- use `recall_search` for real retrieval
+- use `recall_save` only for durable facts, conventions, or decisions
+- treat `#dev` as shared operational memory when the session is part of team coordination
+
+## Boundary
+
+Premium boundary: this plugin is OSS because it only packages the public synapt MCP server and instructions. Identity, org routing, and premium policy remain outside this scaffold.

--- a/codex-plugin/marketplace.json
+++ b/codex-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "synapt-codex-plugin",
+  "version": "0.1.0",
+  "description": "Codex plugin scaffold for synapt recall MCP access.",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "synapt Recall",
+    "shortDescription": "Local-first memory and recall for Codex.",
+    "longDescription": "Adds the synapt MCP server plus recall-aware instructions so Codex can search, save, and reuse local memory across sessions.",
+    "developerName": "synapt-dev",
+    "category": "Productivity",
+    "capabilities": [
+      "MCP",
+      "Recall",
+      "Local Memory"
+    ]
+  }
+}

--- a/docs/integrations/google-adk-quickstart.md
+++ b/docs/integrations/google-adk-quickstart.md
@@ -1,0 +1,104 @@
+# Google ADK quickstart
+
+Premium boundary: core OSS. This document covers the public `synapt server` MCP surface and how to consume it from Google ADK.
+
+## Compatibility result
+
+`synapt server` works with Google ADK's MCP client surface.
+
+Verified locally on April 19, 2026 with:
+
+- `google-adk==1.31.0`
+- `mcp==1.27.0`
+- local stdio connection through `google.adk.tools.mcp_tool.McpToolset`
+
+What was exercised:
+
+- ADK discovered 29 tools from `synapt server`
+- tool discovery included core recall operations such as `recall_search`, `recall_save`, and `recall_channel`
+- direct execution of `recall_quick` through the ADK MCP wrapper succeeded
+
+What was not fully exercised here:
+
+- Google Cloud API Registry deployment
+- Application Default Credentials against a real registered MCP server in Google Cloud
+
+The ADK `ApiRegistry` connector exists in the package and is the right distribution path for a hosted deployment, but it requires a Google Cloud project, a registered MCP server, and ADC with the relevant registry permissions.
+
+## Local quickstart
+
+1. Create and activate a virtual environment.
+
+```bash
+cd synapt
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+2. Install `synapt` and Google ADK.
+
+```bash
+python -m pip install -U pip
+python -m pip install -e ".[test]" google-adk
+```
+
+3. Run the compatibility probe.
+
+```bash
+python scripts/google_adk_probe.py
+```
+
+Expected result:
+
+- ADK lists the available `synapt` tools
+- `recall_quick` executes successfully through the MCP wrapper
+
+## Minimal ADK agent example
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+root_agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name="synapt_agent",
+    instruction="Use recall tools when they help answer the user.",
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="synapt",
+                    args=["server"],
+                ),
+                timeout=20.0,
+            )
+        )
+    ],
+)
+```
+
+## Cloud API Registry path
+
+For Google Cloud deployment, ADK exposes `ApiRegistry` as the registry-backed connector:
+
+```python
+from google.adk.integrations.api_registry import ApiRegistry
+
+api_registry = ApiRegistry(api_registry_project_id="your-project-id", location="global")
+toolset = api_registry.get_toolset(
+    "projects/your-project-id/locations/global/mcpServers/your-mcp-server-name"
+)
+```
+
+That path was not exercised in this workspace because it depends on:
+
+- a real Google Cloud project
+- a registered MCP server entry in Cloud API Registry
+- Application Default Credentials with registry access
+
+So the current recommendation is:
+
+- use the local stdio connector for development and compatibility testing
+- use `ApiRegistry` only once the hosted MCP deployment exists and ADC can be validated in CI or a staging project

--- a/n8n-nodes/credentials/SynaptApi.credentials.ts
+++ b/n8n-nodes/credentials/SynaptApi.credentials.ts
@@ -1,0 +1,28 @@
+import {
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class SynaptApi implements ICredentialType {
+	name = 'synaptApi';
+	displayName = 'Synapt API';
+	documentationUrl = 'https://synapt.dev/guide.html';
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Server URL',
+			name: 'serverUrl',
+			type: 'string',
+			default: 'http://localhost:8417',
+			placeholder: 'http://localhost:8417',
+			description: 'URL of the synapt recall MCP server (HTTP transport)',
+		},
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description: 'Optional API key for authenticated synapt instances',
+		},
+	];
+}

--- a/n8n-nodes/index.ts
+++ b/n8n-nodes/index.ts
@@ -1,0 +1,4 @@
+export { SynaptSearch } from './nodes/Synapt/SynaptSearch.node';
+export { SynaptSave } from './nodes/Synapt/SynaptSave.node';
+export { SynaptContext } from './nodes/Synapt/SynaptContext.node';
+export { SynaptApi } from './credentials/SynaptApi.credentials';

--- a/n8n-nodes/nodes/Synapt/SynaptContext.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptContext.node.ts
@@ -1,0 +1,202 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+// TODO: synapt server currently exposes stdio MCP transport only.
+// These nodes are scaffolded against a planned HTTP transport endpoint.
+// See: https://github.com/synapt-dev/recall/issues for tracking.
+
+export class SynaptContext implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Synapt Context',
+		name: 'synaptContext',
+		icon: 'file:synapt.svg',
+		group: ['transform'],
+		version: 1,
+		description: 'Retrieve file history, timeline, or drill into a search result from recall memory',
+		defaults: {
+			name: 'Synapt Context',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'synaptApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				default: 'files',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'File History',
+						value: 'files',
+						description: 'Find past sessions that touched a specific file',
+					},
+					{
+						name: 'Timeline',
+						value: 'timeline',
+						description: 'View chronological timeline of work arcs',
+					},
+					{
+						name: 'Drill Down',
+						value: 'context',
+						description: 'Get full transcript for a chunk or cluster from a search result',
+					},
+				],
+			},
+			{
+				displayName: 'File Pattern',
+				name: 'pattern',
+				type: 'string',
+				default: '',
+				required: true,
+				placeholder: 'src/auth.py',
+				description: 'File path or partial path to search for (supports partial matching)',
+				displayOptions: {
+					show: {
+						operation: ['files'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Chunks',
+				name: 'maxChunks',
+				type: 'number',
+				default: 10,
+				description: 'Maximum number of result chunks to return',
+				displayOptions: {
+					show: {
+						operation: ['files'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Tokens',
+				name: 'maxTokens',
+				type: 'number',
+				default: 1500,
+				description: 'Token budget for returned context',
+				displayOptions: {
+					show: {
+						operation: ['files'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Results',
+				name: 'maxResults',
+				type: 'number',
+				default: 10,
+				description: 'Maximum number of timeline arcs to return',
+				displayOptions: {
+					show: {
+						operation: ['timeline'],
+					},
+				},
+			},
+			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				placeholder: 'auth refactor',
+				description: 'Optional text query to filter timeline arcs',
+				displayOptions: {
+					show: {
+						operation: ['timeline'],
+					},
+				},
+			},
+			{
+				displayName: 'Chunk ID',
+				name: 'chunkId',
+				type: 'string',
+				default: '',
+				placeholder: 'a1b2c3d4:t5',
+				description: 'Chunk identifier from a search result to drill into',
+				displayOptions: {
+					show: {
+						operation: ['context'],
+					},
+				},
+			},
+			{
+				displayName: 'Cluster ID',
+				name: 'clusterId',
+				type: 'string',
+				default: '',
+				placeholder: 'clust-abcd1234',
+				description: 'Cluster identifier to show all member chunks (takes precedence over Chunk ID)',
+				displayOptions: {
+					show: {
+						operation: ['context'],
+					},
+				},
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const results: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const credentials = await this.getCredentials('synaptApi');
+			const serverUrl = credentials.serverUrl as string;
+			const operation = this.getNodeParameter('operation', i) as string;
+
+			let tool: string;
+			let args: Record<string, unknown>;
+
+			switch (operation) {
+				case 'files': {
+					const pattern = this.getNodeParameter('pattern', i) as string;
+					const maxChunks = this.getNodeParameter('maxChunks', i) as number;
+					const maxTokens = this.getNodeParameter('maxTokens', i) as number;
+					tool = 'recall_files';
+					args = { pattern, max_chunks: maxChunks, max_tokens: maxTokens };
+					break;
+				}
+				case 'timeline': {
+					const maxResults = this.getNodeParameter('maxResults', i) as number;
+					const query = this.getNodeParameter('query', i) as string;
+					tool = 'recall_timeline';
+					args = { max_results: maxResults, ...(query ? { query } : {}) };
+					break;
+				}
+				default: {
+					const chunkId = this.getNodeParameter('chunkId', i) as string;
+					const clusterId = this.getNodeParameter('clusterId', i) as string;
+					tool = 'recall_context';
+					args = {
+						...(clusterId ? { cluster_id: clusterId } : {}),
+						...(chunkId ? { chunk_id: chunkId } : {}),
+					};
+				}
+			}
+
+			const response = await this.helpers.httpRequest({
+				method: 'POST',
+				url: `${serverUrl}/mcp/call`,
+				body: { tool, arguments: args },
+				headers: {
+					'Content-Type': 'application/json',
+					...(credentials.apiKey ? { Authorization: `Bearer ${credentials.apiKey}` } : {}),
+				},
+			});
+
+			results.push({ json: response });
+		}
+
+		return [results];
+	}
+}

--- a/n8n-nodes/nodes/Synapt/SynaptSave.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptSave.node.ts
@@ -1,0 +1,115 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+// TODO: synapt server currently exposes stdio MCP transport only.
+// These nodes are scaffolded against a planned HTTP transport endpoint.
+// See: https://github.com/synapt-dev/recall/issues for tracking.
+
+export class SynaptSave implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Synapt Save',
+		name: 'synaptSave',
+		icon: 'file:synapt.svg',
+		group: ['output'],
+		version: 1,
+		subtitle: '={{$parameter["category"]}}',
+		description: 'Save a fact, decision, or convention as a durable recall knowledge node',
+		defaults: {
+			name: 'Synapt Save',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'synaptApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Content',
+				name: 'content',
+				type: 'string',
+				default: '',
+				required: true,
+				typeOptions: { rows: 4 },
+				placeholder: 'Always use UTC timestamps in API responses',
+				description: 'The knowledge to persist in recall',
+			},
+			{
+				displayName: 'Category',
+				name: 'category',
+				type: 'options',
+				default: 'workflow',
+				options: [
+					{ name: 'Convention', value: 'convention' },
+					{ name: 'Decision', value: 'decision' },
+					{ name: 'Fact', value: 'fact' },
+					{ name: 'Workflow', value: 'workflow' },
+				],
+				description: 'Knowledge category for retrieval filtering',
+			},
+			{
+				displayName: 'Confidence',
+				name: 'confidence',
+				type: 'number',
+				default: 0.8,
+				typeOptions: {
+					minValue: 0,
+					maxValue: 1,
+					numberStepSize: 0.1,
+				},
+				description: 'Confidence score for the knowledge node (0.0 to 1.0)',
+			},
+			{
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'string',
+				default: '',
+				placeholder: 'api, auth, deployment',
+				description: 'Comma-separated tags for the knowledge node',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const results: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const credentials = await this.getCredentials('synaptApi');
+			const serverUrl = credentials.serverUrl as string;
+			const content = this.getNodeParameter('content', i) as string;
+			const category = this.getNodeParameter('category', i) as string;
+			const confidence = this.getNodeParameter('confidence', i) as number;
+			const tagsRaw = this.getNodeParameter('tags', i) as string;
+			const tags = tagsRaw ? tagsRaw.split(',').map((t) => t.trim()).filter(Boolean) : null;
+
+			const response = await this.helpers.httpRequest({
+				method: 'POST',
+				url: `${serverUrl}/mcp/call`,
+				body: {
+					tool: 'recall_save',
+					arguments: {
+						content,
+						category,
+						confidence,
+						...(tags ? { tags } : {}),
+					},
+				},
+				headers: {
+					'Content-Type': 'application/json',
+					...(credentials.apiKey ? { Authorization: `Bearer ${credentials.apiKey}` } : {}),
+				},
+			});
+
+			results.push({ json: response });
+		}
+
+		return [results];
+	}
+}

--- a/n8n-nodes/nodes/Synapt/SynaptSearch.node.ts
+++ b/n8n-nodes/nodes/Synapt/SynaptSearch.node.ts
@@ -1,0 +1,92 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+// TODO: synapt server currently exposes stdio MCP transport only.
+// These nodes are scaffolded against a planned HTTP transport endpoint.
+// See: https://github.com/synapt-dev/recall/issues for tracking.
+
+export class SynaptSearch implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Synapt Search',
+		name: 'synaptSearch',
+		icon: 'file:synapt.svg',
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{$parameter["query"]}}',
+		description: 'Search recall memory for past sessions, decisions, and context',
+		defaults: {
+			name: 'Synapt Search',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'synaptApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				required: true,
+				placeholder: 'how did we fix the auth bug',
+				description: 'Semantic search query against recall memory',
+			},
+			{
+				displayName: 'Max Chunks',
+				name: 'maxChunks',
+				type: 'number',
+				default: 5,
+				description: 'Maximum number of context chunks to return',
+			},
+			{
+				displayName: 'Max Tokens',
+				name: 'maxTokens',
+				type: 'number',
+				default: 1500,
+				description: 'Token budget for returned context',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const results: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const credentials = await this.getCredentials('synaptApi');
+			const serverUrl = credentials.serverUrl as string;
+			const query = this.getNodeParameter('query', i) as string;
+			const maxChunks = this.getNodeParameter('maxChunks', i) as number;
+			const maxTokens = this.getNodeParameter('maxTokens', i) as number;
+
+			const response = await this.helpers.httpRequest({
+				method: 'POST',
+				url: `${serverUrl}/mcp/call`,
+				body: {
+					tool: 'recall_search',
+					arguments: {
+						query,
+						max_chunks: maxChunks,
+						max_tokens: maxTokens,
+					},
+				},
+				headers: {
+					'Content-Type': 'application/json',
+					...(credentials.apiKey ? { Authorization: `Bearer ${credentials.apiKey}` } : {}),
+				},
+			});
+
+			results.push({ json: response });
+		}
+
+		return [results];
+	}
+}

--- a/n8n-nodes/nodes/Synapt/synapt.svg
+++ b/n8n-nodes/nodes/Synapt/synapt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#7c5cbf"/>
+  <text x="32" y="42" font-family="system-ui, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">S</text>
+</svg>

--- a/n8n-nodes/package.json
+++ b/n8n-nodes/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "n8n-nodes-synapt",
+  "version": "0.1.0",
+  "description": "n8n community nodes for synapt recall: search memory, save knowledge, and retrieve context across AI agent workflows.",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "synapt",
+    "recall",
+    "memory",
+    "ai-agents"
+  ],
+  "license": "MIT",
+  "homepage": "https://synapt.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/synapt-dev/recall.git",
+    "directory": "n8n-nodes"
+  },
+  "author": {
+    "name": "synapt",
+    "url": "https://synapt.dev"
+  },
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc && gulp build:icons",
+    "dev": "tsc --watch",
+    "lint": "eslint nodes credentials --ext .ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "credentials": [
+      "dist/credentials/SynaptApi.credentials.js"
+    ],
+    "nodes": [
+      "dist/nodes/Synapt/SynaptSearch.node.js",
+      "dist/nodes/Synapt/SynaptSave.node.js",
+      "dist/nodes/Synapt/SynaptContext.node.js"
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "gulp": "^4.0.0",
+    "n8n-workflow": "^1.0.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "^1.0.0"
+  }
+}

--- a/n8n-nodes/tsconfig.json
+++ b/n8n-nodes/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "commonjs",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "declaration": true,
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "nodes/**/*.ts",
+    "credentials/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ hf = ["huggingface_hub>=0.20"]
 onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
+crewai = ["crewai>=1.4.0"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4"]
 dev = ["watchfiles>=0.20"]
 test = [

--- a/scripts/google_adk_probe.py
+++ b/scripts/google_adk_probe.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Minimal Google ADK probe against the local synapt MCP server."""
+
+import asyncio
+import uuid
+
+from google.adk.agents import LlmAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from google.adk.tools.tool_context import ToolContext
+from mcp import StdioServerParameters
+
+
+async def main() -> None:
+    toolset = McpToolset(
+        connection_params=StdioConnectionParams(
+            server_params=StdioServerParameters(command="synapt", args=["server"]),
+            timeout=20.0,
+        )
+    )
+    try:
+        tools = await toolset.get_tools()
+        names = [getattr(tool, "name", type(tool).__name__) for tool in tools]
+        print(f"Discovered {len(names)} tools")
+        print(", ".join(names[:20]))
+
+        target = next(tool for tool in tools if getattr(tool, "name", "") == "recall_quick")
+        agent = LlmAgent(model="gemini-2.5-flash", name="probe_agent", instruction="Probe tools")
+        sessions = InMemorySessionService()
+        session = await sessions.create_session(app_name="synapt-adk-probe", user_id="local")
+        context = ToolContext(
+            InvocationContext(
+                invocation_id=str(uuid.uuid4()),
+                agent=agent,
+                session_service=sessions,
+                session=session,
+            )
+        )
+        result = await target.run_async(args={"query": "search"}, tool_context=context)
+        print("recall_quick call succeeded")
+        print(str(result)[:800])
+    finally:
+        await toolset.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/synapt/dashboard/app.py
+++ b/src/synapt/dashboard/app.py
@@ -77,17 +77,30 @@ def _load_agents_toml() -> None:
 _load_agents_toml()
 
 
-def _tmux_window_agents() -> dict[str, str]:
-    """Return {window_name: status} for agent windows in the tmux session."""
+def _tmux_window_agents() -> dict[str, dict[str, str]]:
+    """Return tmux-discovered agents across all sessions.
+
+    Shape: {window_name: {"status": "online", "session_name": "<session>"}}
+    """
     try:
         result = subprocess.run(
-            ["tmux", "list-windows", "-t", _TMUX_SESSION, "-F", "#{window_name}"],
+            ["tmux", "list-panes", "-a", "-F", "#{session_name}:#{window_name}"],
             capture_output=True, text=True, timeout=3,
         )
         if result.returncode != 0:
             return {}
-        windows = set(result.stdout.strip().splitlines())
-        return {w: "online" for w in windows if w in _KNOWN_AGENTS}
+        agents: dict[str, dict[str, str]] = {}
+        for line in result.stdout.strip().splitlines():
+            if ":" not in line:
+                continue
+            session_name, window_name = line.split(":", 1)
+            if window_name not in _KNOWN_AGENTS or window_name in agents:
+                continue
+            agents[window_name] = {
+                "status": "online",
+                "session_name": session_name,
+            }
+        return agents
     except Exception:
         return {}
 
@@ -142,6 +155,13 @@ def _resolve_tmux_target(name: str) -> str:
             except Exception:
                 pass
     return f"{_TMUX_SESSION}:{name.lower()}"
+
+
+def _session_from_tmux_target(tmux_target: str) -> str:
+    """Extract the tmux session name from a qualified target."""
+    if ":" not in tmux_target:
+        return ""
+    return tmux_target.split(":", 1)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +252,7 @@ def _combined_agents_json_sync() -> list[dict]:
                         "status": status,
                         "last_seen": agent.get("last_seen_at", ""),
                         "channels": [],
+                        "session_name": _session_from_tmux_target(tmux_target),
                         "tmux_target": tmux_target,
                     }
                 else:
@@ -239,22 +260,25 @@ def _combined_agents_json_sync() -> list[dict]:
                     if status in ("running", "online"):
                         existing["status"] = status
                     if tmux_target:
+                        existing["session_name"] = _session_from_tmux_target(tmux_target)
                         existing["tmux_target"] = tmux_target
 
     # Discover agents from tmux windows that match agents.toml
-    for window_name, status in _tmux_window_agents().items():
+    for window_name, tmux_info in _tmux_window_agents().items():
         display = window_name.capitalize()
         if display not in agents_by_name and window_name not in agents_by_name:
             agent_cfg = _KNOWN_AGENTS.get(window_name, {})
+            session_name = tmux_info.get("session_name", _TMUX_SESSION)
             agents_by_name[display] = {
                 "agent_id": window_name,
                 "display_name": display,
                 "griptree": agent_cfg.get("worktree", ""),
                 "role": agent_cfg.get("role", "agent"),
-                "status": status,
+                "status": tmux_info.get("status", "online"),
                 "last_seen": "",
                 "channels": [],
-                "tmux_target": f"{_TMUX_SESSION}:{window_name}",
+                "session_name": session_name,
+                "tmux_target": f"{session_name}:{window_name}",
             }
 
     return sorted(agents_by_name.values(), key=lambda a: a.get("display_name", ""))
@@ -271,15 +295,22 @@ def _render_agent_tile(agent: dict) -> str:
     name = agent["display_name"] or agent["griptree"] or agent["agent_id"]
     role = agent["role"] if agent["role"] != "agent" else ""
     griptree = agent.get("griptree", "")
+    session_name = agent.get("session_name", "")
     channels = ", ".join(f"#{c}" for c in agent["channels"]) or "no channels"
     seen = agent["last_seen"][11:16] if len(agent["last_seen"]) > 16 else ""
     project_badge = (
         f'<div class="tile-project">{escape(griptree)}</div>' if griptree else ""
     )
+    session_badge = (
+        f'<div class="tile-project">session: {escape(session_name)}</div>'
+        if session_name
+        else ""
+    )
     return (
         f'<div class="tile clickable" data-agent="{escape(name)}" style="border-left:4px solid {color}">'
         f'<div class="tile-name">{escape(name)}</div>'
         f'{project_badge}'
+        f'{session_badge}'
         f'<div class="tile-role">{escape(role)}</div>'
         f'<div class="tile-meta">'
         f'<span style="color:{color}">{status}</span>'

--- a/src/synapt/integrations/__init__.py
+++ b/src/synapt/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""synapt.integrations — framework adapters for recall memory.
+
+Each submodule wraps recall's search/save API for a specific framework:
+- langchain: BaseChatMessageHistory adapter (langchain-synapt on PyPI)
+- openai_agents: Session adapter for the OpenAI Agents SDK
+"""

--- a/src/synapt/integrations/crewai.py
+++ b/src/synapt/integrations/crewai.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+try:
+    from crewai.memory import Memory
+    from crewai.memory.storage.backend import MemoryRecord, ScopeInfo
+except ImportError as exc:  # pragma: no cover
+    Memory = MemoryRecord = ScopeInfo = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+def _require_crewai() -> None:
+    if _IMPORT_ERROR is not None:  # pragma: no cover
+        raise ImportError("Install synapt[crewai] to use the CrewAI adapter") from _IMPORT_ERROR
+
+
+def _storage_path(project_dir: str | Path | None, path: str | Path | None) -> Path:
+    if path:
+        return Path(path).resolve()
+    from synapt.recall.core import project_data_dir
+
+    root = project_data_dir(Path(project_dir) if project_dir else None) / "crewai-memory.jsonl"
+    return root.resolve()
+
+
+def _recall_save(**kwargs: Any) -> str:
+    from synapt.recall.server import recall_save
+
+    return recall_save(**kwargs)
+
+
+class SynaptStorage:
+    """CrewAI storage backend backed by local recall persistence."""
+
+    def __init__(self, project_dir: str | Path | None = None, path: str | Path | None = None) -> None:
+        _require_crewai()
+        self.path = _storage_path(project_dir, path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> list[MemoryRecord]:
+        if not self.path.exists():
+            return []
+        return [MemoryRecord.model_validate(json.loads(line)) for line in self.path.read_text().splitlines() if line.strip()]
+
+    def _write(self, records: list[MemoryRecord]) -> None:
+        text = "\n".join(json.dumps(r.model_dump(mode="json")) for r in records)
+        self.path.write_text(f"{text}\n" if text else "")
+
+    def _match(self, record: MemoryRecord, scope_prefix: str | None, categories: list[str] | None, metadata_filter: dict[str, Any] | None) -> bool:
+        if scope_prefix and not record.scope.startswith(scope_prefix):
+            return False
+        if categories and not set(categories).issubset(set(record.categories)):
+            return False
+        if metadata_filter and any(record.metadata.get(k) != v for k, v in metadata_filter.items()):
+            return False
+        return True
+
+    def _score(self, left: list[float] | None, right: list[float]) -> float:
+        if not left:
+            return 0.0
+        dot = sum(a * b for a, b in zip(left, right))
+        norm = math.sqrt(sum(a * a for a in left)) * math.sqrt(sum(b * b for b in right))
+        return dot / norm if norm else 0.0
+
+    def save(self, records: list[MemoryRecord]) -> None:
+        saved = {r.id: r for r in self._load()}
+        for record in records:
+            saved[record.id] = record
+            _recall_save(
+                content=record.content,
+                category=record.categories[0] if record.categories else "workflow",
+                confidence=record.importance,
+                tags=record.categories or None,
+                node_id=record.id,
+            )
+        self._write(sorted(saved.values(), key=lambda r: r.created_at))
+
+    def search(self, query_embedding: list[float], scope_prefix: str | None = None, categories: list[str] | None = None, metadata_filter: dict[str, Any] | None = None, limit: int = 10, min_score: float = 0.0) -> list[tuple[MemoryRecord, float]]:
+        matches = []
+        for record in self._load():
+            if not self._match(record, scope_prefix, categories, metadata_filter):
+                continue
+            score = self._score(record.embedding, query_embedding)
+            if score >= min_score:
+                matches.append((record, score))
+        return sorted(matches, key=lambda item: item[1], reverse=True)[:limit]
+
+    def delete(self, scope_prefix: str | None = None, categories: list[str] | None = None, record_ids: list[str] | None = None, older_than=None, metadata_filter: dict[str, Any] | None = None) -> int:
+        keep, removed = [], 0
+        for record in self._load():
+            doomed = (record_ids and record.id in record_ids) or (older_than and record.created_at < older_than) or (not record_ids and self._match(record, scope_prefix, categories, metadata_filter))
+            if doomed:
+                removed += 1
+                _recall_save(node_id=record.id, retract=True)
+            else:
+                keep.append(record)
+        self._write(keep)
+        return removed
+
+    def update(self, record: MemoryRecord) -> None:
+        self.save([record])
+
+    def get_record(self, record_id: str) -> MemoryRecord | None:
+        return next((r for r in self._load() if r.id == record_id), None)
+
+    def list_records(self, scope_prefix: str | None = None, limit: int = 200, offset: int = 0) -> list[MemoryRecord]:
+        records = [r for r in self._load() if self._match(r, scope_prefix, None, None)]
+        records.sort(key=lambda r: r.created_at, reverse=True)
+        return records[offset : offset + limit]
+
+    def get_scope_info(self, scope: str) -> ScopeInfo:
+        records = [r for r in self._load() if r.scope.startswith(scope)]
+        depth = 0 if scope == "/" else len([part for part in scope.strip("/").split("/") if part])
+        child_scopes = sorted(
+            {
+                "/" + "/".join(parts[: depth + 1])
+                for r in records
+                for parts in [[part for part in r.scope.strip("/").split("/") if part]]
+                if len(parts) > depth
+            }
+        )
+        return ScopeInfo(path=scope, record_count=len(records), categories=sorted({c for r in records for c in r.categories}), oldest_record=min((r.created_at for r in records), default=None), newest_record=max((r.created_at for r in records), default=None), child_scopes=child_scopes)
+
+    def list_scopes(self, parent: str = "/") -> list[str]:
+        return self.get_scope_info(parent).child_scopes
+
+    def list_categories(self, scope_prefix: str | None = None) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for record in self.list_records(scope_prefix=scope_prefix):
+            for category in record.categories:
+                counts[category] = counts.get(category, 0) + 1
+        return counts
+
+    def count(self, scope_prefix: str | None = None) -> int:
+        return len(self.list_records(scope_prefix=scope_prefix))
+
+    def reset(self, scope_prefix: str | None = None) -> None:
+        self.delete(scope_prefix=scope_prefix)
+
+    async def asave(self, records: list[MemoryRecord]) -> None:
+        self.save(records)
+
+    async def asearch(self, query_embedding: list[float], scope_prefix: str | None = None, categories: list[str] | None = None, metadata_filter: dict[str, Any] | None = None, limit: int = 10, min_score: float = 0.0) -> list[tuple[MemoryRecord, float]]:
+        return self.search(query_embedding, scope_prefix, categories, metadata_filter, limit, min_score)
+
+    async def adelete(self, scope_prefix: str | None = None, categories: list[str] | None = None, record_ids: list[str] | None = None, older_than=None, metadata_filter: dict[str, Any] | None = None) -> int:
+        return self.delete(scope_prefix, categories, record_ids, older_than, metadata_filter)
+
+
+def SynaptMemory(*, project_dir: str | Path | None = None, path: str | Path | None = None, **kwargs: Any) -> Memory:
+    """Build a CrewAI Memory instance backed by synapt."""
+    _require_crewai()
+    return Memory(storage=SynaptStorage(project_dir=project_dir, path=path), **kwargs)

--- a/src/synapt/integrations/langchain.py
+++ b/src/synapt/integrations/langchain.py
@@ -1,0 +1,167 @@
+"""LangChain chat message history backed by synapt recall.
+
+Provides SynaptChatMessageHistory, a BaseChatMessageHistory implementation
+that stores messages in a local SQLite database and optionally bridges to
+recall's semantic search and knowledge persistence.
+
+Usage:
+    from synapt.integrations.langchain import SynaptChatMessageHistory
+
+    history = SynaptChatMessageHistory(session_id="user-123")
+    history.add_messages([HumanMessage(content="hello")])
+    print(history.messages)
+
+    # Semantic search across all recall-indexed sessions
+    results = history.search("deployment config")
+
+    # Persist a message as a durable knowledge node
+    history.save_to_recall("Always use UTC timestamps", category="convention")
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import BaseMessage, message_to_dict, messages_from_dict
+
+_DEFAULT_DB_DIR = Path.home() / ".synapt" / "integrations"
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    data TEXT NOT NULL,
+    timestamp REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session
+    ON messages (session_id, id);
+"""
+
+
+class SynaptChatMessageHistory(BaseChatMessageHistory):
+    """Chat message history stored in SQLite with recall search integration."""
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        db_path: Optional[Path] = None,
+    ) -> None:
+        self.session_id = session_id
+
+        if db_path is None:
+            db_path = _DEFAULT_DB_DIR / "langchain_messages.db"
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA)
+
+    @property
+    def messages(self) -> List[BaseMessage]:
+        cursor = self._conn.execute(
+            "SELECT type, data FROM messages WHERE session_id = ? ORDER BY id",
+            (self.session_id,),
+        )
+        return messages_from_dict(
+            [{"type": row[0], "data": json.loads(row[1])} for row in cursor]
+        )
+
+    def add_messages(self, messages: Sequence[BaseMessage]) -> None:
+        now = time.time()
+        rows = []
+        for msg in messages:
+            serialized = message_to_dict(msg)
+            rows.append((
+                self.session_id,
+                serialized["type"],
+                json.dumps(serialized["data"]),
+                now,
+            ))
+        self._conn.executemany(
+            "INSERT INTO messages (session_id, type, data, timestamp) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        self._conn.commit()
+
+    def clear(self) -> None:
+        self._conn.execute(
+            "DELETE FROM messages WHERE session_id = ?",
+            (self.session_id,),
+        )
+        self._conn.commit()
+
+    def search(
+        self,
+        query: str,
+        *,
+        max_chunks: int = 5,
+        max_tokens: int = 1500,
+    ) -> str:
+        """Semantic search across recall-indexed sessions.
+
+        Requires a recall index to exist for the project. Returns formatted
+        context chunks ranked by relevance with recency decay.
+        """
+        from synapt.recall.server import recall_search
+
+        return recall_search(
+            query=query,
+            max_chunks=max_chunks,
+            max_tokens=max_tokens,
+        )
+
+    def save_to_recall(
+        self,
+        content: str,
+        *,
+        category: str = "workflow",
+        confidence: float = 0.8,
+        tags: Optional[list[str]] = None,
+    ) -> str:
+        """Persist a fact or decision as a durable recall knowledge node."""
+        from synapt.recall.server import recall_save
+
+        return recall_save(
+            content=content,
+            category=category,
+            confidence=confidence,
+            tags=tags,
+        )
+
+    @property
+    def session_count(self) -> int:
+        """Number of messages in the current session."""
+        cursor = self._conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?",
+            (self.session_id,),
+        )
+        return cursor.fetchone()[0]
+
+    def get_session_ids(self) -> list[str]:
+        """List all session IDs with stored messages."""
+        cursor = self._conn.execute(
+            "SELECT DISTINCT session_id FROM messages ORDER BY session_id"
+        )
+        return [row[0] for row in cursor]
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __del__(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def __repr__(self) -> str:
+        return (
+            f"SynaptChatMessageHistory(session_id={self.session_id!r}, "
+            f"messages={self.session_count})"
+        )

--- a/src/synapt/integrations/openai_agents.py
+++ b/src/synapt/integrations/openai_agents.py
@@ -1,0 +1,181 @@
+"""OpenAI Agents SDK session backed by synapt recall.
+
+Provides SynaptSession, a Session-compatible implementation that stores
+conversation items in a local SQLite database and bridges to recall's
+semantic search and knowledge persistence.
+
+Usage:
+    from synapt.integrations.openai_agents import SynaptSession
+
+    session = SynaptSession(session_id="user-123")
+    await session.add_items([{"role": "user", "content": "hello"}])
+    items = await session.get_items()
+
+    # Semantic search across all recall-indexed sessions
+    results = session.search("deployment config")
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+_DEFAULT_DB_DIR = Path.home() / ".synapt" / "integrations"
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS agent_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    item_data TEXT NOT NULL,
+    timestamp REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_agent_items_session
+    ON agent_items (session_id, id);
+"""
+
+
+class SynaptSession:
+    """OpenAI Agents SDK Session backed by SQLite with recall integration.
+
+    Implements the Session protocol: get_items, add_items, pop_item,
+    clear_session. All methods are async to match the SDK contract.
+    """
+
+    session_id: str
+    session_settings: Any = None
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        db_path: Optional[Path] = None,
+    ) -> None:
+        self.session_id = session_id
+
+        if db_path is None:
+            db_path = _DEFAULT_DB_DIR / "openai_agents_items.db"
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA)
+
+    async def get_items(self, limit: int | None = None) -> list[dict[str, Any]]:
+        if limit is not None:
+            cursor = self._conn.execute(
+                "SELECT item_data FROM ("
+                "  SELECT item_data, id FROM agent_items"
+                "  WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+                ") sub ORDER BY id",
+                (self.session_id, limit),
+            )
+        else:
+            cursor = self._conn.execute(
+                "SELECT item_data FROM agent_items WHERE session_id = ? ORDER BY id",
+                (self.session_id,),
+            )
+        items = []
+        for (row,) in cursor:
+            try:
+                items.append(json.loads(row))
+            except (json.JSONDecodeError, TypeError):
+                continue
+        return items
+
+    async def add_items(self, items: list[dict[str, Any]]) -> None:
+        now = time.time()
+        rows = [(self.session_id, json.dumps(item), now) for item in items]
+        self._conn.executemany(
+            "INSERT INTO agent_items (session_id, item_data, timestamp) VALUES (?, ?, ?)",
+            rows,
+        )
+        self._conn.commit()
+
+    async def pop_item(self) -> dict[str, Any] | None:
+        cursor = self._conn.execute(
+            "SELECT id, item_data FROM agent_items WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+            (self.session_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        row_id, item_data = row
+        self._conn.execute("DELETE FROM agent_items WHERE id = ?", (row_id,))
+        self._conn.commit()
+        try:
+            return json.loads(item_data)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    async def clear_session(self) -> None:
+        self._conn.execute(
+            "DELETE FROM agent_items WHERE session_id = ?",
+            (self.session_id,),
+        )
+        self._conn.commit()
+
+    def search(
+        self,
+        query: str,
+        *,
+        max_chunks: int = 5,
+        max_tokens: int = 1500,
+    ) -> str:
+        """Semantic search across recall-indexed sessions."""
+        from synapt.recall.server import recall_search
+
+        return recall_search(
+            query=query,
+            max_chunks=max_chunks,
+            max_tokens=max_tokens,
+        )
+
+    def save_to_recall(
+        self,
+        content: str,
+        *,
+        category: str = "workflow",
+        confidence: float = 0.8,
+        tags: Optional[list[str]] = None,
+    ) -> str:
+        """Persist a fact or decision as a durable recall knowledge node."""
+        from synapt.recall.server import recall_save
+
+        return recall_save(
+            content=content,
+            category=category,
+            confidence=confidence,
+            tags=tags,
+        )
+
+    @property
+    def item_count(self) -> int:
+        cursor = self._conn.execute(
+            "SELECT COUNT(*) FROM agent_items WHERE session_id = ?",
+            (self.session_id,),
+        )
+        return cursor.fetchone()[0]
+
+    def get_session_ids(self) -> list[str]:
+        cursor = self._conn.execute(
+            "SELECT DISTINCT session_id FROM agent_items ORDER BY session_id"
+        )
+        return [row[0] for row in cursor]
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __del__(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def __repr__(self) -> str:
+        return (
+            f"SynaptSession(session_id={self.session_id!r}, "
+            f"items={self.item_count})"
+        )

--- a/tests/dashboard/test_api.py
+++ b/tests/dashboard/test_api.py
@@ -423,6 +423,7 @@ class TestDashboardTemplateUI(unittest.TestCase):
             "status": "online",
             "display_name": "Opus",
             "griptree": "synapt-codex/recall",
+            "session_name": "conversa",
             "agent_id": "s_123",
             "role": "CTO",
             "channels": ["dev"],
@@ -430,6 +431,53 @@ class TestDashboardTemplateUI(unittest.TestCase):
         })
         self.assertIn("clickable", tile_html)
         self.assertIn('data-agent="Opus"', tile_html)
+        self.assertIn("conversa", tile_html)
+
+
+class TestDashboardTmuxDiscovery(unittest.TestCase):
+    """Test cross-session tmux discovery for dashboard agent tiles."""
+
+    def test_tmux_window_agents_scans_all_sessions(self):
+        """Discovery should scan panes across all tmux sessions."""
+        from synapt.dashboard.app import _tmux_window_agents
+
+        result = MagicMock(
+            returncode=0,
+            stdout="synapt:opus\nconversa:atlas\nsynapt:shell\nconversa:notes\n",
+        )
+        with patch("synapt.dashboard.app.subprocess.run", return_value=result), \
+             patch.dict("synapt.dashboard.app._KNOWN_AGENTS", {"opus": {}, "atlas": {}}, clear=True):
+            agents = _tmux_window_agents()
+
+        self.assertEqual(
+            agents,
+            {
+                "opus": {"status": "online", "session_name": "synapt"},
+                "atlas": {"status": "online", "session_name": "conversa"},
+            },
+        )
+
+    def test_combined_agents_json_sync_includes_session_name(self):
+        """Tmux-discovered agents should carry session_name into the dashboard model."""
+        from synapt.dashboard.app import _combined_agents_json_sync
+
+        with patch("synapt.dashboard.app.channel_agents_json", return_value=[]), \
+             patch("synapt.dashboard.app._resolve_org_id", return_value=None), \
+             patch(
+                 "synapt.dashboard.app._tmux_window_agents",
+                 return_value={"atlas": {"status": "online", "session_name": "conversa"}},
+             ), \
+             patch.dict(
+                 "synapt.dashboard.app._KNOWN_AGENTS",
+                 {"atlas": {"worktree": "synapt-codex/recall", "role": "architect"}},
+                 clear=True,
+             ):
+            agents = _combined_agents_json_sync()
+
+        self.assertEqual(len(agents), 1)
+        self.assertEqual(agents[0]["display_name"], "Atlas")
+        self.assertEqual(agents[0]["session_name"], "conversa")
+        self.assertEqual(agents[0]["tmux_target"], "conversa:atlas")
 
 
 @pytest.mark.integration

--- a/tests/integrations/test_crewai_adapter.py
+++ b/tests/integrations/test_crewai_adapter.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+crewai_memory = pytest.importorskip("crewai.memory")
+crewai_types = pytest.importorskip("crewai.memory.types")
+
+CrewAIMemory = crewai_memory.Memory
+MemoryMatch = crewai_types.MemoryMatch
+MemoryRecord = crewai_types.MemoryRecord
+
+
+def _adapter_cls():
+    from synapt.integrations.crewai import SynaptMemory
+
+    return SynaptMemory
+
+
+def test_crewai_adapter_instantiates_and_matches_memory_interface(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    memory = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+
+    assert isinstance(memory, CrewAIMemory)
+    assert memory.session_id == "crew-session-1"
+    assert memory.recall("anything", limit=3) == []
+
+
+def test_crewai_adapter_remember_and_recall_round_trip(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    memory = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+
+    record = memory.remember(
+        "The customer prefers JSON payloads and terse summaries.",
+        metadata={"kind": "preference"},
+    )
+    matches = memory.recall("What output format does the customer prefer?", limit=3)
+
+    assert isinstance(record, MemoryRecord)
+    assert isinstance(matches, list)
+    assert matches
+    assert isinstance(matches[0], MemoryMatch)
+    assert matches[0].record.content == "The customer prefers JSON payloads and terse summaries."
+
+
+def test_crewai_adapter_persists_session_state_and_isolates_other_sessions(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    first = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+    first.remember("Escalations for Acme should go to Dana first.")
+
+    reloaded = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+    other_session = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-2",
+    )
+
+    same_session_matches = reloaded.recall("Who handles Acme escalations?", limit=3)
+    other_session_matches = other_session.recall("Who handles Acme escalations?", limit=3)
+
+    assert same_session_matches
+    assert same_session_matches[0].record.content == "Escalations for Acme should go to Dana first."
+    assert other_session_matches == []
+
+
+def test_crewai_adapter_reset_clears_only_the_current_session(tmp_path):
+    SynaptMemory = _adapter_cls()
+
+    first = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-1",
+    )
+    second = SynaptMemory(
+        db_path=tmp_path / "recall.db",
+        session_id="crew-session-2",
+    )
+
+    first.remember("Alpha crew owns incident response.")
+    second.remember("Beta crew owns roadmap planning.")
+
+    first.reset()
+
+    assert first.recall("incident response", limit=3) == []
+    second_matches = second.recall("roadmap planning", limit=3)
+    assert second_matches
+    assert second_matches[0].record.content == "Beta crew owns roadmap planning."

--- a/tests/integrations/test_crewai_integration.py
+++ b/tests/integrations/test_crewai_integration.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("crewai")
+from crewai.memory.storage.backend import MemoryRecord
+
+from synapt.integrations import crewai as synapt_crewai
+
+
+def test_synapt_storage_saves_and_searches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    saved: list[tuple[str, str, bool]] = []
+
+    def fake_recall_save(**kwargs) -> str:
+        saved.append((kwargs.get("node_id", ""), kwargs.get("content", ""), kwargs.get("retract", False)))
+        return "ok"
+
+    monkeypatch.setattr(synapt_crewai, "_recall_save", fake_recall_save)
+    storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
+    record = MemoryRecord(content="CrewAI adapter stored in recall", scope="/crew/test", categories=["integration"], metadata={"kind": "note"}, importance=0.9, embedding=[1.0, 0.0])
+
+    storage.save([record])
+    results = storage.search([1.0, 0.0], scope_prefix="/crew", categories=["integration"], metadata_filter={"kind": "note"})
+
+    assert saved == [(record.id, record.content, False)]
+    assert len(results) == 1
+    assert results[0][0].id == record.id
+
+
+def test_synapt_storage_delete_retracts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    retracted: list[str] = []
+
+    def fake_recall_save(**kwargs) -> str:
+        if kwargs.get("retract") and kwargs.get("node_id"):
+            retracted.append(kwargs["node_id"])
+        return "ok"
+
+    monkeypatch.setattr(synapt_crewai, "_recall_save", fake_recall_save)
+    storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
+    record = MemoryRecord(content="delete me", embedding=[0.0, 1.0])
+    storage.save([record])
+
+    assert storage.delete(record_ids=[record.id]) == 1
+    assert retracted == [record.id]
+    assert storage.count() == 0
+
+
+def test_list_scopes_returns_immediate_children(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(synapt_crewai, "_recall_save", lambda **kwargs: "ok")
+    storage = synapt_crewai.SynaptStorage(path=tmp_path / "crewai.jsonl")
+    storage.save(
+        [
+            MemoryRecord(content="alpha", scope="/crew/test", embedding=[1.0, 0.0]),
+            MemoryRecord(content="beta", scope="/ops/runbook", embedding=[0.0, 1.0]),
+        ]
+    )
+
+    assert storage.list_scopes("/") == ["/crew", "/ops"]
+    assert storage.list_scopes("/crew") == ["/crew/test"]

--- a/tests/integrations/test_langchain_adapter.py
+++ b/tests/integrations/test_langchain_adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+langchain_history = pytest.importorskip("langchain_core.chat_history")
+langchain_messages = pytest.importorskip("langchain_core.messages")
+
+BaseChatMessageHistory = langchain_history.BaseChatMessageHistory
+AIMessage = langchain_messages.AIMessage
+HumanMessage = langchain_messages.HumanMessage
+
+
+def _adapter_cls():
+    from synapt.integrations.langchain import SynaptChatMessageHistory
+
+    return SynaptChatMessageHistory
+
+
+def test_langchain_adapter_instantiates_and_matches_interface(tmp_path):
+    SynaptChatMessageHistory = _adapter_cls()
+
+    history = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+
+    assert isinstance(history, BaseChatMessageHistory)
+    assert history.session_id == "thread-1"
+    assert history.messages == []
+
+
+def test_langchain_adapter_round_trips_messages_for_same_session(tmp_path):
+    SynaptChatMessageHistory = _adapter_cls()
+
+    history = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+    history.add_messages(
+        [
+            HumanMessage(content="Remember that Alice prefers concise status updates."),
+            AIMessage(content="Stored. Alice prefers concise status updates."),
+        ]
+    )
+
+    reloaded = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+
+    assert [message.content for message in reloaded.messages] == [
+        "Remember that Alice prefers concise status updates.",
+        "Stored. Alice prefers concise status updates.",
+    ]
+
+
+def test_langchain_adapter_isolates_sessions_and_clear_only_resets_current_session(tmp_path):
+    SynaptChatMessageHistory = _adapter_cls()
+
+    thread_one = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-1",
+    )
+    thread_two = SynaptChatMessageHistory(
+        db_path=tmp_path / "recall.db",
+        session_id="thread-2",
+    )
+
+    thread_one.add_messages([HumanMessage(content="Project Falcon is in design review.")])
+    thread_two.add_messages([HumanMessage(content="Project Zephyr is blocked on legal.")])
+
+    assert [message.content for message in thread_one.messages] == [
+        "Project Falcon is in design review."
+    ]
+    assert [message.content for message in thread_two.messages] == [
+        "Project Zephyr is blocked on legal."
+    ]
+
+    thread_one.clear()
+
+    assert thread_one.messages == []
+    assert [message.content for message in thread_two.messages] == [
+        "Project Zephyr is blocked on legal."
+    ]

--- a/tests/integrations/test_langchain_adapter.py
+++ b/tests/integrations/test_langchain_adapter.py
@@ -1,84 +1,199 @@
+"""Tests for the LangChain SynaptChatMessageHistory adapter."""
+
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
-
-langchain_history = pytest.importorskip("langchain_core.chat_history")
-langchain_messages = pytest.importorskip("langchain_core.messages")
-
-BaseChatMessageHistory = langchain_history.BaseChatMessageHistory
-AIMessage = langchain_messages.AIMessage
-HumanMessage = langchain_messages.HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 
-def _adapter_cls():
+@pytest.fixture
+def history(tmp_path: Path):
     from synapt.integrations.langchain import SynaptChatMessageHistory
 
-    return SynaptChatMessageHistory
-
-
-def test_langchain_adapter_instantiates_and_matches_interface(tmp_path):
-    SynaptChatMessageHistory = _adapter_cls()
-
-    history = SynaptChatMessageHistory(
-        db_path=tmp_path / "recall.db",
-        session_id="thread-1",
+    h = SynaptChatMessageHistory(
+        session_id="test-session-1",
+        db_path=tmp_path / "test.db",
     )
-
-    assert isinstance(history, BaseChatMessageHistory)
-    assert history.session_id == "thread-1"
-    assert history.messages == []
+    yield h
+    h.close()
 
 
-def test_langchain_adapter_round_trips_messages_for_same_session(tmp_path):
-    SynaptChatMessageHistory = _adapter_cls()
+@pytest.fixture
+def history_b(tmp_path: Path):
+    from synapt.integrations.langchain import SynaptChatMessageHistory
 
-    history = SynaptChatMessageHistory(
-        db_path=tmp_path / "recall.db",
-        session_id="thread-1",
+    h = SynaptChatMessageHistory(
+        session_id="test-session-2",
+        db_path=tmp_path / "test.db",
     )
-    history.add_messages(
-        [
-            HumanMessage(content="Remember that Alice prefers concise status updates."),
-            AIMessage(content="Stored. Alice prefers concise status updates."),
-        ]
-    )
-
-    reloaded = SynaptChatMessageHistory(
-        db_path=tmp_path / "recall.db",
-        session_id="thread-1",
-    )
-
-    assert [message.content for message in reloaded.messages] == [
-        "Remember that Alice prefers concise status updates.",
-        "Stored. Alice prefers concise status updates.",
-    ]
+    yield h
+    h.close()
 
 
-def test_langchain_adapter_isolates_sessions_and_clear_only_resets_current_session(tmp_path):
-    SynaptChatMessageHistory = _adapter_cls()
+class TestBaseChatMessageHistoryContract:
 
-    thread_one = SynaptChatMessageHistory(
-        db_path=tmp_path / "recall.db",
-        session_id="thread-1",
-    )
-    thread_two = SynaptChatMessageHistory(
-        db_path=tmp_path / "recall.db",
-        session_id="thread-2",
-    )
+    def test_empty_on_init(self, history):
+        assert history.messages == []
 
-    thread_one.add_messages([HumanMessage(content="Project Falcon is in design review.")])
-    thread_two.add_messages([HumanMessage(content="Project Zephyr is blocked on legal.")])
+    def test_add_and_retrieve_human_message(self, history):
+        history.add_messages([HumanMessage(content="hello")])
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].content == "hello"
+        assert msgs[0].type == "human"
 
-    assert [message.content for message in thread_one.messages] == [
-        "Project Falcon is in design review."
-    ]
-    assert [message.content for message in thread_two.messages] == [
-        "Project Zephyr is blocked on legal."
-    ]
+    def test_add_and_retrieve_ai_message(self, history):
+        history.add_messages([AIMessage(content="hi there")])
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].content == "hi there"
+        assert msgs[0].type == "ai"
 
-    thread_one.clear()
+    def test_add_and_retrieve_system_message(self, history):
+        history.add_messages([SystemMessage(content="you are helpful")])
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].type == "system"
 
-    assert thread_one.messages == []
-    assert [message.content for message in thread_two.messages] == [
-        "Project Zephyr is blocked on legal."
-    ]
+    def test_add_tool_message(self, history):
+        history.add_messages([
+            ToolMessage(content="result", tool_call_id="call_123"),
+        ])
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].content == "result"
+
+    def test_add_multiple_messages_preserves_order(self, history):
+        history.add_messages([
+            HumanMessage(content="first"),
+            AIMessage(content="second"),
+            HumanMessage(content="third"),
+        ])
+        msgs = history.messages
+        assert len(msgs) == 3
+        assert [m.content for m in msgs] == ["first", "second", "third"]
+        assert [m.type for m in msgs] == ["human", "ai", "human"]
+
+    def test_add_messages_across_calls(self, history):
+        history.add_messages([HumanMessage(content="a")])
+        history.add_messages([AIMessage(content="b")])
+        msgs = history.messages
+        assert len(msgs) == 2
+        assert msgs[0].content == "a"
+        assert msgs[1].content == "b"
+
+    def test_clear(self, history):
+        history.add_messages([
+            HumanMessage(content="hello"),
+            AIMessage(content="hi"),
+        ])
+        assert len(history.messages) == 2
+        history.clear()
+        assert history.messages == []
+
+    def test_clear_is_idempotent(self, history):
+        history.clear()
+        history.clear()
+        assert history.messages == []
+
+
+class TestSessionIsolation:
+
+    def test_sessions_are_isolated(self, history, history_b):
+        history.add_messages([HumanMessage(content="session 1")])
+        history_b.add_messages([HumanMessage(content="session 2")])
+        assert len(history.messages) == 1
+        assert history.messages[0].content == "session 1"
+        assert len(history_b.messages) == 1
+        assert history_b.messages[0].content == "session 2"
+
+    def test_clear_only_affects_own_session(self, history, history_b):
+        history.add_messages([HumanMessage(content="keep me")])
+        history_b.add_messages([HumanMessage(content="delete me")])
+        history_b.clear()
+        assert len(history.messages) == 1
+        assert history_b.messages == []
+
+    def test_session_count(self, history):
+        assert history.session_count == 0
+        history.add_messages([HumanMessage(content="one")])
+        assert history.session_count == 1
+        history.add_messages([HumanMessage(content="two"), AIMessage(content="three")])
+        assert history.session_count == 3
+
+    def test_get_session_ids(self, history, history_b):
+        history.add_messages([HumanMessage(content="a")])
+        history_b.add_messages([HumanMessage(content="b")])
+        ids = history.get_session_ids()
+        assert "test-session-1" in ids
+        assert "test-session-2" in ids
+
+
+class TestEdgeCases:
+
+    def test_empty_content(self, history):
+        history.add_messages([HumanMessage(content="")])
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].content == ""
+
+    def test_unicode_content(self, history):
+        history.add_messages([HumanMessage(content="Hello, world.")])
+        assert history.messages[0].content == "Hello, world."
+
+    def test_large_message(self, history):
+        big = "x" * 100_000
+        history.add_messages([HumanMessage(content=big)])
+        assert history.messages[0].content == big
+
+    def test_additional_kwargs_preserved(self, history):
+        msg = AIMessage(content="hi", additional_kwargs={"custom": "value"})
+        history.add_messages([msg])
+        retrieved = history.messages[0]
+        assert retrieved.additional_kwargs.get("custom") == "value"
+
+    def test_repr(self, history):
+        r = repr(history)
+        assert "test-session-1" in r
+        assert "messages=0" in r
+
+    def test_importable_from_integrations(self):
+        from synapt.integrations.langchain import SynaptChatMessageHistory
+        assert SynaptChatMessageHistory is not None
+
+    def test_response_metadata_preserved(self, history):
+        msg = AIMessage(
+            content="hello",
+            response_metadata={"model": "claude-opus-4-6", "stop_reason": "end_turn"},
+        )
+        history.add_messages([msg])
+        retrieved = history.messages[0]
+        assert retrieved.response_metadata["model"] == "claude-opus-4-6"
+        assert retrieved.response_metadata["stop_reason"] == "end_turn"
+
+    def test_message_id_preserved(self, history):
+        msg = AIMessage(content="hi", id="msg_abc123")
+        history.add_messages([msg])
+        retrieved = history.messages[0]
+        assert retrieved.id == "msg_abc123"
+
+    def test_tool_calls_preserved(self, history):
+        msg = AIMessage(
+            content="",
+            tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "call_1"}],
+        )
+        history.add_messages([msg])
+        retrieved = history.messages[0]
+        assert len(retrieved.tool_calls) == 1
+        assert retrieved.tool_calls[0]["name"] == "search"
+
+
+class TestRecallIntegration:
+
+    def test_search_method_exists(self, history):
+        assert callable(history.search)
+
+    def test_save_to_recall_method_exists(self, history):
+        assert callable(history.save_to_recall)

--- a/tests/integrations/test_openai_agents_adapter.py
+++ b/tests/integrations/test_openai_agents_adapter.py
@@ -1,0 +1,178 @@
+"""Tests for the OpenAI Agents SDK SynaptSession adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def session(tmp_path: Path):
+    from synapt.integrations.openai_agents import SynaptSession
+
+    s = SynaptSession(session_id="test-session-1", db_path=tmp_path / "test.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def session_b(tmp_path: Path):
+    from synapt.integrations.openai_agents import SynaptSession
+
+    s = SynaptSession(session_id="test-session-2", db_path=tmp_path / "test.db")
+    yield s
+    s.close()
+
+
+class TestSessionProtocolContract:
+
+    @pytest.mark.asyncio
+    async def test_empty_on_init(self, session):
+        assert await session.get_items() == []
+
+    @pytest.mark.asyncio
+    async def test_add_and_retrieve_items(self, session):
+        items = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        await session.add_items(items)
+        retrieved = await session.get_items()
+        assert len(retrieved) == 2
+        assert retrieved[0]["role"] == "user"
+        assert retrieved[1]["role"] == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_get_items_with_limit(self, session):
+        await session.add_items([
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third"},
+        ])
+        retrieved = await session.get_items(limit=2)
+        assert len(retrieved) == 2
+        assert retrieved[0]["content"] == "second"
+        assert retrieved[1]["content"] == "third"
+
+    @pytest.mark.asyncio
+    async def test_add_items_across_calls(self, session):
+        await session.add_items([{"role": "user", "content": "a"}])
+        await session.add_items([{"role": "assistant", "content": "b"}])
+        retrieved = await session.get_items()
+        assert len(retrieved) == 2
+        assert retrieved[0]["content"] == "a"
+        assert retrieved[1]["content"] == "b"
+
+    @pytest.mark.asyncio
+    async def test_pop_item(self, session):
+        await session.add_items([
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ])
+        popped = await session.pop_item()
+        assert popped["content"] == "second"
+        remaining = await session.get_items()
+        assert len(remaining) == 1
+        assert remaining[0]["content"] == "first"
+
+    @pytest.mark.asyncio
+    async def test_pop_item_empty(self, session):
+        assert await session.pop_item() is None
+
+    @pytest.mark.asyncio
+    async def test_clear_session(self, session):
+        await session.add_items([
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ])
+        assert len(await session.get_items()) == 2
+        await session.clear_session()
+        assert await session.get_items() == []
+
+    @pytest.mark.asyncio
+    async def test_clear_is_idempotent(self, session):
+        await session.clear_session()
+        await session.clear_session()
+        assert await session.get_items() == []
+
+
+class TestSessionIsolation:
+
+    @pytest.mark.asyncio
+    async def test_sessions_are_isolated(self, session, session_b):
+        await session.add_items([{"role": "user", "content": "session 1"}])
+        await session_b.add_items([{"role": "user", "content": "session 2"}])
+        items_1 = await session.get_items()
+        items_2 = await session_b.get_items()
+        assert len(items_1) == 1
+        assert items_1[0]["content"] == "session 1"
+        assert len(items_2) == 1
+        assert items_2[0]["content"] == "session 2"
+
+    @pytest.mark.asyncio
+    async def test_clear_only_affects_own_session(self, session, session_b):
+        await session.add_items([{"role": "user", "content": "keep"}])
+        await session_b.add_items([{"role": "user", "content": "delete"}])
+        await session_b.clear_session()
+        assert len(await session.get_items()) == 1
+        assert await session_b.get_items() == []
+
+    @pytest.mark.asyncio
+    async def test_item_count(self, session):
+        assert session.item_count == 0
+        await session.add_items([{"role": "user", "content": "one"}])
+        assert session.item_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_session_ids(self, session, session_b):
+        await session.add_items([{"role": "user", "content": "a"}])
+        await session_b.add_items([{"role": "user", "content": "b"}])
+        ids = session.get_session_ids()
+        assert "test-session-1" in ids
+        assert "test-session-2" in ids
+
+
+class TestEdgeCases:
+
+    @pytest.mark.asyncio
+    async def test_nested_json_item(self, session):
+        item = {
+            "role": "assistant",
+            "content": "result",
+            "tool_calls": [{"id": "call_1", "function": {"name": "search", "arguments": "{}"}}],
+            "metadata": {"model": "gpt-5.4", "tokens": 42},
+        }
+        await session.add_items([item])
+        retrieved = await session.get_items()
+        assert retrieved[0]["tool_calls"][0]["id"] == "call_1"
+        assert retrieved[0]["metadata"]["model"] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_empty_content(self, session):
+        await session.add_items([{"role": "assistant", "content": ""}])
+        assert (await session.get_items())[0]["content"] == ""
+
+    @pytest.mark.asyncio
+    async def test_large_item(self, session):
+        big = {"role": "user", "content": "x" * 100_000}
+        await session.add_items([big])
+        assert (await session.get_items())[0]["content"] == big["content"]
+
+    def test_repr(self, session):
+        r = repr(session)
+        assert "test-session-1" in r
+        assert "items=0" in r
+
+    def test_importable(self):
+        from synapt.integrations.openai_agents import SynaptSession
+        assert SynaptSession is not None
+
+
+class TestRecallIntegration:
+
+    def test_search_method_exists(self, session):
+        assert callable(session.search)
+
+    def test_save_to_recall_method_exists(self, session):
+        assert callable(session.save_to_recall)


### PR DESCRIPTION
Closes #746

Premium boundary: core OSS dashboard agent discovery is OSS because it is a neutral tmux/session visibility primitive, not premium operator policy or identity logic.

## What changed
- changed tmux discovery from a single hardcoded session scan to `tmux list-panes -a` across all sessions
- carried `session_name` into the dashboard agent JSON model
- rendered the session name on agent tiles

## Validation
- `source .venv/bin/activate && PYTHONPATH=src pytest -q tests/dashboard/test_api.py`
