### PR TITLE
feat: make anthropic and openai-agents core deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "mcp[cli]>=1.0",
     "sentence-transformers>=2.0",
     "mlx-lm>=0.10; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "anthropic>=0.70",
+    "openai-agents>=0.10",
 ]
 authors = [
     {name = "Layne Penney"},
@@ -43,6 +45,7 @@ onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
 crewai = ["crewai>=1.4.0"]
+google-adk = ["google-adk>=1.0"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4"]
 dev = ["watchfiles>=0.20"]
 test = [

--- a/src/synapt/integrations/openai_agents.py
+++ b/src/synapt/integrations/openai_agents.py
@@ -23,10 +23,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-try:  # pragma: no cover - optional dependency surface
-    from agents.memory.session import SessionABC
-except ImportError:  # pragma: no cover
-    SessionABC = object  # type: ignore[assignment,misc]
+from agents.memory.session import SessionABC
 
 _DEFAULT_DB_DIR = Path.home() / ".synapt" / "integrations"
 


### PR DESCRIPTION
## Summary
- Moves `anthropic>=0.70` and `openai-agents>=0.10` from optional extras to core dependencies
- Adds `google-adk>=1.0` as optional extra (`pip install synapt[google-adk]`)
- Removes try/except import guard on `SessionABC` since `openai-agents` is now always installed

## Why
These are distribution channels, not optional features. When a user runs `pip install synapt`, they should get enriched memory for Claude Code and OpenAI agents out of the box. The extras friction (`pip install synapt[anthropic]`) is a barrier to the zero-config swap we're positioning: `SynaptMemoryTool` as a drop-in replacement for Claude Code's built-in memory.

Google ADK stays optional because it's heavier and less established.

## Premium boundary
Core OSS (packaging configuration). No premium logic.

## Test plan
- [x] `pip install -e ".[dev]"` succeeds
- [x] `from agents.memory.session import SessionABC` imports without error
- [ ] `from anthropic import Anthropic` imports without error
- [ ] Verify no regressions in existing tests