### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.13.2"
+version = "0.14.0"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.13.2"
+__version__ = "0.14.0"


### PR DESCRIPTION
## Summary
Version bump for Sprint 29 release: platform-native memory backends.

- 0.13.2 → 0.14.0 (minor: new public APIs)
- Anthropic `SynaptMemoryTool`, OpenAI `SynaptSession` upgrade, Google ADK `SynaptMemoryService`
- `anthropic` and `openai-agents` now core dependencies

PR #777 ceremony.

Premium boundary: core OSS (version metadata)

## Test plan
- [x] `bump-version.sh minor` updated both pyproject.toml and __init__.py
- [x] Version verified: `__version__ = "0.14.0"`