### PR TITLE
test: harden langchain-synapt packaging

### DIFF
--- a/tests/integrations/test_langchain_adapter.py
+++ b/tests/integrations/test_langchain_adapter.py
@@ -199,3 +199,39 @@ class TestRecallIntegration:
 
     def test_save_to_recall_method_exists(self, history):
         assert callable(history.save_to_recall)
+
+    def test_search_delegates_to_recall_search(self, history, monkeypatch):
+        def fake_search(*, query, max_chunks, max_tokens):
+            assert query == "deployment config"
+            assert max_chunks == 7
+            assert max_tokens == 900
+            return "chunk: deployment config"
+
+        monkeypatch.setattr("synapt.recall.server.recall_search", fake_search)
+
+        result = history.search(
+            "deployment config",
+            max_chunks=7,
+            max_tokens=900,
+        )
+
+        assert result == "chunk: deployment config"
+
+    def test_save_to_recall_delegates_to_recall_save(self, history, monkeypatch):
+        def fake_save(*, content, category, confidence, tags):
+            assert content == "Always use UTC timestamps"
+            assert category == "convention"
+            assert confidence == 0.9
+            assert tags == ["time", "ops"]
+            return "saved-node-id"
+
+        monkeypatch.setattr("synapt.recall.server.recall_save", fake_save)
+
+        result = history.save_to_recall(
+            "Always use UTC timestamps",
+            category="convention",
+            confidence=0.9,
+            tags=["time", "ops"],
+        )
+
+        assert result == "saved-node-id"

--- a/tests/integrations/test_langchain_synapt_package.py
+++ b/tests/integrations/test_langchain_synapt_package.py
@@ -1,0 +1,69 @@
+"""Packaging tests for the standalone ``langchain-synapt`` distribution."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_DIR = REPO_ROOT / "langchain-synapt"
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_langchain_synapt_package_has_required_files() -> None:
+    assert (PACKAGE_DIR / "pyproject.toml").exists()
+    assert (PACKAGE_DIR / "README.md").exists()
+    assert (PACKAGE_DIR / "src" / "langchain_synapt" / "__init__.py").exists()
+
+
+def test_langchain_synapt_builds_wheel() -> None:
+    _run([sys.executable, "-m", "build", str(PACKAGE_DIR)])
+    dist_dir = PACKAGE_DIR / "dist"
+    wheels = list(dist_dir.glob("langchain_synapt-*.whl"))
+    assert wheels, "expected standalone langchain-synapt wheel to be built"
+
+
+def test_langchain_synapt_installs_and_exports_history_class(tmp_path: Path) -> None:
+    _run([sys.executable, "-m", "build", str(REPO_ROOT)])
+    _run([sys.executable, "-m", "build", str(PACKAGE_DIR)])
+
+    synapt_wheel = next((REPO_ROOT / "dist").glob("synapt-*.whl"))
+    langchain_wheel = next((PACKAGE_DIR / "dist").glob("langchain_synapt-*.whl"))
+
+    venv_dir = tmp_path / "venv"
+    venv.create(venv_dir, with_pip=True)
+    python = venv_dir / "bin" / "python"
+    pip = [str(python), "-m", "pip"]
+
+    _run(pip + ["install", "langchain-core>=0.2"])
+    _run(pip + ["install", "--no-deps", str(synapt_wheel)])
+    _run(pip + ["install", "--no-deps", str(langchain_wheel)])
+
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pathlib import Path; "
+                "from langchain_core.messages import HumanMessage; "
+                "from langchain_synapt import SynaptChatMessageHistory; "
+                "db = Path('history.db'); "
+                "history = SynaptChatMessageHistory(session_id='pkg-test', db_path=db); "
+                "history.add_messages([HumanMessage(content='hello from wheel')]); "
+                "print(history.messages[0].content)"
+            ),
+        ]
+    )
+    assert result.stdout.strip() == "hello from wheel"

--- a/tests/integrations/test_langchain_synapt_package.py
+++ b/tests/integrations/test_langchain_synapt_package.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import venv
+import shutil
 from pathlib import Path
 
 
@@ -22,6 +23,19 @@ def _run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProc
     )
 
 
+def _rebuild_dist(target: Path) -> Path:
+    dist_dir = target / "dist"
+    shutil.rmtree(dist_dir, ignore_errors=True)
+    _run([sys.executable, "-m", "build", str(target)])
+    wheels = sorted(
+        dist_dir.glob("*.whl"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    assert wheels, f"expected wheel build output in {dist_dir}"
+    return wheels[0]
+
+
 def test_langchain_synapt_package_has_required_files() -> None:
     assert (PACKAGE_DIR / "pyproject.toml").exists()
     assert (PACKAGE_DIR / "README.md").exists()
@@ -29,18 +43,13 @@ def test_langchain_synapt_package_has_required_files() -> None:
 
 
 def test_langchain_synapt_builds_wheel() -> None:
-    _run([sys.executable, "-m", "build", str(PACKAGE_DIR)])
-    dist_dir = PACKAGE_DIR / "dist"
-    wheels = list(dist_dir.glob("langchain_synapt-*.whl"))
-    assert wheels, "expected standalone langchain-synapt wheel to be built"
+    wheel = _rebuild_dist(PACKAGE_DIR)
+    assert wheel.name.startswith("langchain_synapt-")
 
 
 def test_langchain_synapt_installs_and_exports_history_class(tmp_path: Path) -> None:
-    _run([sys.executable, "-m", "build", str(REPO_ROOT)])
-    _run([sys.executable, "-m", "build", str(PACKAGE_DIR)])
-
-    synapt_wheel = next((REPO_ROOT / "dist").glob("synapt-*.whl"))
-    langchain_wheel = next((PACKAGE_DIR / "dist").glob("langchain_synapt-*.whl"))
+    synapt_wheel = _rebuild_dist(REPO_ROOT)
+    langchain_wheel = _rebuild_dist(PACKAGE_DIR)
 
     venv_dir = tmp_path / "venv"
     venv.create(venv_dir, with_pip=True)


### PR DESCRIPTION
## Summary
- add standalone package validation for the existing `langchain-synapt` subtree
- add LangChain adapter coverage for `search()` and `save_to_recall()` delegation
- verify the published wheel installs and exposes a working `SynaptChatMessageHistory` class

## Test plan
- [x] `source .venv/bin/activate && python -m pytest -q tests/integrations/test_langchain_adapter.py tests/integrations/test_langchain_synapt_package.py`

Closes #754

Premium boundary: core OSS (public framework adapter package).
