### PR TITLE
feat: platform-native memory backends (recall#758, #759, #760)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 </p>
 
 <p align="center">
+  <img src="https://img.shields.io/badge/Anthropic_Memory-ready-D97706?logo=anthropic&logoColor=white" alt="Anthropic Memory Tool">
+  <img src="https://img.shields.io/badge/OpenAI_Agents-ready-412991?logo=openai&logoColor=white" alt="OpenAI Agents">
+  <img src="https://img.shields.io/badge/Google_ADK-ready-4285F4?logo=google&logoColor=white" alt="Google ADK">
   <img src="https://img.shields.io/badge/LangChain-ready-1C3C3C?logo=langchain&logoColor=white" alt="LangChain">
   <img src="https://img.shields.io/badge/CrewAI-ready-FF6B35?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0id2hpdGUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjYiLz48L3N2Zz4=&logoColor=white" alt="CrewAI">
-  <img src="https://img.shields.io/badge/OpenAI_Agents-ready-412991?logo=openai&logoColor=white" alt="OpenAI Agents">
   <img src="https://img.shields.io/badge/Claude_Code-ready-D97706?logo=anthropic&logoColor=white" alt="Claude Code">
   <img src="https://img.shields.io/badge/Codex_CLI-ready-412991?logo=openai&logoColor=white" alt="Codex CLI">
 </p>
@@ -135,12 +137,129 @@ If your client accepts stdio MCP definitions directly, use:
 
 synapt plugs into popular agent frameworks as a drop-in memory backend. Each adapter wraps recall's search and save API for the framework's native session interface.
 
+Install all integration dependencies at once:
+
+```bash
+pip install synapt[all-integrations]
+```
+
+Or install only the ones you need:
+
+```bash
+pip install synapt[anthropic]    # Anthropic Memory Tool
+pip install synapt[openai]       # OpenAI Agents SDK
+pip install synapt[google-adk]   # Google ADK
+pip install synapt[langchain]    # LangChain
+pip install synapt[crewai]       # CrewAI
+```
+
+### Anthropic Memory Tool
+
+`SynaptMemoryTool` is a drop-in replacement for `BetaAbstractMemoryTool`. It presents recall's knowledge graph as a virtual filesystem that Claude can view, create, edit, and search. File reads are augmented with hybrid search context from recall.
+
+```bash
+pip install synapt[anthropic]
+```
+
+**Before** (default memory, no cross-session persistence):
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic()
+response = client.beta.messages.run_tools(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Remember that we use blue-green deploys"}],
+    tools=[{"type": "memory_20250818", "name": "memory"}],
+).until_done()
+```
+
+**After** (recall-backed memory with hybrid search):
+
+```python
+from anthropic import Anthropic
+from synapt.integrations.anthropic import SynaptMemoryTool
+
+client = Anthropic()
+memory = SynaptMemoryTool()
+
+response = client.beta.messages.run_tools(
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Remember that we use blue-green deploys"}],
+    tools=[memory],
+).until_done()
+```
+
+An async variant (`SynaptAsyncMemoryTool`) is available for `AsyncAnthropic` clients.
+
+### OpenAI Agents SDK
+
+`SynaptSession` implements the Agents SDK `Session` protocol with `SessionSettings` support. Items are stored in SQLite with non-blocking async DB access. Recall search and memory context are built in.
+
+```bash
+pip install synapt[openai]
+```
+
+**Before** (default SQLiteSession, no cross-session search):
+
+```python
+from agents import Agent, Runner
+from agents.memory import SQLiteSession
+
+session = SQLiteSession(session_id="user-123", db_path="sessions.db")
+runner = Runner(agent=agent, session=session)
+```
+
+**After** (recall-backed session with memory context):
+
+```python
+from agents import Agent, Runner
+from synapt.integrations.openai_agents import SynaptSession
+
+session = SynaptSession(session_id="user-123")
+runner = Runner(agent=agent, session=session)
+
+# Retrieve recall context for agent prompts
+context = session.get_memory_context("deployment strategy")
+
+# Persist durable knowledge
+session.save_to_recall("Always use UTC timestamps", category="convention")
+```
+
+### Google ADK
+
+`SynaptMemoryService` is a drop-in replacement for ADK's `InMemoryMemoryService`. Session events are indexed in recall's knowledge graph; `search_memory` uses hybrid retrieval instead of keyword matching.
+
+```bash
+pip install synapt[google-adk]
+```
+
+**Before** (default in-memory, keyword-only search):
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.memory import InMemoryMemoryService
+
+memory = InMemoryMemoryService()
+agent = LlmAgent(model="gemini-2.5-flash", name="my_agent", memory_service=memory)
+```
+
+**After** (recall-backed, hybrid search):
+
+```python
+from google.adk.agents import LlmAgent
+from synapt.integrations.google_adk import SynaptMemoryService
+
+memory = SynaptMemoryService()
+agent = LlmAgent(model="gemini-2.5-flash", name="my_agent", memory_service=memory)
+```
+
 ### LangChain
 
 `SynaptChatMessageHistory` implements LangChain's `BaseChatMessageHistory`. Messages are stored in SQLite with WAL mode; recall search and knowledge persistence are one method call away.
 
 ```bash
-pip install synapt langchain-core
+pip install synapt[langchain]
 ```
 
 ```python
@@ -159,25 +278,6 @@ history.save_to_recall("Always use UTC timestamps", category="convention")
 ```
 
 Works with `RunnableWithMessageHistory`, `ConversationChain`, and any LangChain component that accepts a `BaseChatMessageHistory`.
-
-### OpenAI Agents SDK
-
-`SynaptSession` implements the Agents SDK `Session` protocol. Items are stored as JSON dicts in SQLite; async throughout.
-
-```bash
-pip install synapt openai-agents
-```
-
-```python
-from synapt.integrations.openai_agents import SynaptSession
-
-session = SynaptSession(session_id="agent-run-42")
-await session.add_items([{"role": "user", "content": "hello"}])
-items = await session.get_items(limit=10)
-
-# Bridge to recall search
-results = session.search("prior error handling decisions")
-```
 
 ### CrewAI
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pip install synapt[crewai]       # CrewAI
 
 ### Anthropic Memory Tool
 
-`SynaptMemoryTool` is a drop-in replacement for `BetaAbstractMemoryTool`. It presents recall's knowledge graph as a virtual filesystem that Claude can view, create, edit, and search. File reads are augmented with hybrid search context from recall.
+`SynaptMemoryTool` is a drop-in replacement for `BetaAbstractMemoryTool`. It presents recall's knowledge graph as a virtual filesystem that Claude can view, create, edit, and search. All writes are persisted as durable recall knowledge nodes.
 
 ```bash
 pip install synapt[anthropic]
@@ -194,7 +194,7 @@ An async variant (`SynaptAsyncMemoryTool`) is available for `AsyncAnthropic` cli
 
 ### OpenAI Agents SDK
 
-`SynaptSession` implements the Agents SDK `Session` protocol with `SessionSettings` support. Items are stored in SQLite with non-blocking async DB access. Recall search and memory context are built in.
+`SynaptSession` is a session persistence adapter for the Agents SDK `Session` protocol. Items are stored in SQLite with non-blocking async DB access. Recall search and memory context are available as convenience methods.
 
 ```bash
 pip install synapt[openai]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,22 @@ Homepage = "https://synapt.dev"
 Repository = "https://github.com/synapt-dev/recall"
 
 [project.optional-dependencies]
+anthropic = ["anthropic>=0.77.0"]
+openai = ["openai-agents>=0.10.0"]
+google-adk = ["google-adk>=1.0.0"]
 langchain = ["langchain-core>=0.2"]
+crewai = ["crewai>=1.4.0"]
+all-integrations = [
+    "anthropic>=0.77.0",
+    "openai-agents>=0.10.0",
+    "google-adk>=1.0.0",
+    "langchain-core>=0.2",
+    "crewai>=1.4.0",
+]
 hf = ["huggingface_hub>=0.20"]
 onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
-crewai = ["crewai>=1.4.0"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4"]
 dev = ["watchfiles>=0.20"]
 test = [

--- a/src/synapt/integrations/__init__.py
+++ b/src/synapt/integrations/__init__.py
@@ -1,6 +1,8 @@
 """synapt.integrations — framework adapters for recall memory.
 
 Each submodule wraps recall's search/save API for a specific framework:
+- anthropic: Memory Tool backend for the Anthropic SDK
 - langchain: BaseChatMessageHistory adapter (langchain-synapt on PyPI)
 - openai_agents: Session adapter for the OpenAI Agents SDK
+- google_adk: MemoryService + SessionService for Google ADK
 """

--- a/src/synapt/integrations/anthropic.py
+++ b/src/synapt/integrations/anthropic.py
@@ -34,9 +34,8 @@ import hashlib
 import logging
 import re
 import threading
-from datetime import datetime, timezone
 from pathlib import PurePosixPath
-from typing import Any, Optional
+from typing import Any
 
 try:
     from anthropic.lib.tools import (
@@ -62,7 +61,7 @@ else:
 
 log = logging.getLogger("synapt.integrations.anthropic")
 
-_VIRTUAL_ROOT = "/memory"
+_VIRTUAL_ROOT = "/memories"
 _VIRTUAL_DIRS = ("knowledge", "sessions", "notes")
 
 
@@ -155,7 +154,7 @@ class _RecallBridge:
 
         category = "memory"
         parts = PurePosixPath(path).parts
-        if len(parts) >= 3 and parts[1] == "memory":
+        if len(parts) >= 3 and parts[1] == "memories":
             category = parts[2]
 
         return recall_save(
@@ -218,10 +217,9 @@ class _RecallBridge:
 class _MemoryToolCore:
     """Shared implementation for sync and async memory tools."""
 
-    def __init__(self, *, search_augment: bool = True) -> None:
+    def __init__(self) -> None:
         self._cache = _FileCache()
         self._bridge = _RecallBridge()
-        self._search_augment = search_augment
         self._initialized = False
 
     def _ensure_initialized(self) -> None:
@@ -254,7 +252,7 @@ class _MemoryToolCore:
             if path.rstrip("/").split("/")[-1] in _VIRTUAL_DIRS:
                 return f"Here's the result of running `view` on {path}:\n  (empty directory)\n"
 
-            return f"Error: path '{path}' does not exist. Use `view` on '{_VIRTUAL_ROOT}' to see available files."
+            raise Exception(f"path '{path}' does not exist. Use `view` on '{_VIRTUAL_ROOT}' to see available files.")
 
         view_range = getattr(command, "view_range", None)
         lines = content.split("\n")
@@ -268,28 +266,14 @@ class _MemoryToolCore:
         else:
             numbered = _numbered_lines(content)
 
-        result = f"Here's the result of running `view` on {path}:\n{numbered}\n"
-
-        if self._search_augment and not view_range:
-            filename = PurePosixPath(path).stem.replace("-", " ")
-            try:
-                search_result = self._bridge.search(
-                    f"{filename} {content[:200]}",
-                    max_chunks=2,
-                )
-                if search_result and "No results" not in search_result:
-                    result += f"\n--- Related recall context ---\n{search_result}\n"
-            except Exception as e:
-                log.debug("Search augmentation failed: %s", e)
-
-        return result
+        return f"Here's the result of running `view` on {path}:\n{numbered}\n"
 
     def do_create(self, command: Any) -> str:
         self._ensure_initialized()
         path = _normalize_path(command.path)
 
         if self._cache.get(path) is not None:
-            return f"Error: file '{path}' already exists. Use `str_replace` to edit or `delete` first."
+            raise Exception(f"file '{path}' already exists. Use `str_replace` to edit or `delete` first.")
 
         self._cache.set(path, command.file_text)
 
@@ -306,13 +290,13 @@ class _MemoryToolCore:
         content = self._cache.get(path)
 
         if content is None:
-            return f"Error: file '{path}' does not exist."
+            raise Exception(f"file '{path}' does not exist.")
 
         occurrences = content.count(command.old_str)
         if occurrences == 0:
-            return f"Error: `old_str` not found in {path}. No changes made."
+            raise Exception(f"`old_str` not found in {path}. No changes made.")
         if occurrences > 1:
-            return f"Error: `old_str` found {occurrences} times in {path}. Please provide a more unique string."
+            raise Exception(f"`old_str` found {occurrences} times in {path}. Please provide a more unique string.")
 
         new_content = content.replace(command.old_str, command.new_str, 1)
         self._cache.set(path, new_content)
@@ -330,13 +314,13 @@ class _MemoryToolCore:
         content = self._cache.get(path)
 
         if content is None:
-            return f"Error: file '{path}' does not exist."
+            raise Exception(f"file '{path}' does not exist.")
 
         lines = content.split("\n")
         insert_line = command.insert_line
 
         if insert_line < 0 or insert_line > len(lines):
-            return f"Error: insert_line {insert_line} is out of range [0, {len(lines)}]."
+            raise Exception(f"insert_line {insert_line} is out of range [0, {len(lines)}].")
 
         new_lines = command.insert_text.split("\n")
         lines[insert_line:insert_line] = new_lines
@@ -366,7 +350,7 @@ class _MemoryToolCore:
             return f"Directory '{path}' and {len(children)} file(s) deleted."
 
         if not self._cache.delete(path):
-            return f"Error: path '{path}' does not exist."
+            raise Exception(f"path '{path}' does not exist.")
 
         try:
             self._bridge.retract(path)
@@ -381,10 +365,10 @@ class _MemoryToolCore:
         new_path = _normalize_path(command.new_path)
 
         if self._cache.get(new_path) is not None:
-            return f"Error: destination '{new_path}' already exists."
+            raise Exception(f"destination '{new_path}' already exists.")
 
         if not self._cache.rename(old_path, new_path):
-            return f"Error: source '{old_path}' does not exist."
+            raise Exception(f"source '{old_path}' does not exist.")
 
         try:
             content = self._cache.get(new_path)
@@ -412,20 +396,17 @@ if BetaAbstractMemoryTool is not None:
         hybrid search and knowledge persistence.
 
         Args:
-            search_augment: If True (default), view responses include related
-                recall context from hybrid search below the file content.
             cache_control: Optional Anthropic cache control parameter.
         """
 
         def __init__(
             self,
             *,
-            search_augment: bool = True,
             cache_control: BetaCacheControlEphemeralParam | None = None,
         ) -> None:
             _require_anthropic()
             super().__init__(cache_control=cache_control)
-            self._core = _MemoryToolCore(search_augment=search_augment)
+            self._core = _MemoryToolCore()
 
         def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             return self._core.do_view(command)
@@ -448,6 +429,20 @@ if BetaAbstractMemoryTool is not None:
         def clear_all_memory(self) -> BetaFunctionToolResultType:
             return self._core.do_clear_all()
 
+        def get_context(self, query: str, *, max_chunks: int = 3) -> str:
+            """Search recall for context related to a query.
+
+            Use this outside the memory tool loop to retrieve relevant
+            recall context without polluting view() responses.
+            """
+            try:
+                result = self._core._bridge.search(query, max_chunks=max_chunks)
+                if result and "No results" not in result:
+                    return result
+                return ""
+            except Exception:
+                return ""
+
 
 if BetaAsyncAbstractMemoryTool is not None:
 
@@ -461,12 +456,11 @@ if BetaAsyncAbstractMemoryTool is not None:
         def __init__(
             self,
             *,
-            search_augment: bool = True,
             cache_control: BetaCacheControlEphemeralParam | None = None,
         ) -> None:
             _require_anthropic()
             super().__init__(cache_control=cache_control)
-            self._core = _MemoryToolCore(search_augment=search_augment)
+            self._core = _MemoryToolCore()
 
         async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             return self._core.do_view(command)
@@ -488,6 +482,16 @@ if BetaAsyncAbstractMemoryTool is not None:
 
         async def clear_all_memory(self) -> BetaFunctionToolResultType:
             return self._core.do_clear_all()
+
+        def get_context(self, query: str, *, max_chunks: int = 3) -> str:
+            """Search recall for context related to a query."""
+            try:
+                result = self._core._bridge.search(query, max_chunks=max_chunks)
+                if result and "No results" not in result:
+                    return result
+                return ""
+            except Exception:
+                return ""
 
 else:
 

--- a/src/synapt/integrations/anthropic.py
+++ b/src/synapt/integrations/anthropic.py
@@ -1,0 +1,504 @@
+"""Anthropic Memory Tool backend powered by synapt recall.
+
+Provides SynaptMemoryTool, a drop-in replacement for Anthropic's
+BetaAbstractMemoryTool that routes all memory operations through recall's
+hybrid search and knowledge persistence.
+
+Usage:
+    from anthropic import Anthropic
+    from synapt.integrations.anthropic import SynaptMemoryTool
+
+    client = Anthropic()
+    memory = SynaptMemoryTool()
+
+    response = client.beta.messages.run_tools(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "Remember that deployments use blue-green strategy"}],
+        tools=[memory],
+    ).until_done()
+
+    # Async variant
+    from synapt.integrations.anthropic import SynaptAsyncMemoryTool
+
+    async_memory = SynaptAsyncMemoryTool()
+    response = await client.beta.messages.run_tools(
+        model="claude-sonnet-4-6",
+        messages=[...],
+        tools=[async_memory],
+    ).until_done()
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import PurePosixPath
+from typing import Any, Optional
+
+try:
+    from anthropic.lib.tools import (
+        BetaAbstractMemoryTool,
+        BetaAsyncAbstractMemoryTool,
+        BetaFunctionToolResultType,
+    )
+    from anthropic.types.beta import (
+        BetaCacheControlEphemeralParam,
+        BetaMemoryTool20250818CreateCommand,
+        BetaMemoryTool20250818DeleteCommand,
+        BetaMemoryTool20250818InsertCommand,
+        BetaMemoryTool20250818RenameCommand,
+        BetaMemoryTool20250818StrReplaceCommand,
+        BetaMemoryTool20250818ViewCommand,
+    )
+except ImportError as exc:
+    BetaAbstractMemoryTool = None  # type: ignore[assignment,misc]
+    BetaAsyncAbstractMemoryTool = None  # type: ignore[assignment,misc]
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+log = logging.getLogger("synapt.integrations.anthropic")
+
+_VIRTUAL_ROOT = "/memory"
+_VIRTUAL_DIRS = ("knowledge", "sessions", "notes")
+
+
+def _require_anthropic() -> None:
+    if _IMPORT_ERROR is not None:
+        raise ImportError(
+            "Install anthropic>=0.77.0 to use the Anthropic memory backend"
+        ) from _IMPORT_ERROR
+
+
+def _normalize_path(path: str) -> str:
+    p = PurePosixPath(path)
+    if not p.is_absolute():
+        p = PurePosixPath(_VIRTUAL_ROOT) / p
+    parts = []
+    for part in p.parts:
+        if part == "/":
+            continue
+        parts.append(part)
+    result = "/" + "/".join(parts) if parts else "/"
+    if not result.startswith(_VIRTUAL_ROOT):
+        result = _VIRTUAL_ROOT + result
+    return result
+
+
+def _path_to_node_id(path: str) -> str:
+    return hashlib.sha1(path.encode("utf-8")).hexdigest()[:12]
+
+
+def _numbered_lines(text: str, start: int = 1) -> str:
+    lines = text.split("\n")
+    width = len(str(start + len(lines) - 1))
+    return "\n".join(
+        f"{i:>{width}}\t{line}" for i, line in enumerate(lines, start=start)
+    )
+
+
+class _FileCache:
+    """Thread-safe in-memory cache for virtual memory files."""
+
+    def __init__(self) -> None:
+        self._files: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def get(self, path: str) -> str | None:
+        with self._lock:
+            return self._files.get(path)
+
+    def set(self, path: str, content: str) -> None:
+        with self._lock:
+            self._files[path] = content
+
+    def delete(self, path: str) -> bool:
+        with self._lock:
+            return self._files.pop(path, None) is not None
+
+    def rename(self, old_path: str, new_path: str) -> bool:
+        with self._lock:
+            content = self._files.pop(old_path, None)
+            if content is None:
+                return False
+            self._files[new_path] = content
+            return True
+
+    def list_dir(self, dir_path: str) -> list[str]:
+        with self._lock:
+            prefix = dir_path.rstrip("/") + "/"
+            children: set[str] = set()
+            for p in self._files:
+                if p.startswith(prefix):
+                    remainder = p[len(prefix):]
+                    child = remainder.split("/")[0]
+                    children.add(child)
+            return sorted(children)
+
+    def list_all(self) -> list[str]:
+        with self._lock:
+            return sorted(self._files.keys())
+
+    def clear(self) -> None:
+        with self._lock:
+            self._files.clear()
+
+
+class _RecallBridge:
+    """Bridges virtual file operations to recall's knowledge store."""
+
+    def save(self, path: str, content: str) -> str:
+        from synapt.recall.server import recall_save
+
+        category = "memory"
+        parts = PurePosixPath(path).parts
+        if len(parts) >= 3 and parts[1] == "memory":
+            category = parts[2]
+
+        return recall_save(
+            content=content,
+            category=category,
+            confidence=0.85,
+            tags=["anthropic-memory", PurePosixPath(path).name],
+            node_id=_path_to_node_id(path),
+        )
+
+    def retract(self, path: str) -> str:
+        from synapt.recall.server import recall_save
+
+        return recall_save(
+            node_id=_path_to_node_id(path),
+            retract=True,
+        )
+
+    def search(self, query: str, max_chunks: int = 3) -> str:
+        from synapt.recall.server import recall_search
+
+        return recall_search(
+            query=query,
+            max_chunks=max_chunks,
+            max_tokens=800,
+        )
+
+    def load_knowledge_files(self, cache: _FileCache) -> None:
+        """Seed the cache with existing recall knowledge nodes."""
+        try:
+            from synapt.recall.core import project_index_dir
+            from synapt.recall.storage import RecallDB
+            from pathlib import Path
+
+            project = Path.cwd().resolve()
+            db_path = project_index_dir(project) / "recall.db"
+            if not db_path.exists():
+                return
+            db = RecallDB(db_path)
+            try:
+                nodes = db.list_knowledge_nodes(limit=200)
+                for node in nodes:
+                    if node.get("status") == "retracted":
+                        continue
+                    content = node.get("content", "")
+                    node_id = node.get("id", "")
+                    category = node.get("category", "knowledge")
+                    if category not in _VIRTUAL_DIRS:
+                        category = "knowledge"
+                    slug = re.sub(r"[^a-z0-9]+", "-", content[:60].lower()).strip("-")
+                    filename = f"{slug}-{node_id[:6]}.md"
+                    path = f"{_VIRTUAL_ROOT}/{category}/{filename}"
+                    cache.set(path, content)
+            finally:
+                db.close()
+        except Exception as e:
+            log.debug("Could not seed knowledge files: %s", e)
+
+
+class _MemoryToolCore:
+    """Shared implementation for sync and async memory tools."""
+
+    def __init__(self, *, search_augment: bool = True) -> None:
+        self._cache = _FileCache()
+        self._bridge = _RecallBridge()
+        self._search_augment = search_augment
+        self._initialized = False
+
+    def _ensure_initialized(self) -> None:
+        if not self._initialized:
+            self._bridge.load_knowledge_files(self._cache)
+            self._initialized = True
+
+    def do_view(self, command: Any) -> str:
+        self._ensure_initialized()
+        path = _normalize_path(command.path)
+
+        if path == _VIRTUAL_ROOT or path == _VIRTUAL_ROOT + "/":
+            entries = list(_VIRTUAL_DIRS)
+            cached_top = set()
+            for p in self._cache.list_all():
+                rel = p[len(_VIRTUAL_ROOT) + 1:] if p.startswith(_VIRTUAL_ROOT + "/") else p
+                top = rel.split("/")[0]
+                cached_top.add(top)
+            entries = sorted(set(entries) | cached_top)
+            listing = "\n".join(f"  {e}/" for e in entries)
+            return f"Here's the result of running `view` on {path}:\n{listing}\n"
+
+        content = self._cache.get(path)
+        if content is None:
+            children = self._cache.list_dir(path)
+            if children:
+                listing = "\n".join(f"  {c}" for c in children)
+                return f"Here's the result of running `view` on {path}:\n{listing}\n"
+
+            if path.rstrip("/").split("/")[-1] in _VIRTUAL_DIRS:
+                return f"Here's the result of running `view` on {path}:\n  (empty directory)\n"
+
+            return f"Error: path '{path}' does not exist. Use `view` on '{_VIRTUAL_ROOT}' to see available files."
+
+        view_range = getattr(command, "view_range", None)
+        lines = content.split("\n")
+
+        if view_range and len(view_range) == 2:
+            start, end = view_range
+            start = max(1, start)
+            end = min(len(lines), end)
+            selected = lines[start - 1:end]
+            numbered = _numbered_lines("\n".join(selected), start=start)
+        else:
+            numbered = _numbered_lines(content)
+
+        result = f"Here's the result of running `view` on {path}:\n{numbered}\n"
+
+        if self._search_augment and not view_range:
+            filename = PurePosixPath(path).stem.replace("-", " ")
+            try:
+                search_result = self._bridge.search(
+                    f"{filename} {content[:200]}",
+                    max_chunks=2,
+                )
+                if search_result and "No results" not in search_result:
+                    result += f"\n--- Related recall context ---\n{search_result}\n"
+            except Exception as e:
+                log.debug("Search augmentation failed: %s", e)
+
+        return result
+
+    def do_create(self, command: Any) -> str:
+        self._ensure_initialized()
+        path = _normalize_path(command.path)
+
+        if self._cache.get(path) is not None:
+            return f"Error: file '{path}' already exists. Use `str_replace` to edit or `delete` first."
+
+        self._cache.set(path, command.file_text)
+
+        try:
+            self._bridge.save(path, command.file_text)
+        except Exception as e:
+            log.warning("Recall save failed for %s: %s", path, e)
+
+        return f"File created successfully at {path}."
+
+    def do_str_replace(self, command: Any) -> str:
+        self._ensure_initialized()
+        path = _normalize_path(command.path)
+        content = self._cache.get(path)
+
+        if content is None:
+            return f"Error: file '{path}' does not exist."
+
+        occurrences = content.count(command.old_str)
+        if occurrences == 0:
+            return f"Error: `old_str` not found in {path}. No changes made."
+        if occurrences > 1:
+            return f"Error: `old_str` found {occurrences} times in {path}. Please provide a more unique string."
+
+        new_content = content.replace(command.old_str, command.new_str, 1)
+        self._cache.set(path, new_content)
+
+        try:
+            self._bridge.save(path, new_content)
+        except Exception as e:
+            log.warning("Recall update failed for %s: %s", path, e)
+
+        return f"The file {path} has been edited successfully."
+
+    def do_insert(self, command: Any) -> str:
+        self._ensure_initialized()
+        path = _normalize_path(command.path)
+        content = self._cache.get(path)
+
+        if content is None:
+            return f"Error: file '{path}' does not exist."
+
+        lines = content.split("\n")
+        insert_line = command.insert_line
+
+        if insert_line < 0 or insert_line > len(lines):
+            return f"Error: insert_line {insert_line} is out of range [0, {len(lines)}]."
+
+        new_lines = command.insert_text.split("\n")
+        lines[insert_line:insert_line] = new_lines
+        new_content = "\n".join(lines)
+        self._cache.set(path, new_content)
+
+        try:
+            self._bridge.save(path, new_content)
+        except Exception as e:
+            log.warning("Recall update failed for %s: %s", path, e)
+
+        return f"The file {path} has been edited successfully."
+
+    def do_delete(self, command: Any) -> str:
+        self._ensure_initialized()
+        path = _normalize_path(command.path)
+
+        children = self._cache.list_dir(path)
+        if children:
+            for child in children:
+                child_path = path.rstrip("/") + "/" + child
+                self._cache.delete(child_path)
+                try:
+                    self._bridge.retract(child_path)
+                except Exception:
+                    pass
+            return f"Directory '{path}' and {len(children)} file(s) deleted."
+
+        if not self._cache.delete(path):
+            return f"Error: path '{path}' does not exist."
+
+        try:
+            self._bridge.retract(path)
+        except Exception as e:
+            log.warning("Recall retract failed for %s: %s", path, e)
+
+        return f"File '{path}' has been deleted."
+
+    def do_rename(self, command: Any) -> str:
+        self._ensure_initialized()
+        old_path = _normalize_path(command.old_path)
+        new_path = _normalize_path(command.new_path)
+
+        if self._cache.get(new_path) is not None:
+            return f"Error: destination '{new_path}' already exists."
+
+        if not self._cache.rename(old_path, new_path):
+            return f"Error: source '{old_path}' does not exist."
+
+        try:
+            content = self._cache.get(new_path)
+            if content is not None:
+                self._bridge.retract(old_path)
+                self._bridge.save(new_path, content)
+        except Exception as e:
+            log.warning("Recall rename failed: %s", e)
+
+        return f"Renamed '{old_path}' to '{new_path}'."
+
+    def do_clear_all(self) -> str:
+        self._cache.clear()
+        self._initialized = False
+        return "All memory cleared."
+
+
+if BetaAbstractMemoryTool is not None:
+
+    class SynaptMemoryTool(BetaAbstractMemoryTool):
+        """Anthropic Memory Tool backed by synapt recall.
+
+        Drop-in replacement for BetaAbstractMemoryTool. Routes all file
+        operations through a virtual filesystem facade backed by recall's
+        hybrid search and knowledge persistence.
+
+        Args:
+            search_augment: If True (default), view responses include related
+                recall context from hybrid search below the file content.
+            cache_control: Optional Anthropic cache control parameter.
+        """
+
+        def __init__(
+            self,
+            *,
+            search_augment: bool = True,
+            cache_control: BetaCacheControlEphemeralParam | None = None,
+        ) -> None:
+            _require_anthropic()
+            super().__init__(cache_control=cache_control)
+            self._core = _MemoryToolCore(search_augment=search_augment)
+
+        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+            return self._core.do_view(command)
+
+        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+            return self._core.do_create(command)
+
+        def str_replace(self, command: BetaMemoryTool20250818StrReplaceCommand) -> BetaFunctionToolResultType:
+            return self._core.do_str_replace(command)
+
+        def insert(self, command: BetaMemoryTool20250818InsertCommand) -> BetaFunctionToolResultType:
+            return self._core.do_insert(command)
+
+        def delete(self, command: BetaMemoryTool20250818DeleteCommand) -> BetaFunctionToolResultType:
+            return self._core.do_delete(command)
+
+        def rename(self, command: BetaMemoryTool20250818RenameCommand) -> BetaFunctionToolResultType:
+            return self._core.do_rename(command)
+
+        def clear_all_memory(self) -> BetaFunctionToolResultType:
+            return self._core.do_clear_all()
+
+
+if BetaAsyncAbstractMemoryTool is not None:
+
+    class SynaptAsyncMemoryTool(BetaAsyncAbstractMemoryTool):
+        """Async variant of SynaptMemoryTool.
+
+        Same behavior as SynaptMemoryTool but implements the async interface
+        for use with AsyncAnthropic clients.
+        """
+
+        def __init__(
+            self,
+            *,
+            search_augment: bool = True,
+            cache_control: BetaCacheControlEphemeralParam | None = None,
+        ) -> None:
+            _require_anthropic()
+            super().__init__(cache_control=cache_control)
+            self._core = _MemoryToolCore(search_augment=search_augment)
+
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+            return self._core.do_view(command)
+
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+            return self._core.do_create(command)
+
+        async def str_replace(self, command: BetaMemoryTool20250818StrReplaceCommand) -> BetaFunctionToolResultType:
+            return self._core.do_str_replace(command)
+
+        async def insert(self, command: BetaMemoryTool20250818InsertCommand) -> BetaFunctionToolResultType:
+            return self._core.do_insert(command)
+
+        async def delete(self, command: BetaMemoryTool20250818DeleteCommand) -> BetaFunctionToolResultType:
+            return self._core.do_delete(command)
+
+        async def rename(self, command: BetaMemoryTool20250818RenameCommand) -> BetaFunctionToolResultType:
+            return self._core.do_rename(command)
+
+        async def clear_all_memory(self) -> BetaFunctionToolResultType:
+            return self._core.do_clear_all()
+
+else:
+
+    class SynaptMemoryTool:  # type: ignore[no-redef]
+        """Stub when anthropic SDK is not installed."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            _require_anthropic()
+
+    class SynaptAsyncMemoryTool:  # type: ignore[no-redef]
+        """Stub when anthropic SDK is not installed."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            _require_anthropic()

--- a/src/synapt/integrations/google_adk.py
+++ b/src/synapt/integrations/google_adk.py
@@ -1,0 +1,235 @@
+"""Google ADK memory service backed by synapt recall.
+
+Provides SynaptMemoryService, a BaseMemoryService implementation that
+stores conversation events in recall's knowledge graph and uses hybrid
+search for retrieval. Drop-in replacement for InMemoryMemoryService.
+
+Usage:
+    from google.adk.agents import LlmAgent
+    from synapt.integrations.google_adk import SynaptMemoryService
+
+    memory = SynaptMemoryService()
+
+    agent = LlmAgent(
+        model="gemini-2.5-flash",
+        name="my_agent",
+        memory_service=memory,
+    )
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
+try:
+    from google.adk.memory.base_memory_service import (
+        BaseMemoryService,
+        SearchMemoryResponse,
+    )
+    from google.adk.memory.memory_entry import MemoryEntry
+    from google.genai import types
+except ImportError as exc:
+    BaseMemoryService = None  # type: ignore[assignment,misc]
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+if TYPE_CHECKING:
+    from google.adk.events.event import Event
+    from google.adk.sessions.session import Session
+
+log = logging.getLogger("synapt.integrations.google_adk")
+
+
+def _require_adk() -> None:
+    if _IMPORT_ERROR is not None:
+        raise ImportError(
+            "Install google-adk to use the Google ADK memory backend"
+        ) from _IMPORT_ERROR
+
+
+def _event_text(event: Event) -> str:
+    if not event.content or not event.content.parts:
+        return ""
+    return " ".join(
+        part.text for part in event.content.parts if getattr(part, "text", None)
+    )
+
+
+def _session_key(app_name: str, user_id: str) -> str:
+    return f"{app_name}/{user_id}"
+
+
+def _node_id(app_name: str, user_id: str, content_hash: str) -> str:
+    raw = f"{app_name}/{user_id}/{content_hash}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+if BaseMemoryService is not None:
+
+    class SynaptMemoryService(BaseMemoryService):
+        """Google ADK MemoryService backed by synapt recall.
+
+        Replaces the default InMemoryMemoryService with recall-powered
+        hybrid search. Session events are persisted as recall knowledge
+        nodes; search_memory uses semantic + keyword hybrid retrieval.
+
+        Args:
+            max_search_results: Maximum number of memory entries to return
+                from search_memory (default: 10).
+        """
+
+        def __init__(self, *, max_search_results: int = 10) -> None:
+            _require_adk()
+            self._max_results = max_search_results
+            self._lock = threading.Lock()
+            self._ingested: dict[str, set[str]] = {}
+
+        async def add_session_to_memory(self, session: Session) -> None:
+            key = _session_key(session.app_name, session.user_id)
+
+            with self._lock:
+                if key not in self._ingested:
+                    self._ingested[key] = set()
+                seen = self._ingested[key]
+
+            for event in session.events:
+                text = _event_text(event)
+                if not text or event.id in seen:
+                    continue
+                self._save_to_recall(
+                    app_name=session.app_name,
+                    user_id=session.user_id,
+                    text=text,
+                    author=getattr(event, "author", "unknown"),
+                )
+                with self._lock:
+                    seen.add(event.id)
+
+        async def add_events_to_memory(
+            self,
+            *,
+            app_name: str,
+            user_id: str,
+            events: Sequence[Event],
+            session_id: str | None = None,
+            custom_metadata: Mapping[str, object] | None = None,
+        ) -> None:
+            key = _session_key(app_name, user_id)
+
+            with self._lock:
+                if key not in self._ingested:
+                    self._ingested[key] = set()
+                seen = self._ingested[key]
+
+            for event in events:
+                text = _event_text(event)
+                if not text or event.id in seen:
+                    continue
+                self._save_to_recall(
+                    app_name=app_name,
+                    user_id=user_id,
+                    text=text,
+                    author=getattr(event, "author", "unknown"),
+                )
+                with self._lock:
+                    seen.add(event.id)
+
+        async def add_memory(
+            self,
+            *,
+            app_name: str,
+            user_id: str,
+            memories: Sequence[MemoryEntry],
+            custom_metadata: Mapping[str, object] | None = None,
+        ) -> None:
+            for entry in memories:
+                text = ""
+                if entry.content and entry.content.parts:
+                    text = " ".join(
+                        part.text
+                        for part in entry.content.parts
+                        if getattr(part, "text", None)
+                    )
+                if not text:
+                    continue
+                self._save_to_recall(
+                    app_name=app_name,
+                    user_id=user_id,
+                    text=text,
+                    author=entry.author or "unknown",
+                )
+
+        async def search_memory(
+            self,
+            *,
+            app_name: str,
+            user_id: str,
+            query: str,
+        ) -> SearchMemoryResponse:
+            try:
+                from synapt.recall.server import recall_search
+
+                result_text = recall_search(
+                    query=query,
+                    max_chunks=self._max_results,
+                    max_tokens=2000,
+                )
+            except Exception as e:
+                log.warning("Recall search failed: %s", e)
+                return SearchMemoryResponse()
+
+            if not result_text or "No results" in result_text:
+                return SearchMemoryResponse()
+
+            entries = []
+            for chunk in result_text.split("\n\n"):
+                chunk = chunk.strip()
+                if not chunk or chunk.startswith("---"):
+                    continue
+                entry = MemoryEntry(
+                    content=types.Content(
+                        parts=[types.Part(text=chunk)],
+                        role="model",
+                    ),
+                    author="recall",
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                )
+                entries.append(entry)
+
+            return SearchMemoryResponse(memories=entries[:self._max_results])
+
+        def _save_to_recall(
+            self,
+            *,
+            app_name: str,
+            user_id: str,
+            text: str,
+            author: str,
+        ) -> None:
+            try:
+                from synapt.recall.server import recall_save
+
+                content_hash = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+                recall_save(
+                    content=text,
+                    category="conversation",
+                    confidence=0.8,
+                    tags=["google-adk", app_name, author],
+                    node_id=_node_id(app_name, user_id, content_hash),
+                )
+            except Exception as e:
+                log.warning("Recall save failed: %s", e)
+
+else:
+
+    class SynaptMemoryService:  # type: ignore[no-redef]
+        """Stub when google-adk is not installed."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            _require_adk()

--- a/src/synapt/integrations/openai_agents.py
+++ b/src/synapt/integrations/openai_agents.py
@@ -13,40 +13,73 @@ Usage:
 
     # Semantic search across all recall-indexed sessions
     results = session.search("deployment config")
+
+    # Get recall-augmented context for agent prompts
+    context = session.get_memory_context("What deployment strategy do we use?")
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 import sqlite3
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
 
-try:  # pragma: no cover - optional dependency surface
+try:
     from agents.memory.session import SessionABC
-except ImportError:  # pragma: no cover
+    from agents.memory.session_settings import SessionSettings, resolve_session_limit
+except ImportError:
     SessionABC = object  # type: ignore[assignment,misc]
+    SessionSettings = None  # type: ignore[assignment,misc]
+
+    def resolve_session_limit(explicit_limit, settings):  # type: ignore[misc]
+        if explicit_limit is not None:
+            return explicit_limit
+        return None
+
+
+log = logging.getLogger("synapt.integrations.openai_agents")
 
 _DEFAULT_DB_DIR = Path.home() / ".synapt" / "integrations"
 
 _SCHEMA = """\
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    session_id TEXT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 CREATE TABLE IF NOT EXISTS agent_items (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL,
     item_data TEXT NOT NULL,
-    timestamp REAL NOT NULL
+    timestamp REAL NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES agent_sessions (session_id)
+        ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_agent_items_session
     ON agent_items (session_id, id);
 """
 
 
-class SynaptSession(SessionABC):
+class SynaptSession(SessionABC):  # type: ignore[misc]
     """OpenAI Agents SDK Session backed by SQLite with recall integration.
 
     Implements the Session protocol: get_items, add_items, pop_item,
-    clear_session. All methods are async to match the SDK contract.
+    clear_session. Uses asyncio.to_thread for non-blocking DB access.
+
+    Extends the standard session with recall-powered features:
+    - search(): semantic search across recall-indexed sessions
+    - save_to_recall(): persist durable knowledge nodes
+    - get_memory_context(): retrieve relevant recall context for prompts
+
+    Args:
+        session_id: Unique identifier for the conversation session.
+        db_path: Path to SQLite database. Defaults to ~/.synapt/integrations/.
+        session_settings: Optional SessionSettings for default limit behavior.
     """
 
     session_id: str
@@ -57,70 +90,111 @@ class SynaptSession(SessionABC):
         session_id: str,
         *,
         db_path: Optional[Path] = None,
+        session_settings: Any = None,
     ) -> None:
         self.session_id = session_id
+        if SessionSettings is not None and session_settings is None:
+            self.session_settings = SessionSettings()
+        else:
+            self.session_settings = session_settings
 
         if db_path is None:
             db_path = _DEFAULT_DB_DIR / "openai_agents_items.db"
         self._db_path = Path(db_path)
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(self._db_path))
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.executescript(_SCHEMA)
+        self._closed = False
 
     async def get_items(self, limit: int | None = None) -> list[dict[str, Any]]:
-        if limit is not None:
-            cursor = self._conn.execute(
-                "SELECT item_data FROM ("
-                "  SELECT item_data, id FROM agent_items"
-                "  WHERE session_id = ? ORDER BY id DESC LIMIT ?"
-                ") sub ORDER BY id",
-                (self.session_id, limit),
-            )
-        else:
-            cursor = self._conn.execute(
-                "SELECT item_data FROM agent_items WHERE session_id = ? ORDER BY id",
-                (self.session_id,),
-            )
-        items = []
-        for (row,) in cursor:
-            try:
-                items.append(json.loads(row))
-            except (json.JSONDecodeError, TypeError):
-                continue
-        return items
+        session_limit = resolve_session_limit(limit, self.session_settings)
+
+        def _sync() -> list[dict[str, Any]]:
+            with self._lock:
+                if session_limit is not None:
+                    cursor = self._conn.execute(
+                        "SELECT item_data FROM ("
+                        "  SELECT item_data, id FROM agent_items"
+                        "  WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+                        ") sub ORDER BY id",
+                        (self.session_id, session_limit),
+                    )
+                else:
+                    cursor = self._conn.execute(
+                        "SELECT item_data FROM agent_items WHERE session_id = ? ORDER BY id",
+                        (self.session_id,),
+                    )
+                items = []
+                for (row,) in cursor:
+                    try:
+                        items.append(json.loads(row))
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                return items
+
+        return await asyncio.to_thread(_sync)
 
     async def add_items(self, items: list[dict[str, Any]]) -> None:
+        if not items:
+            return
         now = time.time()
-        rows = [(self.session_id, json.dumps(item), now) for item in items]
-        self._conn.executemany(
-            "INSERT INTO agent_items (session_id, item_data, timestamp) VALUES (?, ?, ?)",
-            rows,
-        )
-        self._conn.commit()
+
+        def _sync() -> None:
+            with self._lock:
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)",
+                    (self.session_id,),
+                )
+                rows = [(self.session_id, json.dumps(item), now) for item in items]
+                self._conn.executemany(
+                    "INSERT INTO agent_items (session_id, item_data, timestamp) VALUES (?, ?, ?)",
+                    rows,
+                )
+                self._conn.execute(
+                    "UPDATE agent_sessions SET updated_at = CURRENT_TIMESTAMP WHERE session_id = ?",
+                    (self.session_id,),
+                )
+                self._conn.commit()
+
+        await asyncio.to_thread(_sync)
 
     async def pop_item(self) -> dict[str, Any] | None:
-        cursor = self._conn.execute(
-            "SELECT id, item_data FROM agent_items WHERE session_id = ? ORDER BY id DESC LIMIT 1",
-            (self.session_id,),
-        )
-        row = cursor.fetchone()
-        if row is None:
-            return None
-        row_id, item_data = row
-        self._conn.execute("DELETE FROM agent_items WHERE id = ?", (row_id,))
-        self._conn.commit()
-        try:
-            return json.loads(item_data)
-        except (json.JSONDecodeError, TypeError):
-            return None
+        def _sync() -> dict[str, Any] | None:
+            with self._lock:
+                cursor = self._conn.execute(
+                    "DELETE FROM agent_items "
+                    "WHERE id = ("
+                    "  SELECT id FROM agent_items WHERE session_id = ? ORDER BY id DESC LIMIT 1"
+                    ") RETURNING item_data",
+                    (self.session_id,),
+                )
+                result = cursor.fetchone()
+                self._conn.commit()
+                if result:
+                    try:
+                        return json.loads(result[0])
+                    except (json.JSONDecodeError, TypeError):
+                        return None
+                return None
+
+        return await asyncio.to_thread(_sync)
 
     async def clear_session(self) -> None:
-        self._conn.execute(
-            "DELETE FROM agent_items WHERE session_id = ?",
-            (self.session_id,),
-        )
-        self._conn.commit()
+        def _sync() -> None:
+            with self._lock:
+                self._conn.execute(
+                    "DELETE FROM agent_items WHERE session_id = ?",
+                    (self.session_id,),
+                )
+                self._conn.execute(
+                    "DELETE FROM agent_sessions WHERE session_id = ?",
+                    (self.session_id,),
+                )
+                self._conn.commit()
+
+        await asyncio.to_thread(_sync)
 
     def search(
         self,
@@ -156,26 +230,59 @@ class SynaptSession(SessionABC):
             tags=tags,
         )
 
+    def get_memory_context(
+        self,
+        query: str,
+        *,
+        max_chunks: int = 3,
+        max_tokens: int = 1000,
+    ) -> str:
+        """Retrieve recall context relevant to a query for agent prompts.
+
+        Returns a formatted string suitable for injection into system
+        prompts or tool context.
+        """
+        try:
+            from synapt.recall.server import recall_search
+
+            result = recall_search(
+                query=query,
+                max_chunks=max_chunks,
+                max_tokens=max_tokens,
+            )
+            if not result or "No results" in result:
+                return ""
+            return result
+        except Exception as e:
+            log.debug("Memory context retrieval failed: %s", e)
+            return ""
+
     @property
     def item_count(self) -> int:
-        cursor = self._conn.execute(
-            "SELECT COUNT(*) FROM agent_items WHERE session_id = ?",
-            (self.session_id,),
-        )
-        return cursor.fetchone()[0]
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT COUNT(*) FROM agent_items WHERE session_id = ?",
+                (self.session_id,),
+            )
+            return cursor.fetchone()[0]
 
     def get_session_ids(self) -> list[str]:
-        cursor = self._conn.execute(
-            "SELECT DISTINCT session_id FROM agent_items ORDER BY session_id"
-        )
-        return [row[0] for row in cursor]
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT DISTINCT session_id FROM agent_items ORDER BY session_id"
+            )
+            return [row[0] for row in cursor]
 
     def close(self) -> None:
-        self._conn.close()
+        with self._lock:
+            if not self._closed:
+                self._closed = True
+                self._conn.close()
 
     def __del__(self) -> None:
         try:
-            self._conn.close()
+            if not self._closed:
+                self._conn.close()
         except Exception:
             pass
 

--- a/tests/integrations/test_anthropic_memory_tool.py
+++ b/tests/integrations/test_anthropic_memory_tool.py
@@ -28,22 +28,7 @@ def tool():
         bridge_instance.load_knowledge_files.return_value = None
 
         from synapt.integrations.anthropic import SynaptMemoryTool
-        t = SynaptMemoryTool(search_augment=False)
-        t._core._bridge = bridge_instance
-        yield t
-
-
-@pytest.fixture
-def tool_with_search():
-    with patch("synapt.integrations.anthropic._RecallBridge") as MockBridge:
-        bridge_instance = MockBridge.return_value
-        bridge_instance.save.return_value = "saved"
-        bridge_instance.retract.return_value = "retracted"
-        bridge_instance.search.return_value = "Relevant context: deploy uses blue-green"
-        bridge_instance.load_knowledge_files.return_value = None
-
-        from synapt.integrations.anthropic import SynaptMemoryTool
-        t = SynaptMemoryTool(search_augment=True)
+        t = SynaptMemoryTool()
         t._core._bridge = bridge_instance
         yield t
 
@@ -79,30 +64,29 @@ def _rename(old_path, new_path):
 class TestViewCommand:
 
     def test_view_root_lists_directories(self, tool):
-        result = tool.view(_view("/memory"))
+        result = tool.view(_view("/memories"))
         assert "knowledge/" in result
         assert "sessions/" in result
         assert "notes/" in result
 
     def test_view_empty_directory(self, tool):
-        result = tool.view(_view("/memory/knowledge"))
+        result = tool.view(_view("/memories/knowledge"))
         assert "empty directory" in result
 
     def test_view_nonexistent_file(self, tool):
-        result = tool.view(_view("/memory/knowledge/nope.md"))
-        assert "Error" in result
-        assert "does not exist" in result
+        with pytest.raises(Exception, match="does not exist"):
+            tool.view(_view("/memories/knowledge/nope.md"))
 
     def test_view_file_with_line_numbers(self, tool):
-        tool.create(_create("/memory/notes/deploy.md", "line one\nline two\nline three"))
-        result = tool.view(_view("/memory/notes/deploy.md"))
+        tool.create(_create("/memories/notes/deploy.md", "line one\nline two\nline three"))
+        result = tool.view(_view("/memories/notes/deploy.md"))
         assert "1\tline one" in result
         assert "2\tline two" in result
         assert "3\tline three" in result
 
     def test_view_file_with_range(self, tool):
-        tool.create(_create("/memory/notes/multi.md", "a\nb\nc\nd\ne"))
-        result = tool.view(_view("/memory/notes/multi.md", view_range=[2, 4]))
+        tool.create(_create("/memories/notes/multi.md", "a\nb\nc\nd\ne"))
+        result = tool.view(_view("/memories/notes/multi.md", view_range=[2, 4]))
         assert "2\tb" in result
         assert "3\tc" in result
         assert "4\td" in result
@@ -110,187 +94,189 @@ class TestViewCommand:
         assert "5\te" not in result
 
     def test_view_directory_listing(self, tool):
-        tool.create(_create("/memory/notes/a.md", "aaa"))
-        tool.create(_create("/memory/notes/b.md", "bbb"))
-        result = tool.view(_view("/memory/notes"))
+        tool.create(_create("/memories/notes/a.md", "aaa"))
+        tool.create(_create("/memories/notes/b.md", "bbb"))
+        result = tool.view(_view("/memories/notes"))
         assert "a.md" in result
         assert "b.md" in result
+
+    def test_view_no_search_augmentation(self, tool):
+        tool._core._bridge.search.return_value = "Relevant context: deploy uses blue-green"
+        tool.create(_create("/memories/notes/deploy.md", "blue-green deploys"))
+        result = tool.view(_view("/memories/notes/deploy.md"))
+        assert "Related recall context" not in result
 
 
 class TestCreateCommand:
 
     def test_create_new_file(self, tool):
-        result = tool.create(_create("/memory/notes/test.md", "hello world"))
+        result = tool.create(_create("/memories/notes/test.md", "hello world"))
         assert "created successfully" in result
 
-    def test_create_duplicate_fails(self, tool):
-        tool.create(_create("/memory/notes/dup.md", "first"))
-        result = tool.create(_create("/memory/notes/dup.md", "second"))
-        assert "Error" in result
-        assert "already exists" in result
+    def test_create_duplicate_raises(self, tool):
+        tool.create(_create("/memories/notes/dup.md", "first"))
+        with pytest.raises(Exception, match="already exists"):
+            tool.create(_create("/memories/notes/dup.md", "second"))
 
     def test_create_triggers_recall_save(self, tool):
-        tool.create(_create("/memory/knowledge/fact.md", "Python 3.13 is latest"))
+        tool.create(_create("/memories/knowledge/fact.md", "Python 3.13 is latest"))
         tool._core._bridge.save.assert_called()
 
     def test_create_relative_path(self, tool):
         result = tool.create(_create("notes/rel.md", "relative path"))
         assert "created successfully" in result
-        view_result = tool.view(_view("/memory/notes/rel.md"))
+        view_result = tool.view(_view("/memories/notes/rel.md"))
         assert "relative path" in view_result
 
 
 class TestStrReplaceCommand:
 
     def test_replace_succeeds(self, tool):
-        tool.create(_create("/memory/notes/edit.md", "old text here"))
-        result = tool.str_replace(_str_replace("/memory/notes/edit.md", "old text", "new text"))
+        tool.create(_create("/memories/notes/edit.md", "old text here"))
+        result = tool.str_replace(_str_replace("/memories/notes/edit.md", "old text", "new text"))
         assert "edited successfully" in result
-        view = tool.view(_view("/memory/notes/edit.md"))
+        view = tool.view(_view("/memories/notes/edit.md"))
         assert "new text" in view
         assert "old text" not in view
 
-    def test_replace_not_found(self, tool):
-        tool.create(_create("/memory/notes/nf.md", "some content"))
-        result = tool.str_replace(_str_replace("/memory/notes/nf.md", "missing", "new"))
-        assert "Error" in result
-        assert "not found" in result
+    def test_replace_not_found_raises(self, tool):
+        tool.create(_create("/memories/notes/nf.md", "some content"))
+        with pytest.raises(Exception, match="not found"):
+            tool.str_replace(_str_replace("/memories/notes/nf.md", "missing", "new"))
 
-    def test_replace_ambiguous(self, tool):
-        tool.create(_create("/memory/notes/amb.md", "aaa aaa"))
-        result = tool.str_replace(_str_replace("/memory/notes/amb.md", "aaa", "bbb"))
-        assert "Error" in result
-        assert "2 times" in result
+    def test_replace_ambiguous_raises(self, tool):
+        tool.create(_create("/memories/notes/amb.md", "aaa aaa"))
+        with pytest.raises(Exception, match="2 times"):
+            tool.str_replace(_str_replace("/memories/notes/amb.md", "aaa", "bbb"))
 
-    def test_replace_nonexistent_file(self, tool):
-        result = tool.str_replace(_str_replace("/memory/notes/nope.md", "a", "b"))
-        assert "Error" in result
-        assert "does not exist" in result
+    def test_replace_nonexistent_file_raises(self, tool):
+        with pytest.raises(Exception, match="does not exist"):
+            tool.str_replace(_str_replace("/memories/notes/nope.md", "a", "b"))
 
 
 class TestInsertCommand:
 
     def test_insert_at_beginning(self, tool):
-        tool.create(_create("/memory/notes/ins.md", "line 1\nline 2"))
-        result = tool.insert(_insert("/memory/notes/ins.md", 0, "new first"))
+        tool.create(_create("/memories/notes/ins.md", "line 1\nline 2"))
+        result = tool.insert(_insert("/memories/notes/ins.md", 0, "new first"))
         assert "edited successfully" in result
-        view = tool.view(_view("/memory/notes/ins.md"))
+        view = tool.view(_view("/memories/notes/ins.md"))
         assert "1\tnew first" in view
 
     def test_insert_at_end(self, tool):
-        tool.create(_create("/memory/notes/ins2.md", "line 1\nline 2"))
-        tool.insert(_insert("/memory/notes/ins2.md", 2, "line 3"))
-        view = tool.view(_view("/memory/notes/ins2.md"))
+        tool.create(_create("/memories/notes/ins2.md", "line 1\nline 2"))
+        tool.insert(_insert("/memories/notes/ins2.md", 2, "line 3"))
+        view = tool.view(_view("/memories/notes/ins2.md"))
         assert "3\tline 3" in view
 
-    def test_insert_out_of_range(self, tool):
-        tool.create(_create("/memory/notes/ins3.md", "one"))
-        result = tool.insert(_insert("/memory/notes/ins3.md", 100, "nope"))
-        assert "Error" in result
-        assert "out of range" in result
+    def test_insert_out_of_range_raises(self, tool):
+        tool.create(_create("/memories/notes/ins3.md", "one"))
+        with pytest.raises(Exception, match="out of range"):
+            tool.insert(_insert("/memories/notes/ins3.md", 100, "nope"))
 
-    def test_insert_nonexistent_file(self, tool):
-        result = tool.insert(_insert("/memory/notes/nope.md", 0, "text"))
-        assert "Error" in result
+    def test_insert_nonexistent_file_raises(self, tool):
+        with pytest.raises(Exception, match="does not exist"):
+            tool.insert(_insert("/memories/notes/nope.md", 0, "text"))
 
 
 class TestDeleteCommand:
 
     def test_delete_file(self, tool):
-        tool.create(_create("/memory/notes/del.md", "to delete"))
-        result = tool.delete(_delete("/memory/notes/del.md"))
+        tool.create(_create("/memories/notes/del.md", "to delete"))
+        result = tool.delete(_delete("/memories/notes/del.md"))
         assert "deleted" in result
-        view = tool.view(_view("/memory/notes/del.md"))
-        assert "does not exist" in view
+        with pytest.raises(Exception, match="does not exist"):
+            tool.view(_view("/memories/notes/del.md"))
 
-    def test_delete_nonexistent(self, tool):
-        result = tool.delete(_delete("/memory/notes/nope.md"))
-        assert "Error" in result
-        assert "does not exist" in result
+    def test_delete_nonexistent_raises(self, tool):
+        with pytest.raises(Exception, match="does not exist"):
+            tool.delete(_delete("/memories/notes/nope.md"))
 
     def test_delete_directory(self, tool):
-        tool.create(_create("/memory/notes/sub/a.md", "aaa"))
-        tool.create(_create("/memory/notes/sub/b.md", "bbb"))
-        result = tool.delete(_delete("/memory/notes/sub"))
+        tool.create(_create("/memories/notes/sub/a.md", "aaa"))
+        tool.create(_create("/memories/notes/sub/b.md", "bbb"))
+        result = tool.delete(_delete("/memories/notes/sub"))
         assert "deleted" in result
         assert "2 file(s)" in result
 
     def test_delete_triggers_recall_retract(self, tool):
-        tool.create(_create("/memory/notes/ret.md", "retract me"))
-        tool.delete(_delete("/memory/notes/ret.md"))
+        tool.create(_create("/memories/notes/ret.md", "retract me"))
+        tool.delete(_delete("/memories/notes/ret.md"))
         tool._core._bridge.retract.assert_called()
 
 
 class TestRenameCommand:
 
     def test_rename_succeeds(self, tool):
-        tool.create(_create("/memory/notes/old.md", "content"))
-        result = tool.rename(_rename("/memory/notes/old.md", "/memory/notes/new.md"))
+        tool.create(_create("/memories/notes/old.md", "content"))
+        result = tool.rename(_rename("/memories/notes/old.md", "/memories/notes/new.md"))
         assert "Renamed" in result
-        view_old = tool.view(_view("/memory/notes/old.md"))
-        assert "does not exist" in view_old
-        view_new = tool.view(_view("/memory/notes/new.md"))
+        with pytest.raises(Exception, match="does not exist"):
+            tool.view(_view("/memories/notes/old.md"))
+        view_new = tool.view(_view("/memories/notes/new.md"))
         assert "content" in view_new
 
-    def test_rename_source_missing(self, tool):
-        result = tool.rename(_rename("/memory/notes/nope.md", "/memory/notes/new.md"))
-        assert "Error" in result
-        assert "does not exist" in result
+    def test_rename_source_missing_raises(self, tool):
+        with pytest.raises(Exception, match="does not exist"):
+            tool.rename(_rename("/memories/notes/nope.md", "/memories/notes/new.md"))
 
-    def test_rename_dest_exists(self, tool):
-        tool.create(_create("/memory/notes/a.md", "aaa"))
-        tool.create(_create("/memory/notes/b.md", "bbb"))
-        result = tool.rename(_rename("/memory/notes/a.md", "/memory/notes/b.md"))
-        assert "Error" in result
-        assert "already exists" in result
+    def test_rename_dest_exists_raises(self, tool):
+        tool.create(_create("/memories/notes/a.md", "aaa"))
+        tool.create(_create("/memories/notes/b.md", "bbb"))
+        with pytest.raises(Exception, match="already exists"):
+            tool.rename(_rename("/memories/notes/a.md", "/memories/notes/b.md"))
 
 
-class TestSearchAugmentation:
+class TestGetContext:
 
-    def test_view_includes_search_context(self, tool_with_search):
-        tool_with_search.create(_create("/memory/notes/deploy.md", "blue-green deploys"))
-        result = tool_with_search.view(_view("/memory/notes/deploy.md"))
-        assert "Related recall context" in result
+    def test_returns_search_results(self, tool):
+        tool._core._bridge.search.return_value = "deploy uses blue-green strategy"
+        result = tool.get_context("deployment")
         assert "blue-green" in result
 
-    def test_view_range_skips_search(self, tool_with_search):
-        tool_with_search.create(_create("/memory/notes/deploy2.md", "line1\nline2\nline3"))
-        result = tool_with_search.view(_view("/memory/notes/deploy2.md", view_range=[1, 2]))
-        assert "Related recall context" not in result
+    def test_returns_empty_on_no_results(self, tool):
+        tool._core._bridge.search.return_value = "No results found."
+        result = tool.get_context("nonexistent topic")
+        assert result == ""
+
+    def test_returns_empty_on_error(self, tool):
+        tool._core._bridge.search.side_effect = Exception("boom")
+        result = tool.get_context("anything")
+        assert result == ""
 
 
 class TestExecuteDispatch:
 
     def test_execute_routes_view(self, tool):
-        result = tool.execute(_view("/memory"))
+        result = tool.execute(_view("/memories"))
         assert "knowledge/" in result
 
     def test_execute_routes_create(self, tool):
-        result = tool.execute(_create("/memory/notes/exec.md", "via execute"))
+        result = tool.execute(_create("/memories/notes/exec.md", "via execute"))
         assert "created successfully" in result
 
 
 class TestClearAll:
 
     def test_clear_all_memory(self, tool):
-        tool.create(_create("/memory/notes/a.md", "aaa"))
-        tool.create(_create("/memory/notes/b.md", "bbb"))
+        tool.create(_create("/memories/notes/a.md", "aaa"))
+        tool.create(_create("/memories/notes/b.md", "bbb"))
         result = tool.clear_all_memory()
         assert "cleared" in result
-        view = tool.view(_view("/memory/notes/a.md"))
-        assert "does not exist" in view
+        with pytest.raises(Exception, match="does not exist"):
+            tool.view(_view("/memories/notes/a.md"))
 
 
 class TestPathNormalization:
 
     def test_relative_path_normalized(self, tool):
         tool.create(_create("knowledge/fact.md", "fact"))
-        result = tool.view(_view("/memory/knowledge/fact.md"))
+        result = tool.view(_view("/memories/knowledge/fact.md"))
         assert "fact" in result
 
     def test_bare_filename(self, tool):
         tool.create(_create("test.md", "bare"))
-        result = tool.view(_view("/memory/test.md"))
+        result = tool.view(_view("/memories/test.md"))
         assert "bare" in result
 
 

--- a/tests/integrations/test_anthropic_memory_tool.py
+++ b/tests/integrations/test_anthropic_memory_tool.py
@@ -1,0 +1,310 @@
+"""Tests for the Anthropic Memory Tool backend (SynaptMemoryTool)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from anthropic.types.beta import (
+    BetaMemoryTool20250818ViewCommand,
+    BetaMemoryTool20250818CreateCommand,
+    BetaMemoryTool20250818DeleteCommand,
+    BetaMemoryTool20250818InsertCommand,
+    BetaMemoryTool20250818RenameCommand,
+    BetaMemoryTool20250818StrReplaceCommand,
+)
+
+
+@pytest.fixture
+def tool():
+    with patch("synapt.integrations.anthropic._RecallBridge") as MockBridge:
+        bridge_instance = MockBridge.return_value
+        bridge_instance.save.return_value = "saved"
+        bridge_instance.retract.return_value = "retracted"
+        bridge_instance.search.return_value = "No results found."
+        bridge_instance.load_knowledge_files.return_value = None
+
+        from synapt.integrations.anthropic import SynaptMemoryTool
+        t = SynaptMemoryTool(search_augment=False)
+        t._core._bridge = bridge_instance
+        yield t
+
+
+@pytest.fixture
+def tool_with_search():
+    with patch("synapt.integrations.anthropic._RecallBridge") as MockBridge:
+        bridge_instance = MockBridge.return_value
+        bridge_instance.save.return_value = "saved"
+        bridge_instance.retract.return_value = "retracted"
+        bridge_instance.search.return_value = "Relevant context: deploy uses blue-green"
+        bridge_instance.load_knowledge_files.return_value = None
+
+        from synapt.integrations.anthropic import SynaptMemoryTool
+        t = SynaptMemoryTool(search_augment=True)
+        t._core._bridge = bridge_instance
+        yield t
+
+
+def _view(path, view_range=None):
+    return BetaMemoryTool20250818ViewCommand(command="view", path=path, view_range=view_range)
+
+
+def _create(path, file_text):
+    return BetaMemoryTool20250818CreateCommand(command="create", path=path, file_text=file_text)
+
+
+def _str_replace(path, old_str, new_str):
+    return BetaMemoryTool20250818StrReplaceCommand(
+        command="str_replace", path=path, old_str=old_str, new_str=new_str
+    )
+
+
+def _insert(path, insert_line, insert_text):
+    return BetaMemoryTool20250818InsertCommand(
+        command="insert", path=path, insert_line=insert_line, insert_text=insert_text
+    )
+
+
+def _delete(path):
+    return BetaMemoryTool20250818DeleteCommand(command="delete", path=path)
+
+
+def _rename(old_path, new_path):
+    return BetaMemoryTool20250818RenameCommand(command="rename", old_path=old_path, new_path=new_path)
+
+
+class TestViewCommand:
+
+    def test_view_root_lists_directories(self, tool):
+        result = tool.view(_view("/memory"))
+        assert "knowledge/" in result
+        assert "sessions/" in result
+        assert "notes/" in result
+
+    def test_view_empty_directory(self, tool):
+        result = tool.view(_view("/memory/knowledge"))
+        assert "empty directory" in result
+
+    def test_view_nonexistent_file(self, tool):
+        result = tool.view(_view("/memory/knowledge/nope.md"))
+        assert "Error" in result
+        assert "does not exist" in result
+
+    def test_view_file_with_line_numbers(self, tool):
+        tool.create(_create("/memory/notes/deploy.md", "line one\nline two\nline three"))
+        result = tool.view(_view("/memory/notes/deploy.md"))
+        assert "1\tline one" in result
+        assert "2\tline two" in result
+        assert "3\tline three" in result
+
+    def test_view_file_with_range(self, tool):
+        tool.create(_create("/memory/notes/multi.md", "a\nb\nc\nd\ne"))
+        result = tool.view(_view("/memory/notes/multi.md", view_range=[2, 4]))
+        assert "2\tb" in result
+        assert "3\tc" in result
+        assert "4\td" in result
+        assert "1\ta" not in result
+        assert "5\te" not in result
+
+    def test_view_directory_listing(self, tool):
+        tool.create(_create("/memory/notes/a.md", "aaa"))
+        tool.create(_create("/memory/notes/b.md", "bbb"))
+        result = tool.view(_view("/memory/notes"))
+        assert "a.md" in result
+        assert "b.md" in result
+
+
+class TestCreateCommand:
+
+    def test_create_new_file(self, tool):
+        result = tool.create(_create("/memory/notes/test.md", "hello world"))
+        assert "created successfully" in result
+
+    def test_create_duplicate_fails(self, tool):
+        tool.create(_create("/memory/notes/dup.md", "first"))
+        result = tool.create(_create("/memory/notes/dup.md", "second"))
+        assert "Error" in result
+        assert "already exists" in result
+
+    def test_create_triggers_recall_save(self, tool):
+        tool.create(_create("/memory/knowledge/fact.md", "Python 3.13 is latest"))
+        tool._core._bridge.save.assert_called()
+
+    def test_create_relative_path(self, tool):
+        result = tool.create(_create("notes/rel.md", "relative path"))
+        assert "created successfully" in result
+        view_result = tool.view(_view("/memory/notes/rel.md"))
+        assert "relative path" in view_result
+
+
+class TestStrReplaceCommand:
+
+    def test_replace_succeeds(self, tool):
+        tool.create(_create("/memory/notes/edit.md", "old text here"))
+        result = tool.str_replace(_str_replace("/memory/notes/edit.md", "old text", "new text"))
+        assert "edited successfully" in result
+        view = tool.view(_view("/memory/notes/edit.md"))
+        assert "new text" in view
+        assert "old text" not in view
+
+    def test_replace_not_found(self, tool):
+        tool.create(_create("/memory/notes/nf.md", "some content"))
+        result = tool.str_replace(_str_replace("/memory/notes/nf.md", "missing", "new"))
+        assert "Error" in result
+        assert "not found" in result
+
+    def test_replace_ambiguous(self, tool):
+        tool.create(_create("/memory/notes/amb.md", "aaa aaa"))
+        result = tool.str_replace(_str_replace("/memory/notes/amb.md", "aaa", "bbb"))
+        assert "Error" in result
+        assert "2 times" in result
+
+    def test_replace_nonexistent_file(self, tool):
+        result = tool.str_replace(_str_replace("/memory/notes/nope.md", "a", "b"))
+        assert "Error" in result
+        assert "does not exist" in result
+
+
+class TestInsertCommand:
+
+    def test_insert_at_beginning(self, tool):
+        tool.create(_create("/memory/notes/ins.md", "line 1\nline 2"))
+        result = tool.insert(_insert("/memory/notes/ins.md", 0, "new first"))
+        assert "edited successfully" in result
+        view = tool.view(_view("/memory/notes/ins.md"))
+        assert "1\tnew first" in view
+
+    def test_insert_at_end(self, tool):
+        tool.create(_create("/memory/notes/ins2.md", "line 1\nline 2"))
+        tool.insert(_insert("/memory/notes/ins2.md", 2, "line 3"))
+        view = tool.view(_view("/memory/notes/ins2.md"))
+        assert "3\tline 3" in view
+
+    def test_insert_out_of_range(self, tool):
+        tool.create(_create("/memory/notes/ins3.md", "one"))
+        result = tool.insert(_insert("/memory/notes/ins3.md", 100, "nope"))
+        assert "Error" in result
+        assert "out of range" in result
+
+    def test_insert_nonexistent_file(self, tool):
+        result = tool.insert(_insert("/memory/notes/nope.md", 0, "text"))
+        assert "Error" in result
+
+
+class TestDeleteCommand:
+
+    def test_delete_file(self, tool):
+        tool.create(_create("/memory/notes/del.md", "to delete"))
+        result = tool.delete(_delete("/memory/notes/del.md"))
+        assert "deleted" in result
+        view = tool.view(_view("/memory/notes/del.md"))
+        assert "does not exist" in view
+
+    def test_delete_nonexistent(self, tool):
+        result = tool.delete(_delete("/memory/notes/nope.md"))
+        assert "Error" in result
+        assert "does not exist" in result
+
+    def test_delete_directory(self, tool):
+        tool.create(_create("/memory/notes/sub/a.md", "aaa"))
+        tool.create(_create("/memory/notes/sub/b.md", "bbb"))
+        result = tool.delete(_delete("/memory/notes/sub"))
+        assert "deleted" in result
+        assert "2 file(s)" in result
+
+    def test_delete_triggers_recall_retract(self, tool):
+        tool.create(_create("/memory/notes/ret.md", "retract me"))
+        tool.delete(_delete("/memory/notes/ret.md"))
+        tool._core._bridge.retract.assert_called()
+
+
+class TestRenameCommand:
+
+    def test_rename_succeeds(self, tool):
+        tool.create(_create("/memory/notes/old.md", "content"))
+        result = tool.rename(_rename("/memory/notes/old.md", "/memory/notes/new.md"))
+        assert "Renamed" in result
+        view_old = tool.view(_view("/memory/notes/old.md"))
+        assert "does not exist" in view_old
+        view_new = tool.view(_view("/memory/notes/new.md"))
+        assert "content" in view_new
+
+    def test_rename_source_missing(self, tool):
+        result = tool.rename(_rename("/memory/notes/nope.md", "/memory/notes/new.md"))
+        assert "Error" in result
+        assert "does not exist" in result
+
+    def test_rename_dest_exists(self, tool):
+        tool.create(_create("/memory/notes/a.md", "aaa"))
+        tool.create(_create("/memory/notes/b.md", "bbb"))
+        result = tool.rename(_rename("/memory/notes/a.md", "/memory/notes/b.md"))
+        assert "Error" in result
+        assert "already exists" in result
+
+
+class TestSearchAugmentation:
+
+    def test_view_includes_search_context(self, tool_with_search):
+        tool_with_search.create(_create("/memory/notes/deploy.md", "blue-green deploys"))
+        result = tool_with_search.view(_view("/memory/notes/deploy.md"))
+        assert "Related recall context" in result
+        assert "blue-green" in result
+
+    def test_view_range_skips_search(self, tool_with_search):
+        tool_with_search.create(_create("/memory/notes/deploy2.md", "line1\nline2\nline3"))
+        result = tool_with_search.view(_view("/memory/notes/deploy2.md", view_range=[1, 2]))
+        assert "Related recall context" not in result
+
+
+class TestExecuteDispatch:
+
+    def test_execute_routes_view(self, tool):
+        result = tool.execute(_view("/memory"))
+        assert "knowledge/" in result
+
+    def test_execute_routes_create(self, tool):
+        result = tool.execute(_create("/memory/notes/exec.md", "via execute"))
+        assert "created successfully" in result
+
+
+class TestClearAll:
+
+    def test_clear_all_memory(self, tool):
+        tool.create(_create("/memory/notes/a.md", "aaa"))
+        tool.create(_create("/memory/notes/b.md", "bbb"))
+        result = tool.clear_all_memory()
+        assert "cleared" in result
+        view = tool.view(_view("/memory/notes/a.md"))
+        assert "does not exist" in view
+
+
+class TestPathNormalization:
+
+    def test_relative_path_normalized(self, tool):
+        tool.create(_create("knowledge/fact.md", "fact"))
+        result = tool.view(_view("/memory/knowledge/fact.md"))
+        assert "fact" in result
+
+    def test_bare_filename(self, tool):
+        tool.create(_create("test.md", "bare"))
+        result = tool.view(_view("/memory/test.md"))
+        assert "bare" in result
+
+
+class TestImportability:
+
+    def test_sync_importable(self):
+        from synapt.integrations.anthropic import SynaptMemoryTool
+        assert SynaptMemoryTool is not None
+
+    def test_async_importable(self):
+        from synapt.integrations.anthropic import SynaptAsyncMemoryTool
+        assert SynaptAsyncMemoryTool is not None
+
+    def test_to_dict(self, tool):
+        d = tool.to_dict()
+        assert d["type"] == "memory_20250818"
+        assert d["name"] == "memory"

--- a/tests/integrations/test_google_adk_memory_service.py
+++ b/tests/integrations/test_google_adk_memory_service.py
@@ -1,0 +1,203 @@
+"""Tests for the Google ADK memory service backend (SynaptMemoryService)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+import pytest_asyncio
+
+from google.genai import types
+from google.adk.memory.memory_entry import MemoryEntry
+
+
+def _make_event(event_id: str, text: str, author: str = "user"):
+    """Create a minimal Event-like object for testing."""
+    from google.adk.events.event import Event
+
+    return Event(
+        id=event_id,
+        author=author,
+        content=types.Content(
+            parts=[types.Part(text=text)],
+            role="user" if author == "user" else "model",
+        ),
+    )
+
+
+def _make_session(app_name: str, user_id: str, session_id: str, events=None):
+    """Create a minimal Session object for testing."""
+    from google.adk.sessions.session import Session
+
+    return Session(
+        id=session_id,
+        app_name=app_name,
+        user_id=user_id,
+        events=events or [],
+    )
+
+
+@pytest.fixture
+def service():
+    with patch("synapt.integrations.google_adk.SynaptMemoryService._save_to_recall") as mock_save:
+        from synapt.integrations.google_adk import SynaptMemoryService
+        svc = SynaptMemoryService(max_search_results=5)
+        svc._mock_save = mock_save
+        yield svc
+
+
+class TestAddSessionToMemory:
+
+    @pytest.mark.asyncio
+    async def test_ingests_events(self, service):
+        events = [
+            _make_event("e1", "hello world"),
+            _make_event("e2", "how are you", author="agent"),
+        ]
+        session = _make_session("myapp", "user1", "s1", events=events)
+        await service.add_session_to_memory(session)
+        assert service._mock_save.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_events(self, service):
+        events = [_make_event("e1", "hello")]
+        session = _make_session("myapp", "user1", "s1", events=events)
+        await service.add_session_to_memory(session)
+        await service.add_session_to_memory(session)
+        assert service._mock_save.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_events(self, service):
+        from google.adk.events.event import Event
+
+        empty = Event(id="e1", author="user", content=None)
+        session = _make_session("myapp", "user1", "s1", events=[empty])
+        await service.add_session_to_memory(session)
+        assert service._mock_save.call_count == 0
+
+
+class TestAddEventsToMemory:
+
+    @pytest.mark.asyncio
+    async def test_incremental_events(self, service):
+        events = [_make_event("e1", "incremental event")]
+        await service.add_events_to_memory(
+            app_name="myapp",
+            user_id="user1",
+            events=events,
+        )
+        assert service._mock_save.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dedup_across_methods(self, service):
+        events = [_make_event("e1", "hello")]
+        session = _make_session("myapp", "user1", "s1", events=events)
+        await service.add_session_to_memory(session)
+        await service.add_events_to_memory(
+            app_name="myapp",
+            user_id="user1",
+            events=events,
+        )
+        assert service._mock_save.call_count == 1
+
+
+class TestAddMemory:
+
+    @pytest.mark.asyncio
+    async def test_direct_memory_write(self, service):
+        entry = MemoryEntry(
+            content=types.Content(
+                parts=[types.Part(text="important fact")],
+                role="model",
+            ),
+            author="agent",
+        )
+        await service.add_memory(
+            app_name="myapp",
+            user_id="user1",
+            memories=[entry],
+        )
+        assert service._mock_save.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_memory(self, service):
+        entry = MemoryEntry(
+            content=types.Content(parts=[], role="model"),
+        )
+        await service.add_memory(
+            app_name="myapp",
+            user_id="user1",
+            memories=[entry],
+        )
+        assert service._mock_save.call_count == 0
+
+
+class TestSearchMemory:
+
+    @pytest.mark.asyncio
+    async def test_search_returns_entries(self, service):
+        with patch("synapt.recall.server.recall_search", return_value="chunk one\n\nchunk two"):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="hello",
+            )
+        assert len(result.memories) == 2
+        assert result.memories[0].content.parts[0].text == "chunk one"
+
+    @pytest.mark.asyncio
+    async def test_search_empty_results(self, service):
+        with patch("synapt.recall.server.recall_search", return_value="No results found."):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="nonexistent",
+            )
+        assert len(result.memories) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_handles_error(self, service):
+        with patch("synapt.recall.server.recall_search", side_effect=Exception("boom")):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="hello",
+            )
+        assert len(result.memories) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_respects_max_results(self, service):
+        chunks = "\n\n".join(f"chunk {i}" for i in range(20))
+        with patch("synapt.recall.server.recall_search", return_value=chunks):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="lots",
+            )
+        assert len(result.memories) <= 5
+
+
+class TestSearchMemoryResponse:
+
+    @pytest.mark.asyncio
+    async def test_entries_have_correct_fields(self, service):
+        with patch("synapt.recall.server.recall_search", return_value="some context"):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="test",
+            )
+        entry = result.memories[0]
+        assert entry.author == "recall"
+        assert entry.timestamp is not None
+        assert entry.content.role == "model"
+
+
+class TestImportability:
+
+    def test_importable(self):
+        from synapt.integrations.google_adk import SynaptMemoryService
+        assert SynaptMemoryService is not None

--- a/tests/integrations/test_openai_agents_adapter.py
+++ b/tests/integrations/test_openai_agents_adapter.py
@@ -73,6 +73,11 @@ class TestSessionProtocolContract:
         assert retrieved[1]["content"] == "b"
 
     @pytest.mark.asyncio
+    async def test_add_empty_items_noop(self, session):
+        await session.add_items([])
+        assert await session.get_items() == []
+
+    @pytest.mark.asyncio
     async def test_pop_item(self, session):
         await session.add_items([
             {"role": "user", "content": "first"},
@@ -141,6 +146,56 @@ class TestSessionIsolation:
         assert "test-session-2" in ids
 
 
+class TestSessionSettings:
+
+    @pytest.mark.asyncio
+    async def test_default_limit_from_settings(self, tmp_path):
+        from agents.memory.session_settings import SessionSettings
+        from synapt.integrations.openai_agents import SynaptSession
+
+        settings = SessionSettings(limit=2)
+        s = SynaptSession(
+            session_id="settings-test",
+            db_path=tmp_path / "test.db",
+            session_settings=settings,
+        )
+        try:
+            await s.add_items([
+                {"role": "user", "content": "a"},
+                {"role": "user", "content": "b"},
+                {"role": "user", "content": "c"},
+            ])
+            items = await s.get_items()
+            assert len(items) == 2
+            assert items[0]["content"] == "b"
+            assert items[1]["content"] == "c"
+        finally:
+            s.close()
+
+    @pytest.mark.asyncio
+    async def test_explicit_limit_overrides_settings(self, tmp_path):
+        from agents.memory.session_settings import SessionSettings
+        from synapt.integrations.openai_agents import SynaptSession
+
+        settings = SessionSettings(limit=2)
+        s = SynaptSession(
+            session_id="override-test",
+            db_path=tmp_path / "test.db",
+            session_settings=settings,
+        )
+        try:
+            await s.add_items([
+                {"role": "user", "content": "a"},
+                {"role": "user", "content": "b"},
+                {"role": "user", "content": "c"},
+            ])
+            items = await s.get_items(limit=1)
+            assert len(items) == 1
+            assert items[0]["content"] == "c"
+        finally:
+            s.close()
+
+
 class TestEdgeCases:
 
     @pytest.mark.asyncio
@@ -184,3 +239,17 @@ class TestRecallIntegration:
 
     def test_save_to_recall_method_exists(self, session):
         assert callable(session.save_to_recall)
+
+    def test_get_memory_context_method_exists(self, session):
+        assert callable(session.get_memory_context)
+
+    def test_get_memory_context_returns_string(self, session):
+        result = session.get_memory_context("test query")
+        assert isinstance(result, str)
+
+
+class TestThreadSafety:
+
+    def test_close_idempotent(self, session):
+        session.close()
+        session.close()


### PR DESCRIPTION
## Summary

- **Anthropic Memory Tool (recall#758):** `SynaptMemoryTool` is a drop-in replacement for `BetaAbstractMemoryTool`. Routes all 6 memory operations (view, create, str_replace, insert, delete, rename) through a virtual filesystem facade backed by recall's hybrid search and knowledge persistence. Uses `/memories` root path matching the Anthropic contract. Errors raise exceptions for proper `is_error=True` handling. Separate `get_context()` method for recall augmentation (not mixed into view responses).

- **Google ADK Memory Service (recall#760):** `SynaptMemoryService` subclasses `BaseMemoryService`. Implements `add_session_to_memory`, `add_events_to_memory`, `add_memory`, and `search_memory` with event deduplication and recall-powered hybrid retrieval.

- **OpenAI Agents SDK Session (recall#759):** Upgrades existing `SynaptSession` to align with SDK v0.14.5: `SessionSettings`/`resolve_session_limit` support, `asyncio.to_thread` for non-blocking DB ops, thread-safe locking, and new `get_memory_context()` for recall-augmented agent prompts. Positioned as a session persistence adapter (OpenAI SDK has no native MemoryService interface).

- **Packaging:** `pip install synapt[anthropic]`, `synapt[openai]`, `synapt[google-adk]`, `synapt[all-integrations]` extras. README with before/after examples and badges for all backends.

All three backends are integration adapters (adoption surface). 100 tests pass, 0 regressions.

Closes #758
Closes #759
Closes #760

Premium boundary: core OSS (integration adapters for platform SDK adoption).

## Test plan

- [x] 37 tests for Anthropic Memory Tool (all 6 commands, path normalization, error handling, get_context)
- [x] 13 tests for Google ADK Memory Service (session ingestion, event dedup, direct memory writes, search, error handling)
- [x] 26 tests for OpenAI Agents Session (protocol contract, session isolation, SessionSettings, edge cases, recall integration)
- [x] Full integration suite: 100 passed, 2 skipped (crewai), 0 failures
- [ ] Manual test: Anthropic Memory Tool with `client.beta.messages.run_tools`
- [ ] Manual test: Google ADK `LlmAgent` with `SynaptMemoryService`