### PR TITLE
Sprint 28b ceremony

### DIFF
--- a/src/synapt/dashboard/app.py
+++ b/src/synapt/dashboard/app.py
@@ -81,7 +81,7 @@ def _tmux_window_agents() -> dict[str, str]:
     """Return {window_name: status} for agent windows in the tmux session."""
     try:
         result = subprocess.run(
-            ["tmux", "list-windows", "-t", _TMUX_SESSION, "-F", "#{window_name}"],
+            ["tmux", "list-windows", "-a", "-F", "#{window_name}"],
             capture_output=True, text=True, timeout=3,
         )
         if result.returncode != 0:

--- a/tests/dashboard/test_api.py
+++ b/tests/dashboard/test_api.py
@@ -255,6 +255,25 @@ class TestDashboardAgentIO(unittest.TestCase):
 
         shutil.rmtree(tmpdir)
 
+    def test_tmux_discovery_scans_all_sessions(self):
+        """Dashboard agent discovery should not hardcode a single tmux session."""
+        from synapt.dashboard.app import _tmux_window_agents
+
+        mock_run = MagicMock()
+        mock_run.return_value = MagicMock(returncode=0, stdout="opus\natlas\n")
+
+        with patch("synapt.dashboard.app.subprocess.run", mock_run), \
+             patch.dict("synapt.dashboard.app._KNOWN_AGENTS", {"opus": {}, "atlas": {}}, clear=True):
+            agents = _tmux_window_agents()
+
+        mock_run.assert_called_once_with(
+            ["tmux", "list-windows", "-a", "-F", "#{window_name}"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        self.assertEqual(agents, {"opus": "online", "atlas": "online"})
+
     def test_dashboard_works_without_tmux_session(self):
         """Dashboard serves with empty agent grid when no tmux session."""
         mock_run = MagicMock()


### PR DESCRIPTION
## Summary

Sprint 28b: ad-hoc bug sprint focused on agent visibility.

- **P0-2A (recall#746)**: `fix: discover agents across all tmux sessions` — changed `list-windows` to `list-windows -a` so the dashboard discovers agents regardless of which tmux session they run in (PR #749)

## What changed

One-line fix in `src/synapt/dashboard/app.py`: the `-a` flag tells tmux to list windows across all sessions, not just the attached one.

## Premium boundary

Core OSS (dashboard agent discovery infrastructure).

## Test plan

- [x] E2E verification: agents API returns agents from multiple tmux sessions
- [x] 216 tests pass on sprint-28b
- [x] No regressions in existing dashboard tests

Closes #746