### PR TITLE
chore: gitignore test history.db artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 *.jsonl
 .synapt/
 .claude/
+history.db*


### PR DESCRIPTION
## What

Add `history.db*` to .gitignore. The integration test `tests/integrations/test_langchain_synapt_package.py` creates `history.db` (+ -shm, -wal companions) in the working directory as a fixture and does not clean up. The artifacts have been polluting the working tree as untracked files.

## Why

Caught during workspace cleanup before Sprint 37. The artifacts were 9 days old (Apr 24) sitting as untracked files in the synapt root.

## Followup

The actual fix is to change the test to use `tmpdir` / `tmp_path` instead of cwd. This PR is the immediate workspace-clean fix; the test fix can come later.

## Premium boundary

OSS infrastructure (.gitignore for tests).