### PR TITLE
test: add red specs for platform memory backends

### DIFF
--- a/tests/integrations/test_anthropic_memory_backend.py
+++ b/tests/integrations/test_anthropic_memory_backend.py
@@ -1,0 +1,240 @@
+"""Red specs for the Anthropic memory backend."""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+from anthropic.lib.tools._beta_builtin_memory_tool import BetaAbstractMemoryTool
+from anthropic.types.beta import (
+    BetaMemoryTool20250818CreateCommand,
+    BetaMemoryTool20250818DeleteCommand,
+    BetaMemoryTool20250818InsertCommand,
+    BetaMemoryTool20250818RenameCommand,
+    BetaMemoryTool20250818StrReplaceCommand,
+    BetaMemoryTool20250818ViewCommand,
+)
+
+
+def _load_synapt_memory_tool():
+    try:
+        module = importlib.import_module("synapt.integrations.anthropic")
+    except ModuleNotFoundError as exc:
+        pytest.fail(
+            "Expected backend module `synapt.integrations.anthropic` with "
+            "`SynaptMemoryTool`, but it does not exist yet."
+        )
+    except Exception as exc:  # pragma: no cover - exercised once backend exists
+        pytest.fail(f"Importing `synapt.integrations.anthropic` failed: {exc!r}")
+
+    try:
+        return module.SynaptMemoryTool
+    except AttributeError:
+        pytest.fail(
+            "Expected `synapt.integrations.anthropic.SynaptMemoryTool`, "
+            "but the symbol is missing."
+        )
+
+
+def _new_tool(project_root: Path):
+    cls = _load_synapt_memory_tool()
+    try:
+        return cls(project_root=project_root)
+    except TypeError as exc:
+        pytest.fail(
+            "SynaptMemoryTool should be constructible as "
+            "`SynaptMemoryTool(project_root=Path(...))`."
+        )
+
+
+def _assert_line_numbered_view(result: str, expected: list[tuple[int, str]]) -> None:
+    for line_no, text in expected:
+        pattern = rf"(?m)^\s*{line_no}(?:\t|:)\s*{re.escape(text)}$"
+        assert re.search(pattern, result), result
+
+
+def test_synapt_memory_tool_matches_anthropic_memory_tool_contract(tmp_path: Path) -> None:
+    tool = _new_tool(tmp_path)
+
+    assert isinstance(tool, BetaAbstractMemoryTool)
+    assert tool.to_dict() == {"type": "memory_20250818", "name": "memory"}
+
+
+def test_create_and_view_expose_a_virtual_memories_filesystem(tmp_path: Path) -> None:
+    tool = _new_tool(tmp_path)
+
+    create_result = tool.execute(
+        BetaMemoryTool20250818CreateCommand(
+            command="create",
+            path="/memories/progress/todo.txt",
+            file_text="first line\nsecond line\n",
+        )
+    )
+    assert create_result == "File created successfully at: /memories/progress/todo.txt"
+
+    directory_result = tool.execute(
+        BetaMemoryTool20250818ViewCommand(command="view", path="/memories")
+    )
+    assert "/memories/progress/todo.txt" in directory_result
+    assert "/memories" in directory_result
+
+    file_result = tool.execute(
+        BetaMemoryTool20250818ViewCommand(
+            command="view",
+            path="/memories/progress/todo.txt",
+        )
+    )
+    assert "Here's the content of /memories/progress/todo.txt" in file_result
+    _assert_line_numbered_view(
+        file_result,
+        [(1, "first line"), (2, "second line")],
+    )
+
+    range_result = tool.execute(
+        BetaMemoryTool20250818ViewCommand(
+            command="view",
+            path="/memories/progress/todo.txt",
+            view_range=[2, -1],
+        )
+    )
+    assert "Here's the content of /memories/progress/todo.txt" in range_result
+    assert not re.search(r"(?m)^\s*1(?:\t|:)", range_result), range_result
+    _assert_line_numbered_view(range_result, [(2, "second line")])
+
+
+def test_str_replace_matches_filesystem_tool_style_and_returns_numbered_snippet(
+    tmp_path: Path,
+) -> None:
+    tool = _new_tool(tmp_path)
+    tool.execute(
+        BetaMemoryTool20250818CreateCommand(
+            command="create",
+            path="/memories/preferences.txt",
+            file_text="favorite drink: tea\nfavorite snack: pears\n",
+        )
+    )
+
+    result = tool.execute(
+        BetaMemoryTool20250818StrReplaceCommand(
+            command="str_replace",
+            path="/memories/preferences.txt",
+            old_str="favorite drink: tea",
+            new_str="favorite drink: coffee",
+        )
+    )
+
+    assert "The memory file has been edited." in result
+    _assert_line_numbered_view(result, [(1, "favorite drink: coffee")])
+
+
+def test_insert_matches_filesystem_tool_success_message(tmp_path: Path) -> None:
+    tool = _new_tool(tmp_path)
+    tool.execute(
+        BetaMemoryTool20250818CreateCommand(
+            command="create",
+            path="/memories/todo.txt",
+            file_text="- first\n- third\n",
+        )
+    )
+
+    result = tool.execute(
+        BetaMemoryTool20250818InsertCommand(
+            command="insert",
+            path="/memories/todo.txt",
+            insert_line=1,
+            insert_text="- second\n",
+        )
+    )
+
+    assert result == "The file /memories/todo.txt has been edited."
+    file_result = tool.execute(
+        BetaMemoryTool20250818ViewCommand(command="view", path="/memories/todo.txt")
+    )
+    _assert_line_numbered_view(
+        file_result,
+        [(1, "- first"), (2, "- second"), (3, "- third")],
+    )
+
+
+def test_delete_and_rename_match_documented_success_messages(tmp_path: Path) -> None:
+    tool = _new_tool(tmp_path)
+    tool.execute(
+        BetaMemoryTool20250818CreateCommand(
+            command="create",
+            path="/memories/draft.txt",
+            file_text="draft\n",
+        )
+    )
+
+    rename_result = tool.execute(
+        BetaMemoryTool20250818RenameCommand(
+            command="rename",
+            old_path="/memories/draft.txt",
+            new_path="/memories/final.txt",
+        )
+    )
+    assert rename_result == (
+        "Successfully renamed /memories/draft.txt to /memories/final.txt"
+    )
+
+    delete_result = tool.execute(
+        BetaMemoryTool20250818DeleteCommand(
+            command="delete",
+            path="/memories/final.txt",
+        )
+    )
+    assert delete_result == "Successfully deleted /memories/final.txt"
+
+
+def test_path_traversal_is_rejected_by_the_virtual_facade(tmp_path: Path) -> None:
+    tool = _new_tool(tmp_path)
+
+    result = tool.execute(
+        BetaMemoryTool20250818ViewCommand(
+            command="view",
+            path="/memories/../../outside.txt",
+        )
+    )
+
+    assert "error" in result.lower()
+    assert "outside.txt" in result
+    assert not (tmp_path.parent / "outside.txt").exists()
+
+
+def test_write_operations_schedule_async_enrichment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _new_tool(tmp_path)
+    scheduled: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_schedule(*args: object, **kwargs: object) -> None:
+        scheduled.append((args, kwargs))
+
+    monkeypatch.setattr(tool, "_schedule_enrichment", fake_schedule, raising=False)
+
+    tool.execute(
+        BetaMemoryTool20250818CreateCommand(
+            command="create",
+            path="/memories/notes.txt",
+            file_text="alpha\nbeta\n",
+        )
+    )
+    tool.execute(
+        BetaMemoryTool20250818StrReplaceCommand(
+            command="str_replace",
+            path="/memories/notes.txt",
+            old_str="beta",
+            new_str="gamma",
+        )
+    )
+    tool.execute(
+        BetaMemoryTool20250818InsertCommand(
+            command="insert",
+            path="/memories/notes.txt",
+            insert_line=2,
+            insert_text="delta\n",
+        )
+    )
+
+    assert len(scheduled) == 3
+    assert all("/memories/notes.txt" in repr(call) for call in scheduled)

--- a/tests/integrations/test_google_adk_memory_backend.py
+++ b/tests/integrations/test_google_adk_memory_backend.py
@@ -1,0 +1,127 @@
+"""Red specs for the Google ADK memory backend."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+
+import pytest
+from google.adk.events import Event
+from google.adk.memory.base_memory_service import BaseMemoryService, SearchMemoryResponse
+from google.adk.sessions import Session
+from google.genai import types
+
+
+def _load_synapt_memory_service():
+    try:
+        module = importlib.import_module("synapt.integrations.google_adk")
+    except ModuleNotFoundError:
+        pytest.fail(
+            "Expected backend module `synapt.integrations.google_adk` with "
+            "`SynaptMemoryService`, but it does not exist yet."
+        )
+    except Exception as exc:  # pragma: no cover - exercised once backend exists
+        pytest.fail(f"Importing `synapt.integrations.google_adk` failed: {exc!r}")
+
+    try:
+        return module.SynaptMemoryService
+    except AttributeError:
+        pytest.fail(
+            "Expected `synapt.integrations.google_adk.SynaptMemoryService`, "
+            "but the symbol is missing."
+        )
+
+
+def _new_memory_service(tmp_path: Path):
+    cls = _load_synapt_memory_service()
+    try:
+        return cls(project_root=tmp_path)
+    except TypeError:
+        pytest.fail(
+            "SynaptMemoryService should be constructible as "
+            "`SynaptMemoryService(project_root=Path(...))`."
+        )
+
+
+def _event(text: str, *, invocation_id: str) -> Event:
+    return Event(
+        author="user",
+        invocation_id=invocation_id,
+        content=types.Content(parts=[types.Part(text=text)], role="user"),
+    )
+
+
+def test_synapt_memory_service_satisfies_the_adk_memory_interface(tmp_path: Path) -> None:
+    service = _new_memory_service(tmp_path)
+
+    assert isinstance(service, BaseMemoryService)
+
+
+def test_add_session_to_memory_and_search_memory_round_trip(tmp_path: Path) -> None:
+    service = _new_memory_service(tmp_path)
+    session = Session(
+        id="sess-1",
+        app_name="synapt-app",
+        user_id="user-1",
+        events=[_event("prefers pour-over coffee", invocation_id="inv-1")],
+    )
+
+    asyncio.run(service.add_session_to_memory(session))
+    result = asyncio.run(
+        service.search_memory(
+            app_name="synapt-app",
+            user_id="user-1",
+            query="coffee",
+        )
+    )
+
+    assert isinstance(result, SearchMemoryResponse)
+    assert len(result.memories) == 1
+    assert result.memories[0].content.parts[0].text == "prefers pour-over coffee"
+
+
+def test_add_events_to_memory_supports_incremental_updates(tmp_path: Path) -> None:
+    service = _new_memory_service(tmp_path)
+
+    asyncio.run(
+        service.add_events_to_memory(
+            app_name="synapt-app",
+            user_id="user-1",
+            session_id="sess-2",
+            events=[_event("likes Ethiopian beans", invocation_id="inv-2")],
+        )
+    )
+
+    result = asyncio.run(
+        service.search_memory(
+            app_name="synapt-app",
+            user_id="user-1",
+            query="Ethiopian",
+        )
+    )
+
+    assert len(result.memories) == 1
+    assert result.memories[0].content.parts[0].text == "likes Ethiopian beans"
+
+
+def test_memory_search_is_scoped_by_app_and_user(tmp_path: Path) -> None:
+    service = _new_memory_service(tmp_path)
+    session = Session(
+        id="sess-3",
+        app_name="synapt-app",
+        user_id="user-1",
+        events=[_event("favorite IDE theme is light", invocation_id="inv-3")],
+    )
+
+    asyncio.run(service.add_session_to_memory(session))
+
+    miss = asyncio.run(
+        service.search_memory(
+            app_name="synapt-app",
+            user_id="user-2",
+            query="theme",
+        )
+    )
+
+    assert miss.memories == []

--- a/tests/integrations/test_openai_agents_memory_backend.py
+++ b/tests/integrations/test_openai_agents_memory_backend.py
@@ -1,0 +1,124 @@
+"""Red specs for the OpenAI Agents session backend."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+
+import pytest
+from agents.memory.session import Session
+from agents.memory.session_settings import SessionSettings
+
+
+def _load_synapt_session():
+    try:
+        module = importlib.import_module("synapt.integrations.openai_agents")
+    except ModuleNotFoundError:
+        pytest.fail(
+            "Expected backend module `synapt.integrations.openai_agents` with "
+            "`SynaptSession`, but it does not exist yet."
+        )
+    except Exception as exc:  # pragma: no cover - exercised once backend exists
+        pytest.fail(f"Importing `synapt.integrations.openai_agents` failed: {exc!r}")
+
+    try:
+        return module.SynaptSession
+    except AttributeError:
+        pytest.fail(
+            "Expected `synapt.integrations.openai_agents.SynaptSession`, "
+            "but the symbol is missing."
+        )
+
+
+def _new_session(
+    tmp_path: Path,
+    session_id: str = "session-1",
+    *,
+    session_settings: SessionSettings | None = None,
+):
+    cls = _load_synapt_session()
+    try:
+        return cls(
+            session_id=session_id,
+            db_path=tmp_path / "synapt-openai-session.db",
+            session_settings=session_settings,
+        )
+    except TypeError:
+        pytest.fail(
+            "SynaptSession should accept the SQLiteSession-style constructor "
+            "`(session_id, db_path=..., session_settings=...)`."
+        )
+
+
+def test_synapt_session_satisfies_the_openai_session_protocol(tmp_path: Path) -> None:
+    session = _new_session(tmp_path)
+
+    assert isinstance(session, Session)
+    assert session.session_id == "session-1"
+
+
+def test_synapt_session_round_trips_items_in_chronological_order(tmp_path: Path) -> None:
+    session = _new_session(tmp_path)
+    items = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+    ]
+
+    asyncio.run(session.add_items(items))
+    stored = asyncio.run(session.get_items())
+
+    assert stored == items
+
+
+def test_synapt_session_honors_explicit_and_default_limits(tmp_path: Path) -> None:
+    session = _new_session(
+        tmp_path,
+        session_settings=SessionSettings(limit=2),
+    )
+    items = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+    ]
+
+    asyncio.run(session.add_items(items))
+
+    assert asyncio.run(session.get_items()) == items[-2:]
+    assert asyncio.run(session.get_items(limit=1)) == items[-1:]
+
+
+def test_synapt_session_pop_item_matches_sqlite_session_lifo_behavior(tmp_path: Path) -> None:
+    session = _new_session(tmp_path)
+    items = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+    ]
+
+    asyncio.run(session.add_items(items))
+
+    popped = asyncio.run(session.pop_item())
+    remaining = asyncio.run(session.get_items())
+
+    assert popped == items[-1]
+    assert remaining == items[:-1]
+
+
+def test_synapt_session_clear_session_removes_all_history(tmp_path: Path) -> None:
+    session = _new_session(tmp_path)
+    asyncio.run(session.add_items([{"role": "user", "content": "ephemeral"}]))
+
+    asyncio.run(session.clear_session())
+
+    assert asyncio.run(session.get_items()) == []
+    assert asyncio.run(session.pop_item()) is None
+
+
+def test_synapt_session_persists_across_instances_like_sqlite_session(tmp_path: Path) -> None:
+    first = _new_session(tmp_path, session_id="shared")
+    asyncio.run(first.add_items([{"role": "user", "content": "persist me"}]))
+
+    second = _new_session(tmp_path, session_id="shared")
+    restored = asyncio.run(second.get_items())
+
+    assert restored == [{"role": "user", "content": "persist me"}]


### PR DESCRIPTION
## Summary
- add Anthropic red specs for the memory backend contract, facade behavior, and write-enrichment scheduling
- add OpenAI Agents SDK session parity specs against the current Session/SQLiteSession interface
- add Google ADK memory service parity specs for session ingest, delta ingest, search, and scope isolation

## Verification
- PYTHONPATH=synapt/src pytest -q tests/integrations/test_anthropic_memory_backend.py
- PYTHONPATH=synapt/src pytest -q tests/integrations/test_openai_agents_memory_backend.py
- PYTHONPATH=synapt/src pytest -q tests/integrations/test_google_adk_memory_backend.py

These are expected red specs against the current checkout: the failures are at the missing `synapt.integrations` backend boundary.