### PR TITLE
fix: make synapt init succeed with zero transcripts (#753)

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -2296,30 +2296,30 @@ def cmd_setup(args: argparse.Namespace) -> None:
         if archive_count:
             print(f"  Found {archive_count} archived transcript(s)")
 
-    if not transcript_dir and codex_count == 0 and not (archive_dir.exists() and any(archive_dir.glob("*.jsonl"))):
-        print(f"  No transcripts found for this project.", file=sys.stderr)
-        print(f"  Start a Claude Code or Codex session in this project first,", file=sys.stderr)
-        print(f"  or use --sync to pull from HuggingFace.", file=sys.stderr)
-        sys.exit(1)
+    has_transcripts = bool(transcript_dir) or codex_count > 0 or (archive_dir.exists() and any(archive_dir.glob("*.jsonl")))
+    stats = None
 
-    use_emb = not args.no_embeddings
-    if use_emb:
-        print("  Computing embeddings ...")
+    if not has_transcripts:
+        print(f"  No transcripts found yet. Skipping index build.")
+        print(f"  Start a Claude Code or Codex session, then run 'synapt init' again to index.")
+    else:
+        use_emb = not args.no_embeddings
+        if use_emb:
+            print("  Computing embeddings ...")
 
-    final_index = _archive_and_build(
-        project,
-        use_embeddings=use_emb,
-    )
+        final_index = _archive_and_build(
+            project,
+            use_embeddings=use_emb,
+        )
 
-    if not final_index or not final_index.chunks:
-        print("  No chunks parsed from transcripts.", file=sys.stderr)
-        sys.exit(1)
-
-    stats = final_index.stats()
-    print(f"  Index saved: {stats['chunk_count']} chunks, {stats['session_count']} sessions")
-    if stats.get("date_range"):
-        dr = stats["date_range"]
-        print(f"  Date range: {dr['earliest'][:10]} to {dr['latest'][:10]}")
+        if final_index and final_index.chunks:
+            stats = final_index.stats()
+            print(f"  Index saved: {stats['chunk_count']} chunks, {stats['session_count']} sessions")
+            if stats.get("date_range"):
+                dr = stats["date_range"]
+                print(f"  Date range: {dr['earliest'][:10]} to {dr['latest'][:10]}")
+        else:
+            print(f"  No chunks parsed from transcripts. Index not built.")
     print()
 
     # --- 2. Register MCP server ---
@@ -2390,14 +2390,16 @@ def cmd_setup(args: argparse.Namespace) -> None:
         print()
 
     # --- Summary ---
-    index_dir = project_index_dir(project)
-    total_size = sum(fp.stat().st_size for fp in index_dir.iterdir() if fp.is_file())
-
     print("=" * 50)
     print("  synapt setup complete!")
-    print(f"  Index:    {index_dir} ({format_size(total_size)})")
-    print(f"  Chunks:   {stats['chunk_count']}")
-    print(f"  Sessions: {stats['session_count']}")
+    index_dir = project_index_dir(project)
+    if stats:
+        total_size = sum(fp.stat().st_size for fp in index_dir.iterdir() if fp.is_file())
+        print(f"  Index:    {index_dir} ({format_size(total_size)})")
+        print(f"  Chunks:   {stats['chunk_count']}")
+        print(f"  Sessions: {stats['session_count']}")
+    else:
+        print(f"  Index:    not yet built (no transcripts)")
     print(f"  MCP:      registered (scope: {scope})")
     if not args.no_hook:
         print(f"  Hook:     installed")

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -561,17 +561,16 @@ def recall_setup(no_hook: bool = False) -> str:
     finally:
         _invalidate_cache()
 
-    if not final_index or not final_index.chunks:
-        return (
-            "No Claude Code or Codex transcripts found for this project. "
-            "Start a Claude Code or Codex session first, then run recall_setup again."
+    if final_index and final_index.chunks:
+        stats = final_index.stats()
+        steps.append(
+            f"Index built: {stats['chunk_count']} chunks from "
+            f"{stats['session_count']} sessions"
         )
-
-    stats = final_index.stats()
-    steps.append(
-        f"Index built: {stats['chunk_count']} chunks from "
-        f"{stats['session_count']} sessions"
-    )
+    else:
+        steps.append(
+            "No transcripts found yet. Start a session, then run recall_setup again to index."
+        )
 
     # 2. Install global hooks (user-level ~/.claude/settings.json)
     if not no_hook:
@@ -589,8 +588,9 @@ def recall_setup(no_hook: bool = False) -> str:
 
     # Summary
     index_dir = project_index_dir(project)
-    total_size = sum(fp.stat().st_size for fp in index_dir.iterdir() if fp.is_file())
-    steps.append(f"Index size: {format_size(total_size)}")
+    if index_dir.exists() and any(index_dir.iterdir()):
+        total_size = sum(fp.stat().st_size for fp in index_dir.iterdir() if fp.is_file())
+        steps.append(f"Index size: {format_size(total_size)}")
 
     return "Setup complete.\n" + "\n".join(f"  - {s}" for s in steps)
 

--- a/tests/recall/test_cli.py
+++ b/tests/recall/test_cli.py
@@ -314,6 +314,60 @@ def test_cmd_setup_with_codex_only_transcripts(tmp_path):
     assert (tmp_path / ".codex" / "skills" / "dev-loop" / "SKILL.md").exists()
 
 
+def test_cmd_setup_no_transcripts_still_registers_mcp(tmp_path):
+    """setup with zero transcripts skips indexing but still registers MCP, hooks, gitignore."""
+    project_dir = tmp_path / "freshproject"
+    project_dir.mkdir()
+
+    mock_run = MagicMock()
+    mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+    with patch.dict("os.environ", {"CODEX_HOME": str(tmp_path / ".codex")}), \
+         patch("synapt.recall.core.Path.home", return_value=tmp_path), \
+         patch("synapt.recall.core.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.cli.Path.cwd", return_value=project_dir), \
+         patch("synapt.recall.cli.subprocess.run", mock_run), \
+         patch("synapt.recall.cli.shutil.which", return_value="/usr/bin/claude"):
+        from synapt.recall.cli import cmd_setup
+        args = argparse.Namespace(
+            no_embeddings=True,
+            no_hook=False,
+            global_scope=False,
+            sync=None,
+        )
+        cmd_setup(args)
+
+    # No index should exist (nothing to index)
+    index_dir = project_index_dir(project_dir)
+    assert not (index_dir / "recall.db").exists()
+
+    # MCP registration was still called
+    mcp_calls = [c for c in mock_run.call_args_list if "claude" in c[0][0]]
+    assert len(mcp_calls) == 1
+    call_args = mcp_calls[0][0][0]
+    assert "mcp" in call_args
+
+    # Global hooks were still registered
+    global_settings = tmp_path / ".claude" / "settings.json"
+    assert global_settings.exists()
+    settings = json.loads(global_settings.read_text())
+    hook_cmds = []
+    for event_hooks in settings.get("hooks", {}).values():
+        for matcher in event_hooks:
+            for h in matcher.get("hooks", []):
+                hook_cmds.append(h.get("command", ""))
+    assert "synapt recall hook session-start" in hook_cmds
+
+    # .gitignore was still created
+    gitignore = project_dir / ".gitignore"
+    assert gitignore.exists()
+    assert ".synapt/" in gitignore.read_text()
+
+    # Codex skill was still deployed
+    skill_path = tmp_path / ".codex" / "skills" / "dev-loop" / "SKILL.md"
+    assert skill_path.exists()
+
+
 def test_ensure_gitignore_creates_file(tmp_path):
     """_ensure_gitignore creates .gitignore with .synapt/ entry if missing."""
     _ensure_gitignore(tmp_path)
@@ -534,7 +588,7 @@ def test_recall_setup_no_hook(tmp_path):
 
 
 def test_recall_setup_no_transcripts(tmp_path):
-    """recall_setup returns helpful message when no transcripts exist."""
+    """recall_setup still completes hooks and gitignore when no transcripts exist."""
     from synapt.recall.server import recall_setup
 
     project_dir = tmp_path / "myproject"
@@ -545,7 +599,16 @@ def test_recall_setup_no_transcripts(tmp_path):
          patch("synapt.recall.cli.Path.cwd", return_value=project_dir):
         result = recall_setup()
 
-    assert "No Claude Code or Codex transcripts found" in result
+    assert "Setup complete" in result
+    assert "No transcripts found yet" in result
+    assert ".gitignore" in result
+
+    global_settings = tmp_path / ".claude" / "settings.json"
+    assert global_settings.exists()
+
+    gitignore = project_dir / ".gitignore"
+    assert gitignore.exists()
+    assert ".synapt/" in gitignore.read_text()
 
 
 def test_recall_setup_mcp_tool_with_codex_only_transcripts(tmp_path):


### PR DESCRIPTION
## Summary

- `synapt init` in a fresh project (no transcripts) now succeeds instead of exiting with code 1
- Step 1 (archive+index) is non-fatal: prints a note and continues to subsequent steps
- MCP registration, hooks, Codex skill, and gitignore all run regardless of transcript availability
- MCP server `recall_setup` tool gets the same fix: always completes hooks and gitignore

## Changes

- **`src/synapt/recall/cli.py`**: Replace two `sys.exit(1)` calls with conditional skip. Guard summary section for missing stats.
- **`src/synapt/recall/server.py`**: Replace early return on no-transcripts with graceful continuation through hooks and gitignore steps.
- **`tests/recall/test_cli.py`**: Add `test_cmd_setup_no_transcripts_still_registers_mcp` (new). Update `test_recall_setup_no_transcripts` to assert hooks and gitignore are set up even without transcripts.

## Premium boundary

OSS - CLI setup flow (public package distribution).

## Test plan

- [x] New test: zero-transcript project completes MCP registration, hooks, gitignore, Codex skill
- [x] Updated test: MCP server recall_setup completes hooks and gitignore with no transcripts
- [x] Existing test: full setup with Claude transcripts still works
- [x] Existing test: Codex-only transcripts still works
- [x] All 47 CLI tests pass
- [x] Full test suite passes (104 passed, 1 pre-existing ADK failure unrelated)

Generated with Claude Code