### PR TITLE
fix: scope google adk memory search

### DIFF
--- a/src/synapt/integrations/google_adk.py
+++ b/src/synapt/integrations/google_adk.py
@@ -21,10 +21,13 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 import threading
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
+
+from synapt.recall.core import project_index_dir
+from synapt.recall.storage import RecallDB
 
 try:
     from google.adk.memory.base_memory_service import (
@@ -68,6 +71,10 @@ def _session_key(app_name: str, user_id: str) -> str:
 def _node_id(app_name: str, user_id: str, content_hash: str) -> str:
     raw = f"{app_name}/{user_id}/{content_hash}"
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def _words(text: str) -> set[str]:
+    return {word.lower() for word in re.findall(r"[A-Za-z0-9_]+", text)}
 
 
 if BaseMemoryService is not None:
@@ -173,34 +180,17 @@ if BaseMemoryService is not None:
             query: str,
         ) -> SearchMemoryResponse:
             try:
-                from synapt.recall.server import recall_search
-
-                result_text = recall_search(
+                entries = self._search_scoped_recall(
+                    app_name=app_name,
+                    user_id=user_id,
                     query=query,
-                    max_chunks=self._max_results,
-                    max_tokens=2000,
                 )
             except Exception as e:
                 log.warning("Recall search failed: %s", e)
                 return SearchMemoryResponse()
 
-            if not result_text or "No results" in result_text:
+            if not entries:
                 return SearchMemoryResponse()
-
-            entries = []
-            for chunk in result_text.split("\n\n"):
-                chunk = chunk.strip()
-                if not chunk or chunk.startswith("---"):
-                    continue
-                entry = MemoryEntry(
-                    content=types.Content(
-                        parts=[types.Part(text=chunk)],
-                        role="model",
-                    ),
-                    author="recall",
-                    timestamp=datetime.now(timezone.utc).isoformat(),
-                )
-                entries.append(entry)
 
             return SearchMemoryResponse(memories=entries[:self._max_results])
 
@@ -220,11 +210,75 @@ if BaseMemoryService is not None:
                     content=text,
                     category="conversation",
                     confidence=0.8,
-                    tags=["google-adk", app_name, author],
+                    tags=[
+                        "google-adk",
+                        f"app:{app_name}",
+                        f"user:{user_id}",
+                        f"author:{author}",
+                    ],
                     node_id=_node_id(app_name, user_id, content_hash),
                 )
             except Exception as e:
                 log.warning("Recall save failed: %s", e)
+
+        def _search_scoped_recall(
+            self,
+            *,
+            app_name: str,
+            user_id: str,
+            query: str,
+        ) -> list[MemoryEntry]:
+            query_words = _words(query)
+            if not query_words:
+                return []
+
+            app_tag = f"app:{app_name}"
+            user_tag = f"user:{user_id}"
+            db = RecallDB(project_index_dir() / "recall.db")
+            try:
+                nodes = db.load_knowledge_nodes(status="active")
+            finally:
+                db.close()
+
+            scored: list[tuple[float, dict[str, Any]]] = []
+            for node in nodes:
+                tags = set(node.get("tags", []))
+                if "google-adk" not in tags or app_tag not in tags or user_tag not in tags:
+                    continue
+                content = node.get("content", "")
+                content_words = _words(content)
+                if not content_words:
+                    continue
+
+                overlap = len(query_words & content_words)
+                if overlap == 0:
+                    continue
+
+                score = float(overlap)
+                if query.lower() in content.lower():
+                    score += 0.5
+                scored.append((score, node))
+
+            scored.sort(key=lambda item: item[0], reverse=True)
+            entries: list[MemoryEntry] = []
+            for _, node in scored[: self._max_results]:
+                tags = node.get("tags", [])
+                author = "recall"
+                for tag in tags:
+                    if tag.startswith("author:"):
+                        author = tag.split(":", 1)[1] or "recall"
+                        break
+                entries.append(
+                    MemoryEntry(
+                        content=types.Content(
+                            parts=[types.Part(text=node.get("content", ""))],
+                            role="model",
+                        ),
+                        author=author,
+                        timestamp=node.get("updated_at") or node.get("created_at"),
+                    )
+                )
+            return entries
 
 else:
 

--- a/tests/integrations/test_google_adk_memory_service.py
+++ b/tests/integrations/test_google_adk_memory_service.py
@@ -8,8 +8,6 @@ import pytest
 
 pytest.importorskip("google.adk")
 
-import pytest_asyncio
-
 from google.genai import types
 from google.adk.memory.memory_entry import MemoryEntry
 
@@ -139,18 +137,38 @@ class TestSearchMemory:
 
     @pytest.mark.asyncio
     async def test_search_returns_entries(self, service):
-        with patch("synapt.recall.server.recall_search", return_value="chunk one\n\nchunk two"):
+        fake_nodes = [
+            {
+                "content": "chunk one",
+                "tags": ["google-adk", "app:myapp", "user:user1", "author:recall"],
+                "updated_at": "2026-04-24T00:00:00Z",
+                "created_at": "2026-04-24T00:00:00Z",
+            },
+            {
+                "content": "chunk two",
+                "tags": ["google-adk", "app:myapp", "user:user1", "author:recall"],
+                "updated_at": "2026-04-24T00:00:01Z",
+                "created_at": "2026-04-24T00:00:01Z",
+            },
+        ]
+        mock_db = MagicMock()
+        mock_db.load_knowledge_nodes.return_value = fake_nodes
+        with patch("synapt.integrations.google_adk.RecallDB", return_value=mock_db), \
+             patch("synapt.integrations.google_adk.project_index_dir", return_value=MagicMock()):
             result = await service.search_memory(
                 app_name="myapp",
                 user_id="user1",
-                query="hello",
+                query="chunk",
             )
         assert len(result.memories) == 2
         assert result.memories[0].content.parts[0].text == "chunk one"
 
     @pytest.mark.asyncio
     async def test_search_empty_results(self, service):
-        with patch("synapt.recall.server.recall_search", return_value="No results found."):
+        mock_db = MagicMock()
+        mock_db.load_knowledge_nodes.return_value = []
+        with patch("synapt.integrations.google_adk.RecallDB", return_value=mock_db), \
+             patch("synapt.integrations.google_adk.project_index_dir", return_value=MagicMock()):
             result = await service.search_memory(
                 app_name="myapp",
                 user_id="user1",
@@ -160,7 +178,7 @@ class TestSearchMemory:
 
     @pytest.mark.asyncio
     async def test_search_handles_error(self, service):
-        with patch("synapt.recall.server.recall_search", side_effect=Exception("boom")):
+        with patch("synapt.integrations.google_adk.RecallDB", side_effect=Exception("boom")):
             result = await service.search_memory(
                 app_name="myapp",
                 user_id="user1",
@@ -170,8 +188,19 @@ class TestSearchMemory:
 
     @pytest.mark.asyncio
     async def test_search_respects_max_results(self, service):
-        chunks = "\n\n".join(f"chunk {i}" for i in range(20))
-        with patch("synapt.recall.server.recall_search", return_value=chunks):
+        fake_nodes = [
+            {
+                "content": f"lots chunk {i}",
+                "tags": ["google-adk", "app:myapp", "user:user1", "author:recall"],
+                "updated_at": f"2026-04-24T00:00:{i:02d}Z",
+                "created_at": f"2026-04-24T00:00:{i:02d}Z",
+            }
+            for i in range(20)
+        ]
+        mock_db = MagicMock()
+        mock_db.load_knowledge_nodes.return_value = fake_nodes
+        with patch("synapt.integrations.google_adk.RecallDB", return_value=mock_db), \
+             patch("synapt.integrations.google_adk.project_index_dir", return_value=MagicMock()):
             result = await service.search_memory(
                 app_name="myapp",
                 user_id="user1",
@@ -179,21 +208,109 @@ class TestSearchMemory:
             )
         assert len(result.memories) <= 5
 
+    @pytest.mark.asyncio
+    async def test_search_scopes_by_app_and_user(self, service):
+        fake_nodes = [
+            {
+                "content": "deployment strategy is blue green",
+                "tags": ["google-adk", "app:myapp", "user:user1", "author:atlas"],
+                "updated_at": "2026-04-24T00:00:00Z",
+                "created_at": "2026-04-24T00:00:00Z",
+            },
+            {
+                "content": "deployment strategy is canary",
+                "tags": ["google-adk", "app:otherapp", "user:user1", "author:apollo"],
+                "updated_at": "2026-04-24T00:00:01Z",
+                "created_at": "2026-04-24T00:00:01Z",
+            },
+            {
+                "content": "deployment strategy is rolling",
+                "tags": ["google-adk", "app:myapp", "user:user2", "author:sentinel"],
+                "updated_at": "2026-04-24T00:00:02Z",
+                "created_at": "2026-04-24T00:00:02Z",
+            },
+        ]
+        mock_db = MagicMock()
+        mock_db.load_knowledge_nodes.return_value = fake_nodes
+        with patch("synapt.integrations.google_adk.RecallDB", return_value=mock_db), \
+             patch("synapt.integrations.google_adk.project_index_dir", return_value=MagicMock()):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="deployment strategy",
+            )
+        assert len(result.memories) == 1
+        assert result.memories[0].content.parts[0].text == "deployment strategy is blue green"
+        assert result.memories[0].author == "atlas"
+
+    @pytest.mark.asyncio
+    async def test_search_ignores_legacy_unscoped_nodes(self, service):
+        fake_nodes = [
+            {
+                "content": "deployment strategy is blue green",
+                "tags": ["google-adk", "myapp", "atlas"],
+                "updated_at": "2026-04-24T00:00:00Z",
+                "created_at": "2026-04-24T00:00:00Z",
+            }
+        ]
+        mock_db = MagicMock()
+        mock_db.load_knowledge_nodes.return_value = fake_nodes
+        with patch("synapt.integrations.google_adk.RecallDB", return_value=mock_db), \
+             patch("synapt.integrations.google_adk.project_index_dir", return_value=MagicMock()):
+            result = await service.search_memory(
+                app_name="myapp",
+                user_id="user1",
+                query="deployment strategy",
+            )
+        assert len(result.memories) == 0
+
 
 class TestSearchMemoryResponse:
 
     @pytest.mark.asyncio
     async def test_entries_have_correct_fields(self, service):
-        with patch("synapt.recall.server.recall_search", return_value="some context"):
+        fake_nodes = [
+            {
+                "content": "some context",
+                "tags": ["google-adk", "app:myapp", "user:user1", "author:recall"],
+                "updated_at": "2026-04-24T00:00:00Z",
+                "created_at": "2026-04-24T00:00:00Z",
+            }
+        ]
+        mock_db = MagicMock()
+        mock_db.load_knowledge_nodes.return_value = fake_nodes
+        with patch("synapt.integrations.google_adk.RecallDB", return_value=mock_db), \
+             patch("synapt.integrations.google_adk.project_index_dir", return_value=MagicMock()):
             result = await service.search_memory(
                 app_name="myapp",
                 user_id="user1",
-                query="test",
+                query="context",
             )
         entry = result.memories[0]
         assert entry.author == "recall"
         assert entry.timestamp is not None
         assert entry.content.role == "model"
+
+
+class TestSaveToRecallTags:
+
+    @pytest.mark.asyncio
+    async def test_direct_memory_write_tags_app_and_user(self, service):
+        entry = MemoryEntry(
+            content=types.Content(
+                parts=[types.Part(text="important fact")],
+                role="model",
+            ),
+            author="agent",
+        )
+        await service.add_memory(
+            app_name="myapp",
+            user_id="user1",
+            memories=[entry],
+        )
+        _, kwargs = service._mock_save.call_args
+        assert kwargs["app_name"] == "myapp"
+        assert kwargs["user_id"] == "user1"
 
 
 class TestImportability:


### PR DESCRIPTION
## Summary

- scope Google ADK `search_memory()` by `app_name` and `user_id` instead of calling unscoped `recall_search()`
- tag new Google ADK writes with explicit `app:` and `user:` tags so scoped retrieval has a stable filter surface
- add regression tests for tenant isolation and legacy unscoped-node exclusion

Premium boundary: core OSS (platform integration adapter hardening in public recall).

## Test plan

- [x] `source .venv/bin/activate && PYTHONPATH=src pytest -q tests/integrations/test_google_adk_memory_service.py`

Closes #758