### PR TITLE
feat: @synapt/extract JSON Schema + TypeScript types (#792)

### DIFF
--- a/packages/extract-py/pyproject.toml
+++ b/packages/extract-py/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "synapt-extract"
+version = "0.1.0"
+description = "SynaptExtraction IL v1 — schema, validation, and finalization"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    {name = "Layne Penney"},
+]
+
+[project.urls]
+Homepage = "https://synapt.dev"
+Repository = "https://github.com/synapt-dev/recall"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/extract-py/src/synapt_extract/__init__.py
+++ b/packages/extract-py/src/synapt_extract/__init__.py
@@ -1,0 +1,33 @@
+"""synapt-extract: SynaptExtraction IL v1 schema, validation, and finalization."""
+
+from synapt_extract.schema import (
+    SynaptExtraction,
+    SynaptEntity,
+    SynaptGoal,
+    SynaptFact,
+    SynaptRelation,
+    SynaptSourceRef,
+    SynaptEmbedding,
+    SynaptAssertionSignals,
+    SynaptTemporalRef,
+)
+from synapt_extract.validate import validate_extraction, ValidationResult, ValidationError
+from synapt_extract.finalize import finalize_extraction, FinalizeContext, FinalizeResult
+
+__all__ = [
+    "SynaptExtraction",
+    "SynaptEntity",
+    "SynaptGoal",
+    "SynaptFact",
+    "SynaptRelation",
+    "SynaptSourceRef",
+    "SynaptEmbedding",
+    "SynaptAssertionSignals",
+    "SynaptTemporalRef",
+    "validate_extraction",
+    "ValidationResult",
+    "ValidationError",
+    "finalize_extraction",
+    "FinalizeContext",
+    "FinalizeResult",
+]

--- a/packages/extract-py/src/synapt_extract/finalize.py
+++ b/packages/extract-py/src/synapt_extract/finalize.py
@@ -1,0 +1,187 @@
+"""Three-stage finalization pipeline for SynaptExtraction IL v1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from synapt_extract.validate import ValidationResult, validate_extraction
+
+
+@dataclass
+class FinalizeContext:
+    produced_by: str
+    user_id: str | None = None
+    source_id: str | None = None
+    source_type: str | None = None
+    kind: str | None = None
+    extensions: dict[str, Any] | None = None
+    embeddings: list[dict[str, Any]] | None = None
+    capabilities_hint: list[str] | None = None
+
+
+@dataclass
+class FinalizeResult:
+    extraction: dict[str, Any]
+    validation: ValidationResult
+    warnings: list[str] = field(default_factory=list)
+
+
+def _has_payload_beyond_version(obj: dict[str, Any]) -> bool:
+    return any(k != "version" for k in obj)
+
+
+def _detect_capabilities(doc: dict[str, Any]) -> list[str]:
+    caps: list[str] = []
+    entities = doc.get("entities", [])
+    goals = doc.get("goals", [])
+
+    if isinstance(entities, list) and entities:
+        caps.append("entities")
+        if any(e.get("state") is not None for e in entities):
+            caps.append("entity_state")
+        if any(e.get("context") is not None or e.get("date_hint") is not None for e in entities):
+            caps.append("entity_context")
+        if any(e.get("id") is not None for e in entities):
+            caps.append("entity_ids")
+        all_rels = [r for e in entities for r in (e.get("relations") or [])]
+        if all_rels:
+            caps.append("relations")
+            if any(r.get("origin") is not None for r in all_rels):
+                caps.append("relation_origin")
+        if any(e.get("source") is not None for e in entities):
+            caps.append("evidence_anchoring")
+        if any(e.get("signals") is not None for e in entities):
+            caps.append("assertion_signals")
+
+    if isinstance(goals, list) and goals:
+        caps.append("goals")
+        if any(g.get("stated_at") is not None or g.get("resolved_at") is not None for g in goals):
+            caps.append("goal_timing")
+        if any(isinstance(g.get("entity_refs"), list) and g["entity_refs"] for g in goals):
+            caps.append("goal_entity_refs")
+        if "evidence_anchoring" not in caps and any(g.get("source") is not None for g in goals):
+            caps.append("evidence_anchoring")
+        if "assertion_signals" not in caps and any(g.get("signals") is not None for g in goals):
+            caps.append("assertion_signals")
+
+    themes = doc.get("themes")
+    if isinstance(themes, list) and themes:
+        caps.append("themes")
+    if isinstance(doc.get("summary"), str):
+        caps.append("summary")
+    if isinstance(doc.get("sentiment"), str):
+        caps.append("sentiment")
+
+    facts = doc.get("facts", [])
+    if isinstance(facts, list) and facts:
+        caps.append("facts")
+        if "evidence_anchoring" not in caps and any(f.get("source") is not None for f in facts):
+            caps.append("evidence_anchoring")
+        if "assertion_signals" not in caps and any(f.get("signals") is not None for f in facts):
+            caps.append("assertion_signals")
+
+    temporal = doc.get("temporal_refs", [])
+    if isinstance(temporal, list) and temporal:
+        caps.append("temporal_refs")
+        if any(r.get("type") is not None or r.get("resolved_end") is not None for r in temporal):
+            caps.append("temporal_classes")
+
+    return caps
+
+
+def _inject_sub_versions(obj: dict[str, Any]) -> None:
+    obj["version"] = "1"
+
+
+def finalize_extraction(
+    llm_output: dict[str, Any],
+    context: FinalizeContext,
+) -> FinalizeResult:
+    """Assemble a complete SynaptExtraction from LLM output and client context.
+
+    Stage 1 (llm_output): content fields from the LLM.
+    Stage 2: injects client context (produced_by, user_id, embeddings, etc.).
+    Stage 3: injects sub-schema versions, computes capabilities, validates.
+    """
+    warnings: list[str] = []
+    doc = dict(llm_output)
+
+    # Stage 2: inject client context
+    doc["version"] = "1"
+    doc["produced_by"] = context.produced_by
+    if context.user_id is not None:
+        doc["user_id"] = context.user_id
+    if context.source_id is not None:
+        doc["source_id"] = context.source_id
+    if context.source_type is not None:
+        doc["source_type"] = context.source_type
+    if context.kind is not None:
+        doc["kind"] = context.kind
+    if context.extensions is not None:
+        doc["extensions"] = context.extensions
+
+    if context.embeddings is not None:
+        finalized_embs = []
+        for emb in context.embeddings:
+            full = {"version": "1", **emb}
+            if "dimensions" not in full and isinstance(full.get("vector"), list):
+                full["dimensions"] = len(full["vector"])
+            finalized_embs.append(full)
+        doc["embeddings"] = finalized_embs
+
+    # Stage 3: inject sub-schema versions, strip empty sub-schemas
+    for items_key in ("entities", "goals", "facts"):
+        items = doc.get(items_key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            for sub_key in ("source", "signals"):
+                sub = item.get(sub_key)
+                if isinstance(sub, dict):
+                    if _has_payload_beyond_version(sub):
+                        _inject_sub_versions(sub)
+                    else:
+                        del item[sub_key]
+            if items_key == "entities" and isinstance(item.get("relations"), list):
+                for rel in item["relations"]:
+                    if isinstance(rel, dict) and isinstance(rel.get("signals"), dict):
+                        sig = rel["signals"]
+                        if _has_payload_beyond_version(sig):
+                            _inject_sub_versions(sig)
+                        else:
+                            del rel["signals"]
+
+    temporal = doc.get("temporal_refs")
+    if isinstance(temporal, list):
+        for ref in temporal:
+            if isinstance(ref, dict):
+                _inject_sub_versions(ref)
+
+    # Stage 3: compute capabilities from observed payload
+    observed = _detect_capabilities(doc)
+    if context.capabilities_hint:
+        for hinted in context.capabilities_hint:
+            if hinted not in observed:
+                warnings.append(
+                    f'capabilities_hint includes "{hinted}" but payload does not contain it; using observed'
+                )
+    doc["capabilities"] = observed
+
+    # Stage 3: capability implication warnings
+    if "goal_entity_refs" in observed and "entity_ids" not in observed:
+        warnings.append(
+            "goal_entity_refs present but entity_ids missing; "
+            "entity ref resolution will fall back to name matching"
+        )
+
+    # Stage 3: validate
+    validation = validate_extraction(doc)
+
+    return FinalizeResult(
+        extraction=doc,
+        validation=validation,
+        warnings=warnings,
+    )

--- a/packages/extract-py/src/synapt_extract/schema.py
+++ b/packages/extract-py/src/synapt_extract/schema.py
@@ -1,0 +1,106 @@
+"""SynaptExtraction IL v1 type definitions."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+
+class SynaptSourceRef(TypedDict, total=False):
+    version: str
+    snippet: str
+    offset_start: int
+    offset_end: int
+    sentence_index: int
+
+
+class SynaptEmbedding(TypedDict, total=False):
+    version: str
+    vector: list[float]
+    model: str
+    input: str
+    dimensions: int
+    space: str
+    computed_at: str
+
+
+class SynaptAssertionSignals(TypedDict, total=False):
+    version: str
+    confidence: float
+    negated: bool
+    hedged: bool
+    condition: str
+
+
+class SynaptTemporalRef(TypedDict, total=False):
+    version: str
+    raw: str
+    type: Literal["point", "range", "duration", "unresolved"]
+    resolved: str
+    resolved_end: str
+    context: str
+
+
+class SynaptRelation(TypedDict, total=False):
+    target: str
+    type: str
+    origin: str
+    signals: SynaptAssertionSignals
+
+
+class SynaptEntity(TypedDict, total=False):
+    id: str
+    name: str
+    type: str
+    state: str
+    context: str
+    date_hint: str
+    source: SynaptSourceRef
+    signals: SynaptAssertionSignals
+    relations: list[SynaptRelation]
+
+
+class SynaptGoal(TypedDict, total=False):
+    text: str
+    status: Literal["open", "resolved", "abandoned", "in_progress"]
+    entity_refs: list[str]
+    stated_at: str
+    resolved_at: str
+    source: SynaptSourceRef
+    signals: SynaptAssertionSignals
+
+
+class SynaptFact(TypedDict, total=False):
+    text: str
+    category: str
+    source: SynaptSourceRef
+    signals: SynaptAssertionSignals
+
+
+EXTRACTION_CAPABILITIES = frozenset([
+    "entities", "entity_state", "entity_context", "entity_ids",
+    "goals", "goal_timing", "goal_entity_refs",
+    "themes", "summary", "sentiment", "facts",
+    "temporal_refs", "temporal_classes",
+    "relations", "relation_origin",
+    "assertion_signals", "evidence_anchoring",
+])
+
+
+class SynaptExtraction(TypedDict, total=False):
+    version: str
+    extracted_at: str
+    source_id: str
+    source_type: str
+    user_id: str
+    produced_by: str
+    kind: str
+    entities: list[SynaptEntity]
+    goals: list[SynaptGoal]
+    themes: list[str]
+    sentiment: str
+    summary: str
+    facts: list[SynaptFact]
+    temporal_refs: list[SynaptTemporalRef]
+    capabilities: list[str]
+    embeddings: list[SynaptEmbedding]
+    extensions: dict[str, Any]

--- a/packages/extract-py/src/synapt_extract/validate.py
+++ b/packages/extract-py/src/synapt_extract/validate.py
@@ -1,0 +1,208 @@
+"""Structural validation for SynaptExtraction IL v1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from synapt_extract.schema import EXTRACTION_CAPABILITIES
+
+VALID_GOAL_STATUSES = frozenset(["open", "resolved", "abandoned", "in_progress"])
+VALID_TEMPORAL_TYPES = frozenset(["point", "range", "duration", "unresolved"])
+
+
+@dataclass
+class ValidationError:
+    path: str
+    message: str
+
+
+@dataclass
+class ValidationResult:
+    valid: bool
+    errors: list[ValidationError] = field(default_factory=list)
+
+
+def _check_source_ref(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if obj.get("version") != "1":
+        errors.append(ValidationError(f"{path}.version", 'must be "1"'))
+    if "snippet" in obj and not isinstance(obj["snippet"], str):
+        errors.append(ValidationError(f"{path}.snippet", "must be a string"))
+
+
+def _check_signals(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if obj.get("version") != "1":
+        errors.append(ValidationError(f"{path}.version", 'must be "1"'))
+    if "confidence" in obj:
+        c = obj["confidence"]
+        if not isinstance(c, (int, float)) or c < 0 or c > 1:
+            errors.append(ValidationError(f"{path}.confidence", "must be a number between 0.0 and 1.0"))
+    if "negated" in obj and not isinstance(obj["negated"], bool):
+        errors.append(ValidationError(f"{path}.negated", "must be a boolean"))
+    if "hedged" in obj and not isinstance(obj["hedged"], bool):
+        errors.append(ValidationError(f"{path}.hedged", "must be a boolean"))
+    if "condition" in obj and not isinstance(obj["condition"], str):
+        errors.append(ValidationError(f"{path}.condition", "must be a string"))
+
+
+def _check_embedding(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if obj.get("version") != "1":
+        errors.append(ValidationError(f"{path}.version", 'must be "1"'))
+    if not isinstance(obj.get("vector"), list):
+        errors.append(ValidationError(f"{path}.vector", "required array"))
+    if not isinstance(obj.get("model"), str):
+        errors.append(ValidationError(f"{path}.model", "required string"))
+    if not isinstance(obj.get("input"), str):
+        errors.append(ValidationError(f"{path}.input", "required string"))
+    dims = obj.get("dimensions")
+    if not isinstance(dims, int) or dims < 1:
+        errors.append(ValidationError(f"{path}.dimensions", "required positive integer"))
+
+
+def _check_relation(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if not isinstance(obj.get("target"), str):
+        errors.append(ValidationError(f"{path}.target", "required string"))
+    if not isinstance(obj.get("type"), str):
+        errors.append(ValidationError(f"{path}.type", "required string"))
+    if "signals" in obj:
+        _check_signals(obj["signals"], f"{path}.signals", errors)
+
+
+def _check_entity(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if not isinstance(obj.get("name"), str):
+        errors.append(ValidationError(f"{path}.name", "required string"))
+    if not isinstance(obj.get("type"), str):
+        errors.append(ValidationError(f"{path}.type", "required string"))
+    if "source" in obj:
+        _check_source_ref(obj["source"], f"{path}.source", errors)
+    if "signals" in obj:
+        _check_signals(obj["signals"], f"{path}.signals", errors)
+    if "relations" in obj:
+        if not isinstance(obj["relations"], list):
+            errors.append(ValidationError(f"{path}.relations", "must be an array"))
+        else:
+            for i, rel in enumerate(obj["relations"]):
+                _check_relation(rel, f"{path}.relations[{i}]", errors)
+
+
+def _check_goal(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if not isinstance(obj.get("text"), str):
+        errors.append(ValidationError(f"{path}.text", "required string"))
+    status = obj.get("status")
+    if not isinstance(status, str) or status not in VALID_GOAL_STATUSES:
+        errors.append(ValidationError(f"{path}.status", "must be one of: open, resolved, abandoned, in_progress"))
+    if not isinstance(obj.get("entity_refs"), list):
+        errors.append(ValidationError(f"{path}.entity_refs", "required array of strings"))
+    if "source" in obj:
+        _check_source_ref(obj["source"], f"{path}.source", errors)
+    if "signals" in obj:
+        _check_signals(obj["signals"], f"{path}.signals", errors)
+
+
+def _check_fact(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if not isinstance(obj.get("text"), str):
+        errors.append(ValidationError(f"{path}.text", "required string"))
+    if "source" in obj:
+        _check_source_ref(obj["source"], f"{path}.source", errors)
+    if "signals" in obj:
+        _check_signals(obj["signals"], f"{path}.signals", errors)
+
+
+def _check_temporal_ref(obj: Any, path: str, errors: list[ValidationError]) -> None:
+    if not isinstance(obj, dict):
+        errors.append(ValidationError(path, "must be an object"))
+        return
+    if obj.get("version") != "1":
+        errors.append(ValidationError(f"{path}.version", 'must be "1"'))
+    if not isinstance(obj.get("raw"), str):
+        errors.append(ValidationError(f"{path}.raw", "required string"))
+    if "type" in obj:
+        if not isinstance(obj["type"], str) or obj["type"] not in VALID_TEMPORAL_TYPES:
+            errors.append(ValidationError(f"{path}.type", "must be one of: point, range, duration, unresolved"))
+
+
+def validate_extraction(obj: Any) -> ValidationResult:
+    """Validate a SynaptExtraction document for structural conformance.
+
+    Returns a ValidationResult with valid=True if the document conforms
+    to the IL v1 schema, or valid=False with a list of errors.
+    """
+    errors: list[ValidationError] = []
+
+    if not isinstance(obj, dict):
+        return ValidationResult(valid=False, errors=[ValidationError("", "must be an object")])
+
+    if obj.get("version") != "1":
+        errors.append(ValidationError("version", 'must be "1"'))
+    if not isinstance(obj.get("extracted_at"), str):
+        errors.append(ValidationError("extracted_at", "required string (ISO 8601)"))
+    if not isinstance(obj.get("produced_by"), str):
+        errors.append(ValidationError("produced_by", "required string (provider URI)"))
+
+    if not isinstance(obj.get("entities"), list):
+        errors.append(ValidationError("entities", "required array"))
+    else:
+        for i, ent in enumerate(obj["entities"]):
+            _check_entity(ent, f"entities[{i}]", errors)
+
+    if not isinstance(obj.get("goals"), list):
+        errors.append(ValidationError("goals", "required array"))
+    else:
+        for i, goal in enumerate(obj["goals"]):
+            _check_goal(goal, f"goals[{i}]", errors)
+
+    if not isinstance(obj.get("themes"), list):
+        errors.append(ValidationError("themes", "required array"))
+
+    if not isinstance(obj.get("capabilities"), list):
+        errors.append(ValidationError("capabilities", "required array"))
+    else:
+        for i, cap in enumerate(obj["capabilities"]):
+            if not isinstance(cap, str):
+                errors.append(ValidationError(f"capabilities[{i}]", "must be a string"))
+            elif cap not in EXTRACTION_CAPABILITIES:
+                errors.append(ValidationError(f"capabilities[{i}]", f'unknown capability: "{cap}"'))
+
+    if "facts" in obj:
+        if not isinstance(obj["facts"], list):
+            errors.append(ValidationError("facts", "must be an array"))
+        else:
+            for i, fact in enumerate(obj["facts"]):
+                _check_fact(fact, f"facts[{i}]", errors)
+
+    if "temporal_refs" in obj:
+        if not isinstance(obj["temporal_refs"], list):
+            errors.append(ValidationError("temporal_refs", "must be an array"))
+        else:
+            for i, ref in enumerate(obj["temporal_refs"]):
+                _check_temporal_ref(ref, f"temporal_refs[{i}]", errors)
+
+    if "embeddings" in obj:
+        if not isinstance(obj["embeddings"], list):
+            errors.append(ValidationError("embeddings", "must be an array"))
+        else:
+            for i, emb in enumerate(obj["embeddings"]):
+                _check_embedding(emb, f"embeddings[{i}]", errors)
+
+    return ValidationResult(valid=len(errors) == 0, errors=errors)

--- a/packages/extract/src/finalize.ts
+++ b/packages/extract/src/finalize.ts
@@ -1,0 +1,240 @@
+import type {
+  SynaptExtraction,
+  SynaptEntity,
+  SynaptGoal,
+  SynaptFact,
+  SynaptEmbedding,
+  SynaptTemporalRef,
+  ExtractionCapability,
+} from "./schema.js";
+import { validateExtraction, type ValidationResult } from "./validate.js";
+
+export interface FinalizeContext {
+  produced_by: string;
+  user_id?: string;
+  source_id?: string;
+  source_type?: string;
+  kind?: string;
+  extensions?: Record<string, unknown>;
+  embeddings?: Omit<SynaptEmbedding, "version">[];
+  capabilities_hint?: ExtractionCapability[];
+}
+
+export interface FinalizeResult {
+  extraction: SynaptExtraction;
+  validation: ValidationResult;
+  warnings: string[];
+}
+
+const CAPABILITY_DEPS: Record<string, string[]> = {
+  entity_state: ["entities"],
+  entity_context: ["entities"],
+  entity_ids: ["entities"],
+  goal_timing: ["goals"],
+  goal_entity_refs: ["goals", "entity_ids"],
+  temporal_classes: ["temporal_refs"],
+  relations: ["entities", "entity_ids"],
+  relation_origin: ["relations"],
+};
+
+function injectSubSchemaVersions(obj: Record<string, unknown>): void {
+  if (obj && typeof obj === "object") {
+    obj.version = "1";
+  }
+}
+
+function hasPayloadBeyondVersion(obj: Record<string, unknown>): boolean {
+  return Object.keys(obj).some((k) => k !== "version");
+}
+
+function detectCapabilities(doc: Record<string, unknown>): ExtractionCapability[] {
+  const caps: ExtractionCapability[] = [];
+  const entities = doc.entities as Record<string, unknown>[] | undefined;
+  const goals = doc.goals as Record<string, unknown>[] | undefined;
+
+  if (Array.isArray(entities) && entities.length > 0) {
+    caps.push("entities");
+    if (entities.some((e) => e.state !== undefined)) caps.push("entity_state");
+    if (entities.some((e) => e.context !== undefined || e.date_hint !== undefined)) caps.push("entity_context");
+    if (entities.some((e) => e.id !== undefined)) caps.push("entity_ids");
+    if (entities.some((e) => Array.isArray(e.relations) && (e.relations as unknown[]).length > 0)) {
+      caps.push("relations");
+      const allRelations = entities.flatMap((e) => (e.relations as Record<string, unknown>[]) || []);
+      if (allRelations.some((r) => r.origin !== undefined)) caps.push("relation_origin");
+    }
+    if (entities.some((e) => e.source !== undefined)) caps.push("evidence_anchoring");
+    if (entities.some((e) => e.signals !== undefined)) caps.push("assertion_signals");
+  }
+
+  if (Array.isArray(goals) && goals.length > 0) {
+    caps.push("goals");
+    if (goals.some((g) => g.stated_at !== undefined || g.resolved_at !== undefined)) caps.push("goal_timing");
+    if (goals.some((g) => Array.isArray(g.entity_refs) && (g.entity_refs as unknown[]).length > 0)) {
+      caps.push("goal_entity_refs");
+    }
+    if (!caps.includes("evidence_anchoring") && goals.some((g) => g.source !== undefined)) {
+      caps.push("evidence_anchoring");
+    }
+    if (!caps.includes("assertion_signals") && goals.some((g) => g.signals !== undefined)) {
+      caps.push("assertion_signals");
+    }
+  }
+
+  if (Array.isArray(doc.themes) && (doc.themes as unknown[]).length > 0) caps.push("themes");
+  if (typeof doc.summary === "string") caps.push("summary");
+  if (typeof doc.sentiment === "string") caps.push("sentiment");
+
+  if (Array.isArray(doc.facts) && (doc.facts as unknown[]).length > 0) {
+    caps.push("facts");
+    const facts = doc.facts as Record<string, unknown>[];
+    if (!caps.includes("evidence_anchoring") && facts.some((f) => f.source !== undefined)) {
+      caps.push("evidence_anchoring");
+    }
+    if (!caps.includes("assertion_signals") && facts.some((f) => f.signals !== undefined)) {
+      caps.push("assertion_signals");
+    }
+  }
+
+  if (Array.isArray(doc.temporal_refs) && (doc.temporal_refs as unknown[]).length > 0) {
+    caps.push("temporal_refs");
+    const refs = doc.temporal_refs as Record<string, unknown>[];
+    if (refs.some((r) => r.type !== undefined || r.resolved_end !== undefined)) caps.push("temporal_classes");
+  }
+
+  return caps;
+}
+
+export function finalizeExtraction(
+  llmOutput: Record<string, unknown>,
+  context: FinalizeContext,
+): FinalizeResult {
+  const warnings: string[] = [];
+  const doc = { ...llmOutput };
+
+  // Stage 2: inject client context
+  doc.version = "1";
+  doc.produced_by = context.produced_by;
+  if (context.user_id !== undefined) doc.user_id = context.user_id;
+  if (context.source_id !== undefined) doc.source_id = context.source_id;
+  if (context.source_type !== undefined) doc.source_type = context.source_type;
+  if (context.kind !== undefined) doc.kind = context.kind;
+  if (context.extensions !== undefined) doc.extensions = context.extensions;
+
+  // Stage 2: inject embeddings with version
+  if (context.embeddings !== undefined) {
+    doc.embeddings = context.embeddings.map((emb) => {
+      const full: Record<string, unknown> = { version: "1", ...emb };
+      if (full.dimensions === undefined && Array.isArray(full.vector)) {
+        full.dimensions = (full.vector as number[]).length;
+      }
+      return full;
+    });
+  }
+
+  // Stage 3: inject sub-schema versions on source refs and signals
+  if (Array.isArray(doc.entities)) {
+    for (const ent of doc.entities as Record<string, unknown>[]) {
+      if (ent.source && typeof ent.source === "object") {
+        const src = ent.source as Record<string, unknown>;
+        if (hasPayloadBeyondVersion(src)) {
+          injectSubSchemaVersions(src);
+        } else {
+          delete ent.source;
+        }
+      }
+      if (ent.signals && typeof ent.signals === "object") {
+        const sig = ent.signals as Record<string, unknown>;
+        if (hasPayloadBeyondVersion(sig)) {
+          injectSubSchemaVersions(sig);
+        } else {
+          delete ent.signals;
+        }
+      }
+      if (Array.isArray(ent.relations)) {
+        for (const rel of ent.relations as Record<string, unknown>[]) {
+          if (rel.signals && typeof rel.signals === "object") {
+            const sig = rel.signals as Record<string, unknown>;
+            if (hasPayloadBeyondVersion(sig)) {
+              injectSubSchemaVersions(sig);
+            } else {
+              delete rel.signals;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(doc.goals)) {
+    for (const goal of doc.goals as Record<string, unknown>[]) {
+      if (goal.source && typeof goal.source === "object") {
+        const src = goal.source as Record<string, unknown>;
+        if (hasPayloadBeyondVersion(src)) {
+          injectSubSchemaVersions(src);
+        } else {
+          delete goal.source;
+        }
+      }
+      if (goal.signals && typeof goal.signals === "object") {
+        const sig = goal.signals as Record<string, unknown>;
+        if (hasPayloadBeyondVersion(sig)) {
+          injectSubSchemaVersions(sig);
+        } else {
+          delete goal.signals;
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(doc.facts)) {
+    for (const fact of doc.facts as Record<string, unknown>[]) {
+      if (fact.source && typeof fact.source === "object") {
+        const src = fact.source as Record<string, unknown>;
+        if (hasPayloadBeyondVersion(src)) {
+          injectSubSchemaVersions(src);
+        } else {
+          delete fact.source;
+        }
+      }
+      if (fact.signals && typeof fact.signals === "object") {
+        const sig = fact.signals as Record<string, unknown>;
+        if (hasPayloadBeyondVersion(sig)) {
+          injectSubSchemaVersions(sig);
+        } else {
+          delete fact.signals;
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(doc.temporal_refs)) {
+    for (const ref of doc.temporal_refs as Record<string, unknown>[]) {
+      injectSubSchemaVersions(ref);
+    }
+  }
+
+  // Stage 3: compute capabilities from observed payload
+  const observed = detectCapabilities(doc);
+  if (context.capabilities_hint) {
+    for (const hinted of context.capabilities_hint) {
+      if (!observed.includes(hinted)) {
+        warnings.push(`capabilities_hint includes "${hinted}" but payload does not contain it; using observed`);
+      }
+    }
+  }
+  doc.capabilities = observed;
+
+  // Stage 3: capability implication enforcement
+  if (observed.includes("goal_entity_refs") && !observed.includes("entity_ids")) {
+    warnings.push("goal_entity_refs present but entity_ids missing; entity ref resolution will fall back to name matching");
+  }
+
+  // Stage 3: validate
+  const validation = validateExtraction(doc);
+
+  return {
+    extraction: doc as unknown as SynaptExtraction,
+    validation,
+    warnings,
+  };
+}

--- a/packages/extract/src/index.ts
+++ b/packages/extract/src/index.ts
@@ -1,0 +1,18 @@
+export type {
+  SynaptExtraction,
+  SynaptEntity,
+  SynaptGoal,
+  SynaptFact,
+  SynaptRelation,
+  SynaptSourceRef,
+  SynaptEmbedding,
+  SynaptAssertionSignals,
+  SynaptTemporalRef,
+  ExtractionCapability,
+} from "./schema.js";
+
+export { validateExtraction } from "./validate.js";
+export type { ValidationResult, ValidationError } from "./validate.js";
+
+export { finalizeExtraction } from "./finalize.js";
+export type { FinalizeContext, FinalizeResult } from "./finalize.js";

--- a/packages/extract/src/schema.ts
+++ b/packages/extract/src/schema.ts
@@ -1,0 +1,109 @@
+export interface SynaptSourceRef {
+  version: "1";
+  snippet?: string;
+  offset_start?: number;
+  offset_end?: number;
+  sentence_index?: number;
+}
+
+export interface SynaptEmbedding {
+  version: "1";
+  vector: number[];
+  model: string;
+  input: "source" | "summary" | "entities" | string;
+  dimensions: number;
+  space?: string;
+  computed_at?: string;
+}
+
+export interface SynaptAssertionSignals {
+  version: "1";
+  confidence?: number;
+  negated?: boolean;
+  hedged?: boolean;
+  condition?: string;
+}
+
+export interface SynaptTemporalRef {
+  version: "1";
+  raw: string;
+  type?: "point" | "range" | "duration" | "unresolved";
+  resolved?: string;
+  resolved_end?: string;
+  context?: string;
+}
+
+export interface SynaptRelation {
+  target: string;
+  type: string;
+  origin?: string;
+  signals?: SynaptAssertionSignals;
+}
+
+export interface SynaptEntity {
+  id?: string;
+  name: string;
+  type: "person" | "place" | "event" | "concept" | "organization" | "object" | string;
+  state?: string;
+  context?: string;
+  date_hint?: string;
+  source?: SynaptSourceRef;
+  signals?: SynaptAssertionSignals;
+  relations?: SynaptRelation[];
+}
+
+export interface SynaptGoal {
+  text: string;
+  status: "open" | "resolved" | "abandoned" | "in_progress";
+  entity_refs: string[];
+  stated_at?: string;
+  resolved_at?: string;
+  source?: SynaptSourceRef;
+  signals?: SynaptAssertionSignals;
+}
+
+export interface SynaptFact {
+  text: string;
+  category?: string;
+  source?: SynaptSourceRef;
+  signals?: SynaptAssertionSignals;
+}
+
+export type ExtractionCapability =
+  | "entities"
+  | "entity_state"
+  | "entity_context"
+  | "entity_ids"
+  | "goals"
+  | "goal_timing"
+  | "goal_entity_refs"
+  | "themes"
+  | "summary"
+  | "sentiment"
+  | "facts"
+  | "temporal_refs"
+  | "temporal_classes"
+  | "relations"
+  | "relation_origin"
+  | "assertion_signals"
+  | "evidence_anchoring";
+
+export interface SynaptExtraction {
+  version: "1";
+  extracted_at: string;
+  source_id?: string;
+  source_type?: string;
+  user_id?: string;
+  produced_by: string;
+  kind?: string;
+  entities: SynaptEntity[];
+  goals: SynaptGoal[];
+  themes: string[];
+  sentiment?: string;
+  summary?: string;
+  facts?: SynaptFact[];
+  temporal_refs?: SynaptTemporalRef[];
+  capabilities: ExtractionCapability[];
+  embeddings?: SynaptEmbedding[];
+  extensions?: Record<string, unknown>;
+}

--- a/packages/extract/src/validate.ts
+++ b/packages/extract/src/validate.ts
@@ -1,0 +1,283 @@
+import type { SynaptExtraction, ExtractionCapability } from "./schema.js";
+
+export interface ValidationError {
+  path: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+const VALID_CAPABILITIES: Set<string> = new Set([
+  "entities", "entity_state", "entity_context", "entity_ids",
+  "goals", "goal_timing", "goal_entity_refs",
+  "themes", "summary", "sentiment", "facts",
+  "temporal_refs", "temporal_classes",
+  "relations", "relation_origin",
+  "assertion_signals", "evidence_anchoring",
+]);
+
+const VALID_ENTITY_TYPES: Set<string> = new Set([
+  "person", "place", "event", "concept", "organization", "object",
+]);
+
+const VALID_GOAL_STATUSES: Set<string> = new Set([
+  "open", "resolved", "abandoned", "in_progress",
+]);
+
+const VALID_TEMPORAL_TYPES: Set<string> = new Set([
+  "point", "range", "duration", "unresolved",
+]);
+
+function validateSourceRef(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const ref = obj as Record<string, unknown>;
+  if (ref.version !== "1") {
+    errors.push({ path: `${path}.version`, message: "must be \"1\"" });
+  }
+  if (ref.snippet !== undefined && typeof ref.snippet !== "string") {
+    errors.push({ path: `${path}.snippet`, message: "must be a string" });
+  }
+}
+
+function validateSignals(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const sig = obj as Record<string, unknown>;
+  if (sig.version !== "1") {
+    errors.push({ path: `${path}.version`, message: "must be \"1\"" });
+  }
+  if (sig.confidence !== undefined) {
+    if (typeof sig.confidence !== "number" || sig.confidence < 0 || sig.confidence > 1) {
+      errors.push({ path: `${path}.confidence`, message: "must be a number between 0.0 and 1.0" });
+    }
+  }
+  if (sig.negated !== undefined && typeof sig.negated !== "boolean") {
+    errors.push({ path: `${path}.negated`, message: "must be a boolean" });
+  }
+  if (sig.hedged !== undefined && typeof sig.hedged !== "boolean") {
+    errors.push({ path: `${path}.hedged`, message: "must be a boolean" });
+  }
+  if (sig.condition !== undefined && typeof sig.condition !== "string") {
+    errors.push({ path: `${path}.condition`, message: "must be a string" });
+  }
+}
+
+function validateEmbedding(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const emb = obj as Record<string, unknown>;
+  if (emb.version !== "1") {
+    errors.push({ path: `${path}.version`, message: "must be \"1\"" });
+  }
+  if (!Array.isArray(emb.vector)) {
+    errors.push({ path: `${path}.vector`, message: "required array" });
+  }
+  if (typeof emb.model !== "string") {
+    errors.push({ path: `${path}.model`, message: "required string" });
+  }
+  if (typeof emb.input !== "string") {
+    errors.push({ path: `${path}.input`, message: "required string" });
+  }
+  if (typeof emb.dimensions !== "number" || !Number.isInteger(emb.dimensions) || emb.dimensions < 1) {
+    errors.push({ path: `${path}.dimensions`, message: "required positive integer" });
+  }
+}
+
+function validateRelation(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const rel = obj as Record<string, unknown>;
+  if (typeof rel.target !== "string") {
+    errors.push({ path: `${path}.target`, message: "required string" });
+  }
+  if (typeof rel.type !== "string") {
+    errors.push({ path: `${path}.type`, message: "required string" });
+  }
+  if (rel.signals !== undefined) {
+    validateSignals(rel.signals, `${path}.signals`, errors);
+  }
+}
+
+function validateEntity(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const ent = obj as Record<string, unknown>;
+  if (typeof ent.name !== "string") {
+    errors.push({ path: `${path}.name`, message: "required string" });
+  }
+  if (typeof ent.type !== "string") {
+    errors.push({ path: `${path}.type`, message: "required string" });
+  }
+  if (ent.source !== undefined) {
+    validateSourceRef(ent.source, `${path}.source`, errors);
+  }
+  if (ent.signals !== undefined) {
+    validateSignals(ent.signals, `${path}.signals`, errors);
+  }
+  if (ent.relations !== undefined) {
+    if (!Array.isArray(ent.relations)) {
+      errors.push({ path: `${path}.relations`, message: "must be an array" });
+    } else {
+      for (let i = 0; i < ent.relations.length; i++) {
+        validateRelation(ent.relations[i], `${path}.relations[${i}]`, errors);
+      }
+    }
+  }
+}
+
+function validateGoal(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const goal = obj as Record<string, unknown>;
+  if (typeof goal.text !== "string") {
+    errors.push({ path: `${path}.text`, message: "required string" });
+  }
+  if (typeof goal.status !== "string" || !VALID_GOAL_STATUSES.has(goal.status)) {
+    errors.push({ path: `${path}.status`, message: "must be one of: open, resolved, abandoned, in_progress" });
+  }
+  if (!Array.isArray(goal.entity_refs)) {
+    errors.push({ path: `${path}.entity_refs`, message: "required array of strings" });
+  }
+  if (goal.source !== undefined) {
+    validateSourceRef(goal.source, `${path}.source`, errors);
+  }
+  if (goal.signals !== undefined) {
+    validateSignals(goal.signals, `${path}.signals`, errors);
+  }
+}
+
+function validateFact(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const fact = obj as Record<string, unknown>;
+  if (typeof fact.text !== "string") {
+    errors.push({ path: `${path}.text`, message: "required string" });
+  }
+  if (fact.source !== undefined) {
+    validateSourceRef(fact.source, `${path}.source`, errors);
+  }
+  if (fact.signals !== undefined) {
+    validateSignals(fact.signals, `${path}.signals`, errors);
+  }
+}
+
+function validateTemporalRef(obj: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof obj !== "object" || obj === null) {
+    errors.push({ path, message: "must be an object" });
+    return;
+  }
+  const ref = obj as Record<string, unknown>;
+  if (ref.version !== "1") {
+    errors.push({ path: `${path}.version`, message: "must be \"1\"" });
+  }
+  if (typeof ref.raw !== "string") {
+    errors.push({ path: `${path}.raw`, message: "required string" });
+  }
+  if (ref.type !== undefined && (typeof ref.type !== "string" || !VALID_TEMPORAL_TYPES.has(ref.type))) {
+    errors.push({ path: `${path}.type`, message: "must be one of: point, range, duration, unresolved" });
+  }
+}
+
+export function validateExtraction(obj: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (typeof obj !== "object" || obj === null) {
+    return { valid: false, errors: [{ path: "", message: "must be an object" }] };
+  }
+
+  const doc = obj as Record<string, unknown>;
+
+  if (doc.version !== "1") {
+    errors.push({ path: "version", message: "must be \"1\"" });
+  }
+
+  if (typeof doc.extracted_at !== "string") {
+    errors.push({ path: "extracted_at", message: "required string (ISO 8601)" });
+  }
+
+  if (typeof doc.produced_by !== "string") {
+    errors.push({ path: "produced_by", message: "required string (provider URI)" });
+  }
+
+  if (!Array.isArray(doc.entities)) {
+    errors.push({ path: "entities", message: "required array" });
+  } else {
+    for (let i = 0; i < doc.entities.length; i++) {
+      validateEntity(doc.entities[i], `entities[${i}]`, errors);
+    }
+  }
+
+  if (!Array.isArray(doc.goals)) {
+    errors.push({ path: "goals", message: "required array" });
+  } else {
+    for (let i = 0; i < doc.goals.length; i++) {
+      validateGoal(doc.goals[i], `goals[${i}]`, errors);
+    }
+  }
+
+  if (!Array.isArray(doc.themes)) {
+    errors.push({ path: "themes", message: "required array" });
+  }
+
+  if (!Array.isArray(doc.capabilities)) {
+    errors.push({ path: "capabilities", message: "required array" });
+  } else {
+    for (let i = 0; i < doc.capabilities.length; i++) {
+      if (typeof doc.capabilities[i] !== "string") {
+        errors.push({ path: `capabilities[${i}]`, message: "must be a string" });
+      } else if (!VALID_CAPABILITIES.has(doc.capabilities[i] as string)) {
+        errors.push({ path: `capabilities[${i}]`, message: `unknown capability: "${doc.capabilities[i]}"` });
+      }
+    }
+  }
+
+  if (doc.facts !== undefined) {
+    if (!Array.isArray(doc.facts)) {
+      errors.push({ path: "facts", message: "must be an array" });
+    } else {
+      for (let i = 0; i < doc.facts.length; i++) {
+        validateFact(doc.facts[i], `facts[${i}]`, errors);
+      }
+    }
+  }
+
+  if (doc.temporal_refs !== undefined) {
+    if (!Array.isArray(doc.temporal_refs)) {
+      errors.push({ path: "temporal_refs", message: "must be an array" });
+    } else {
+      for (let i = 0; i < doc.temporal_refs.length; i++) {
+        validateTemporalRef(doc.temporal_refs[i], `temporal_refs[${i}]`, errors);
+      }
+    }
+  }
+
+  if (doc.embeddings !== undefined) {
+    if (!Array.isArray(doc.embeddings)) {
+      errors.push({ path: "embeddings", message: "must be an array" });
+    } else {
+      for (let i = 0; i < doc.embeddings.length; i++) {
+        validateEmbedding(doc.embeddings[i], `embeddings[${i}]`, errors);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/schemas/assertion-signals/v1.json
+++ b/schemas/assertion-signals/v1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://synapt.dev/schemas/assertion-signals/v1.json",
+  "title": "SynaptAssertionSignals",
+  "description": "Raw linguistic signals for uncertainty handling.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": "1",
+      "description": "Sub-schema version."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "Extraction confidence: how sure is the LLM it correctly extracted this? (0.0-1.0)"
+    },
+    "negated": {
+      "type": "boolean",
+      "description": "The statement is negated (\"not\", \"no longer\", \"don't want\")."
+    },
+    "hedged": {
+      "type": "boolean",
+      "description": "Hedging language present (\"might\", \"maybe\", \"I think\", \"possibly\")."
+    },
+    "condition": {
+      "type": "string",
+      "description": "Conditional on something. Value is the condition text (\"if we get funding\")."
+    }
+  },
+  "required": ["version"],
+  "additionalProperties": false
+}

--- a/schemas/embedding/v1.json
+++ b/schemas/embedding/v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://synapt.dev/schemas/embedding/v1.json",
+  "title": "SynaptEmbedding",
+  "description": "Pre-computed embedding vector with provenance metadata.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": "1",
+      "description": "Sub-schema version."
+    },
+    "vector": {
+      "type": "array",
+      "items": { "type": "number" },
+      "description": "The embedding vector."
+    },
+    "model": {
+      "type": "string",
+      "description": "Model that produced this vector (URI format: \"provider://model-name\")."
+    },
+    "input": {
+      "type": "string",
+      "description": "What was embedded: \"source\", \"summary\", \"entities\", or custom string."
+    },
+    "dimensions": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Vector dimensionality (for validation without reading the full array)."
+    },
+    "space": {
+      "type": "string",
+      "description": "Semantic space identifier. Vectors are only comparable when they share a space."
+    },
+    "computed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this embedding was computed (ISO 8601)."
+    }
+  },
+  "required": ["version", "vector", "model", "input", "dimensions"],
+  "additionalProperties": false
+}

--- a/schemas/extraction/v1.json
+++ b/schemas/extraction/v1.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://synapt.dev/schemas/extraction/v1.json",
+  "title": "SynaptExtraction",
+  "description": "SynaptExtraction IL v1 — universal exchange format between text extraction and intelligence operations.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": "1",
+      "description": "Schema major version."
+    },
+    "extracted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the extraction was performed (ISO 8601)."
+    },
+    "source_id": {
+      "type": "string",
+      "description": "Customer's external document ID (e.g., prayer_id, session_id). Idempotency key for memory.ingest()."
+    },
+    "source_type": {
+      "type": "string",
+      "description": "Type of source document."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "Customer's user identifier."
+    },
+    "produced_by": {
+      "type": "string",
+      "description": "Model that produced the Stage 1 extraction (URI format: \"provider://model-name\")."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Primary extension. Identifies the dominant domain context. Format: \"vendor/kind\"."
+    },
+    "entities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/SynaptEntity" },
+      "description": "Extracted entities."
+    },
+    "goals": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/SynaptGoal" },
+      "description": "Extracted goals."
+    },
+    "themes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Topic strings."
+    },
+    "sentiment": {
+      "type": "string",
+      "description": "Overall emotional tone."
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-sentence summary, max 200 characters."
+    },
+    "facts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/SynaptFact" },
+      "description": "Extracted factual statements."
+    },
+    "temporal_refs": {
+      "type": "array",
+      "items": { "$ref": "https://synapt.dev/schemas/temporal-ref/v1.json" },
+      "description": "Temporal references extracted from the source."
+    },
+    "capabilities": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Which extraction capabilities the producer attempted to fill."
+    },
+    "embeddings": {
+      "type": "array",
+      "items": { "$ref": "https://synapt.dev/schemas/embedding/v1.json" },
+      "description": "Pre-computed embeddings."
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Domain-specific structured extras. Keys are scoped: \"vendor/kind\"."
+    }
+  },
+  "required": ["version", "extracted_at", "produced_by", "entities", "goals", "themes", "capabilities"],
+  "additionalProperties": false,
+  "$defs": {
+    "SynaptSourceRef": {
+      "$ref": "https://synapt.dev/schemas/source-ref/v1.json"
+    },
+    "SynaptAssertionSignals": {
+      "$ref": "https://synapt.dev/schemas/assertion-signals/v1.json"
+    },
+    "SynaptRelation": {
+      "type": "object",
+      "description": "Best-effort extracted edge between entities.",
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Extraction-local ID of the target entity."
+        },
+        "type": {
+          "type": "string",
+          "description": "Relationship type."
+        },
+        "origin": {
+          "type": "string",
+          "description": "How this relation was derived: \"explicit\", \"inferred\", or \"dependent\"."
+        },
+        "signals": { "$ref": "https://synapt.dev/schemas/assertion-signals/v1.json" }
+      },
+      "required": ["target", "type"],
+      "additionalProperties": false
+    },
+    "SynaptEntity": {
+      "type": "object",
+      "description": "Extracted entity with optional state, context, relations, and evidence.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Extraction-local ID. Stable within this extraction only."
+        },
+        "name": {
+          "type": "string",
+          "description": "Display name as it appeared in the source text."
+        },
+        "type": {
+          "type": "string",
+          "description": "Entity type: \"person\", \"place\", \"event\", \"concept\", \"organization\", \"object\", or custom string."
+        },
+        "state": {
+          "type": "string",
+          "description": "Current state described in text."
+        },
+        "context": {
+          "type": "string",
+          "description": "Role or relationship context."
+        },
+        "date_hint": {
+          "type": "string",
+          "description": "Relevant date hint."
+        },
+        "source": { "$ref": "https://synapt.dev/schemas/source-ref/v1.json" },
+        "signals": { "$ref": "https://synapt.dev/schemas/assertion-signals/v1.json" },
+        "relations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SynaptRelation" },
+          "description": "Relations from this entity to other entities."
+        }
+      },
+      "required": ["name", "type"],
+      "additionalProperties": false
+    },
+    "SynaptGoal": {
+      "type": "object",
+      "description": "Extracted goal with status tracking.",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Goal description."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["open", "resolved", "abandoned", "in_progress"],
+          "description": "Current goal status."
+        },
+        "entity_refs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extraction-local IDs of entities involved."
+        },
+        "stated_at": {
+          "type": "string",
+          "description": "When the goal was stated (ISO 8601)."
+        },
+        "resolved_at": {
+          "type": "string",
+          "description": "When the goal was resolved (ISO 8601)."
+        },
+        "source": { "$ref": "https://synapt.dev/schemas/source-ref/v1.json" },
+        "signals": { "$ref": "https://synapt.dev/schemas/assertion-signals/v1.json" }
+      },
+      "required": ["text", "status", "entity_refs"],
+      "additionalProperties": false
+    },
+    "SynaptFact": {
+      "type": "object",
+      "description": "Extracted factual statement.",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The factual statement."
+        },
+        "category": {
+          "type": "string",
+          "description": "Fact category."
+        },
+        "source": { "$ref": "https://synapt.dev/schemas/source-ref/v1.json" },
+        "signals": { "$ref": "https://synapt.dev/schemas/assertion-signals/v1.json" }
+      },
+      "required": ["text"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/source-ref/v1.json
+++ b/schemas/source-ref/v1.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://synapt.dev/schemas/source-ref/v1.json",
+  "title": "SynaptSourceRef",
+  "description": "Evidence anchor linking an extracted item back to the source text.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": "1",
+      "description": "Sub-schema version."
+    },
+    "snippet": {
+      "type": "string",
+      "description": "Verbatim or near-verbatim text from the source."
+    },
+    "offset_start": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Character offset of the start of the evidence span (reserved for future use)."
+    },
+    "offset_end": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Character offset of the end of the evidence span (reserved for future use)."
+    },
+    "sentence_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sentence index within the source text (reserved for future use)."
+    }
+  },
+  "required": ["version"],
+  "additionalProperties": false
+}

--- a/schemas/temporal-ref/v1.json
+++ b/schemas/temporal-ref/v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://synapt.dev/schemas/temporal-ref/v1.json",
+  "title": "SynaptTemporalRef",
+  "description": "Temporal reference with optional resolution.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": "1",
+      "description": "Sub-schema version."
+    },
+    "raw": {
+      "type": "string",
+      "description": "The temporal expression as it appeared in the source text."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["point", "range", "duration", "unresolved"],
+      "description": "Value class. Not all temporal expressions resolve to a single timestamp."
+    },
+    "resolved": {
+      "type": "string",
+      "description": "Resolved value (ISO 8601 for point/range, ISO 8601 duration for duration, omit for unresolved)."
+    },
+    "resolved_end": {
+      "type": "string",
+      "description": "End of range, if type is \"range\"."
+    },
+    "context": {
+      "type": "string",
+      "description": "Additional context for temporal resolution."
+    }
+  },
+  "required": ["version", "raw"],
+  "additionalProperties": false
+}

--- a/tests/extract/test_finalize.py
+++ b/tests/extract/test_finalize.py
@@ -1,0 +1,364 @@
+"""Tests for SynaptExtraction IL v1 finalization pipeline."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "packages" / "extract-py" / "src"))
+
+from synapt_extract.finalize import finalize_extraction, FinalizeContext
+
+
+def _llm_output(**overrides):
+    base = {
+        "extracted_at": "2026-04-26T00:00:00Z",
+        "entities": [{"name": "Mom", "type": "person"}],
+        "goals": [{"text": "Recovery", "status": "open", "entity_refs": []}],
+        "themes": ["Health"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestStage2Injection:
+
+    def test_injects_version(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(produced_by="openai://gpt-4o-mini"),
+        )
+        assert result.extraction["version"] == "1"
+
+    def test_injects_produced_by(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(produced_by="openai://gpt-4o-mini"),
+        )
+        assert result.extraction["produced_by"] == "openai://gpt-4o-mini"
+
+    def test_injects_user_id(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(produced_by="test://model", user_id="u123"),
+        )
+        assert result.extraction["user_id"] == "u123"
+
+    def test_injects_source_id(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(produced_by="test://model", source_id="prayer-001"),
+        )
+        assert result.extraction["source_id"] == "prayer-001"
+
+    def test_injects_kind(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(produced_by="test://model", kind="conversa/prayer"),
+        )
+        assert result.extraction["kind"] == "conversa/prayer"
+
+    def test_injects_extensions(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(
+                produced_by="test://model",
+                extensions={"conversa/prayer": {"category": "Health"}},
+            ),
+        )
+        assert result.extraction["extensions"]["conversa/prayer"]["category"] == "Health"
+
+
+class TestStage2Embeddings:
+
+    def test_injects_embedding_version(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(
+                produced_by="test://model",
+                embeddings=[{
+                    "vector": [0.1, 0.2, 0.3],
+                    "model": "openai://text-embedding-3-small",
+                    "input": "source",
+                    "dimensions": 3,
+                }],
+            ),
+        )
+        emb = result.extraction["embeddings"][0]
+        assert emb["version"] == "1"
+
+    def test_auto_populates_dimensions(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(
+                produced_by="test://model",
+                embeddings=[{
+                    "vector": [0.1, 0.2, 0.3, 0.4],
+                    "model": "test://emb",
+                    "input": "source",
+                }],
+            ),
+        )
+        emb = result.extraction["embeddings"][0]
+        assert emb["dimensions"] == 4
+
+
+class TestStage3SubSchemaVersions:
+
+    def test_injects_source_ref_version(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "source": {"snippet": "My mom"},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert result.extraction["entities"][0]["source"]["version"] == "1"
+
+    def test_injects_signals_version(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "signals": {"confidence": 0.9},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert result.extraction["entities"][0]["signals"]["version"] == "1"
+
+    def test_injects_temporal_ref_version(self):
+        result = finalize_extraction(
+            _llm_output(temporal_refs=[{"raw": "next week", "type": "range"}]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert result.extraction["temporal_refs"][0]["version"] == "1"
+
+    def test_strips_empty_source(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "source": {},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "source" not in result.extraction["entities"][0]
+
+    def test_strips_version_only_signals(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "signals": {"version": "1"},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "signals" not in result.extraction["entities"][0]
+
+    def test_injects_goal_source_version(self):
+        result = finalize_extraction(
+            _llm_output(goals=[{
+                "text": "Recovery",
+                "status": "open",
+                "entity_refs": [],
+                "source": {"snippet": "I hope she recovers"},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert result.extraction["goals"][0]["source"]["version"] == "1"
+
+    def test_injects_fact_source_version(self):
+        result = finalize_extraction(
+            _llm_output(facts=[{
+                "text": "Surgery happened",
+                "source": {"snippet": "Mom had surgery"},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert result.extraction["facts"][0]["source"]["version"] == "1"
+
+    def test_injects_relation_signals_version(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "id": "e1",
+                "name": "Mom",
+                "type": "person",
+                "relations": [{"target": "e2", "type": "parent_of", "signals": {"confidence": 0.8}}],
+            }, {
+                "id": "e2",
+                "name": "Me",
+                "type": "person",
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        rel = result.extraction["entities"][0]["relations"][0]
+        assert rel["signals"]["version"] == "1"
+
+
+class TestStage3CapabilityDetection:
+
+    def test_detects_entities(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "entities" in result.extraction["capabilities"]
+
+    def test_detects_entity_state(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "state": "recovering",
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "entity_state" in result.extraction["capabilities"]
+
+    def test_detects_entity_ids(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "id": "e1",
+                "name": "Mom",
+                "type": "person",
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "entity_ids" in result.extraction["capabilities"]
+
+    def test_detects_relations(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "id": "e1",
+                "name": "Mom",
+                "type": "person",
+                "relations": [{"target": "e2", "type": "knows"}],
+            }, {
+                "id": "e2",
+                "name": "Dad",
+                "type": "person",
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "relations" in result.extraction["capabilities"]
+
+    def test_detects_evidence_anchoring(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "source": {"snippet": "My mom"},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "evidence_anchoring" in result.extraction["capabilities"]
+
+    def test_detects_assertion_signals(self):
+        result = finalize_extraction(
+            _llm_output(entities=[{
+                "name": "Mom",
+                "type": "person",
+                "signals": {"confidence": 0.9},
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "assertion_signals" in result.extraction["capabilities"]
+
+    def test_detects_goal_timing(self):
+        result = finalize_extraction(
+            _llm_output(goals=[{
+                "text": "Recovery",
+                "status": "open",
+                "entity_refs": [],
+                "stated_at": "2026-04-20",
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert "goal_timing" in result.extraction["capabilities"]
+
+    def test_detects_summary_and_sentiment(self):
+        result = finalize_extraction(
+            _llm_output(summary="A prayer for healing.", sentiment="hopeful"),
+            FinalizeContext(produced_by="test://model"),
+        )
+        caps = result.extraction["capabilities"]
+        assert "summary" in caps
+        assert "sentiment" in caps
+
+    def test_detects_temporal_classes(self):
+        result = finalize_extraction(
+            _llm_output(temporal_refs=[{
+                "raw": "April 20 to May 1",
+                "type": "range",
+                "resolved": "2026-04-20",
+                "resolved_end": "2026-05-01",
+            }]),
+            FinalizeContext(produced_by="test://model"),
+        )
+        caps = result.extraction["capabilities"]
+        assert "temporal_refs" in caps
+        assert "temporal_classes" in caps
+
+
+class TestStage3Warnings:
+
+    def test_warns_on_hint_mismatch(self):
+        result = finalize_extraction(
+            _llm_output(),
+            FinalizeContext(
+                produced_by="test://model",
+                capabilities_hint=["relations"],
+            ),
+        )
+        assert any("relations" in w for w in result.warnings)
+
+    def test_warns_on_goal_entity_refs_without_entity_ids(self):
+        result = finalize_extraction(
+            _llm_output(
+                entities=[{"name": "Mom", "type": "person"}],
+                goals=[{"text": "Recovery", "status": "open", "entity_refs": ["e1"]}],
+            ),
+            FinalizeContext(produced_by="test://model"),
+        )
+        assert any("entity_ids" in w for w in result.warnings)
+
+
+class TestEndToEnd:
+
+    def test_finalized_extraction_passes_validation(self):
+        result = finalize_extraction(
+            _llm_output(
+                entities=[{
+                    "id": "e1",
+                    "name": "Mom",
+                    "type": "person",
+                    "state": "recovering",
+                    "source": {"snippet": "My mom is recovering"},
+                    "signals": {"confidence": 0.9},
+                }],
+                goals=[{
+                    "text": "Full recovery",
+                    "status": "open",
+                    "entity_refs": ["e1"],
+                    "stated_at": "2026-04-20",
+                }],
+                facts=[{"text": "Had surgery April 20", "source": {"snippet": "surgery"}}],
+                summary="Prayer for mom's recovery.",
+                sentiment="hopeful",
+            ),
+            FinalizeContext(
+                produced_by="openai://gpt-4o-mini",
+                user_id="user_123",
+                source_id="prayer-001",
+                kind="conversa/prayer",
+                extensions={"conversa/prayer": {"category": "Health"}},
+            ),
+        )
+        assert result.validation.valid, [f"{e.path}: {e.message}" for e in result.validation.errors]
+        assert result.extraction["version"] == "1"
+        assert result.extraction["produced_by"] == "openai://gpt-4o-mini"
+        assert "entities" in result.extraction["capabilities"]
+        assert "evidence_anchoring" in result.extraction["capabilities"]

--- a/tests/extract/test_validate.py
+++ b/tests/extract/test_validate.py
@@ -1,0 +1,317 @@
+"""Tests for SynaptExtraction IL v1 validation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "packages" / "extract-py" / "src"))
+
+from synapt_extract.validate import validate_extraction
+
+
+def _minimal_extraction(**overrides):
+    base = {
+        "version": "1",
+        "extracted_at": "2026-04-26T00:00:00Z",
+        "produced_by": "openai://gpt-4o-mini",
+        "entities": [],
+        "goals": [],
+        "themes": [],
+        "capabilities": ["entities", "goals", "themes"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidExtraction:
+
+    def test_minimal_valid(self):
+        result = validate_extraction(_minimal_extraction())
+        assert result.valid
+        assert result.errors == []
+
+    def test_full_extraction_valid(self):
+        doc = _minimal_extraction(
+            entities=[{
+                "id": "e1",
+                "name": "Mom",
+                "type": "person",
+                "state": "recovering",
+                "context": "family member",
+                "date_hint": "2026-04-20",
+                "source": {"version": "1", "snippet": "My mom is recovering"},
+                "signals": {"version": "1", "confidence": 0.9, "negated": False},
+                "relations": [{"target": "e2", "type": "parent_of"}],
+            }, {
+                "id": "e2",
+                "name": "Surgery",
+                "type": "event",
+            }],
+            goals=[{
+                "text": "Mom's full recovery",
+                "status": "open",
+                "entity_refs": ["e1"],
+                "stated_at": "2026-04-20T10:00:00Z",
+                "source": {"version": "1", "snippet": "I hope mom recovers"},
+                "signals": {"version": "1", "hedged": True},
+            }],
+            themes=["Health", "Family"],
+            summary="Prayer for mom's recovery after surgery.",
+            sentiment="hopeful",
+            facts=[{
+                "text": "Mom had surgery on April 20",
+                "category": "Health",
+                "source": {"version": "1", "snippet": "Mom had surgery"},
+            }],
+            temporal_refs=[{
+                "version": "1",
+                "raw": "April 20",
+                "type": "point",
+                "resolved": "2026-04-20",
+            }],
+            capabilities=[
+                "entities", "entity_state", "entity_context", "entity_ids",
+                "goals", "goal_timing", "goal_entity_refs",
+                "themes", "summary", "sentiment", "facts",
+                "temporal_refs", "temporal_classes",
+                "relations", "assertion_signals", "evidence_anchoring",
+            ],
+        )
+        result = validate_extraction(doc)
+        assert result.valid, [f"{e.path}: {e.message}" for e in result.errors]
+
+
+class TestMissingRequiredFields:
+
+    def test_missing_version(self):
+        doc = _minimal_extraction()
+        del doc["version"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "version" for e in result.errors)
+
+    def test_missing_extracted_at(self):
+        doc = _minimal_extraction()
+        del doc["extracted_at"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "extracted_at" for e in result.errors)
+
+    def test_missing_produced_by(self):
+        doc = _minimal_extraction()
+        del doc["produced_by"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "produced_by" for e in result.errors)
+
+    def test_missing_entities(self):
+        doc = _minimal_extraction()
+        del doc["entities"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "entities" for e in result.errors)
+
+    def test_missing_goals(self):
+        doc = _minimal_extraction()
+        del doc["goals"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "goals" for e in result.errors)
+
+    def test_missing_themes(self):
+        doc = _minimal_extraction()
+        del doc["themes"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "themes" for e in result.errors)
+
+    def test_missing_capabilities(self):
+        doc = _minimal_extraction()
+        del doc["capabilities"]
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any(e.path == "capabilities" for e in result.errors)
+
+    def test_not_an_object(self):
+        result = validate_extraction("not an object")
+        assert not result.valid
+        assert result.errors[0].message == "must be an object"
+
+    def test_null(self):
+        result = validate_extraction(None)
+        assert not result.valid
+
+
+class TestEntityValidation:
+
+    def test_entity_missing_name(self):
+        doc = _minimal_extraction(entities=[{"type": "person"}])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("name" in e.path for e in result.errors)
+
+    def test_entity_missing_type(self):
+        doc = _minimal_extraction(entities=[{"name": "Mom"}])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("type" in e.path for e in result.errors)
+
+    def test_entity_bad_source_ref_version(self):
+        doc = _minimal_extraction(entities=[{
+            "name": "Mom",
+            "type": "person",
+            "source": {"version": "2", "snippet": "test"},
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("source.version" in e.path for e in result.errors)
+
+    def test_entity_bad_signals_confidence(self):
+        doc = _minimal_extraction(entities=[{
+            "name": "Mom",
+            "type": "person",
+            "signals": {"version": "1", "confidence": 1.5},
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("confidence" in e.path for e in result.errors)
+
+    def test_entity_relation_missing_target(self):
+        doc = _minimal_extraction(entities=[{
+            "name": "Mom",
+            "type": "person",
+            "relations": [{"type": "knows"}],
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("target" in e.path for e in result.errors)
+
+
+class TestGoalValidation:
+
+    def test_goal_missing_text(self):
+        doc = _minimal_extraction(goals=[{
+            "status": "open",
+            "entity_refs": [],
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("text" in e.path for e in result.errors)
+
+    def test_goal_invalid_status(self):
+        doc = _minimal_extraction(goals=[{
+            "text": "recover",
+            "status": "pending",
+            "entity_refs": [],
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("status" in e.path for e in result.errors)
+
+    def test_goal_missing_entity_refs(self):
+        doc = _minimal_extraction(goals=[{
+            "text": "recover",
+            "status": "open",
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("entity_refs" in e.path for e in result.errors)
+
+
+class TestCapabilityValidation:
+
+    def test_unknown_capability(self):
+        doc = _minimal_extraction(capabilities=["entities", "psychic_powers"])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("psychic_powers" in e.message for e in result.errors)
+
+    def test_all_valid_capabilities(self):
+        from synapt_extract.schema import EXTRACTION_CAPABILITIES
+        doc = _minimal_extraction(capabilities=sorted(EXTRACTION_CAPABILITIES))
+        result = validate_extraction(doc)
+        assert result.valid
+
+
+class TestEmbeddingValidation:
+
+    def test_valid_embedding(self):
+        doc = _minimal_extraction(embeddings=[{
+            "version": "1",
+            "vector": [0.1, 0.2, 0.3],
+            "model": "openai://text-embedding-3-small",
+            "input": "source",
+            "dimensions": 3,
+        }])
+        result = validate_extraction(doc)
+        assert result.valid
+
+    def test_embedding_missing_vector(self):
+        doc = _minimal_extraction(embeddings=[{
+            "version": "1",
+            "model": "openai://text-embedding-3-small",
+            "input": "source",
+            "dimensions": 3,
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("vector" in e.path for e in result.errors)
+
+
+class TestTemporalRefValidation:
+
+    def test_valid_temporal_ref(self):
+        doc = _minimal_extraction(temporal_refs=[{
+            "version": "1",
+            "raw": "next Tuesday",
+            "type": "point",
+            "resolved": "2026-04-28",
+        }])
+        result = validate_extraction(doc)
+        assert result.valid
+
+    def test_invalid_temporal_type(self):
+        doc = _minimal_extraction(temporal_refs=[{
+            "version": "1",
+            "raw": "sometime",
+            "type": "vague",
+        }])
+        result = validate_extraction(doc)
+        assert not result.valid
+        assert any("type" in e.path for e in result.errors)
+
+
+class TestJsonSchemaFiles:
+
+    def test_all_schema_files_are_valid_json(self):
+        schema_dir = Path(__file__).resolve().parents[2] / "schemas"
+        for schema_file in schema_dir.rglob("*.json"):
+            content = schema_file.read_text()
+            parsed = json.loads(content)
+            assert "$schema" in parsed, f"{schema_file.name} missing $schema"
+            assert "$id" in parsed, f"{schema_file.name} missing $id"
+
+    def test_extraction_schema_references_sub_schemas(self):
+        schema_path = Path(__file__).resolve().parents[2] / "schemas" / "extraction" / "v1.json"
+        schema = json.loads(schema_path.read_text())
+        schema_str = json.dumps(schema)
+        assert "source-ref/v1.json" in schema_str
+        assert "embedding/v1.json" in schema_str
+        assert "assertion-signals/v1.json" in schema_str
+        assert "temporal-ref/v1.json" in schema_str
+
+    def test_extraction_schema_required_fields(self):
+        schema_path = Path(__file__).resolve().parents[2] / "schemas" / "extraction" / "v1.json"
+        schema = json.loads(schema_path.read_text())
+        required = schema["required"]
+        assert "version" in required
+        assert "extracted_at" in required
+        assert "produced_by" in required
+        assert "entities" in required
+        assert "goals" in required
+        assert "themes" in required
+        assert "capabilities" in required


### PR DESCRIPTION
## Summary

- 5 JSON Schema files for SynaptExtraction IL v1.0 (root + 4 sub-schemas)
- TypeScript interfaces and Python TypedDicts matching the locked spec
- `validateExtraction()` / `validate_extraction()` structural validators
- `finalizeExtraction()` / `finalize_extraction()` three-stage pipeline: LLM content -> client injection -> library normalization
- 56 tests passing

## Files

**JSON Schemas** (canonical definitions):
- `schemas/extraction/v1.json` - root schema with entity, goal, fact, relation $defs
- `schemas/source-ref/v1.json`, `schemas/embedding/v1.json`, `schemas/assertion-signals/v1.json`, `schemas/temporal-ref/v1.json`

**TypeScript** (`packages/extract/src/`): schema.ts, validate.ts, finalize.ts, index.ts

**Python** (`packages/extract-py/src/synapt_extract/`): schema.py, validate.py, finalize.py

## Premium boundary

OSS - schema definition package (public IL contract).

## Test plan

- [x] 56 tests: validation (required fields, entity/goal/fact/temporal/embedding/capability validation), finalization (stage 2 injection, stage 3 version injection, empty sub-schema stripping, capability detection, warnings), JSON Schema file integrity
- [x] Full extraction round-trip: LLM output -> finalizeExtraction -> validateExtraction passes

Closes #792

Generated with [Claude Code](https://claude.com/claude-code)