### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.14.0"
+version = "0.15.0"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"


### PR DESCRIPTION
Sprint 30 ceremony version bump: 0.14.0 → 0.15.0

**Premium boundary: OSS (version metadata only)**

Closes: n/a (ceremony prep)