### PR TITLE
fix: resolve beam_eval import path in CI

### DIFF
--- a/tests/evaluation/test_beam_eval.py
+++ b/tests/evaluation/test_beam_eval.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 
 def _load_beam_eval():
+    import sys
     repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
     module_path = repo_root / "evaluation" / "beam_eval.py"
     spec = importlib.util.spec_from_file_location("tests_beam_eval_module", module_path)
     assert spec and spec.loader


### PR DESCRIPTION
## Summary

- Fixes `ModuleNotFoundError: No module named 'evaluation.locomo_eval'` that was failing CI test collection on every PR
- Root cause: `test_beam_eval.py` loads `beam_eval.py` via `importlib` file path, but `beam_eval.py` does package-style `from evaluation.locomo_eval import ...` which requires repo root on `sys.path`
- Fix: add repo root to `sys.path` before loading, matching the pattern `codememo/eval.py` already uses

## Impact

This was silently failing test collection in CI across all PRs (confirmed on #802, #803, #666). The 4 beam eval tests were never running; now they will.

Premium boundary: core OSS (test infrastructure).

## Test plan

- [x] `pytest tests/evaluation/test_beam_eval.py -v` passes (4/4)
- [x] Import resolves in isolated environment without repo root on path

🤖 Generated with [Claude Code](https://claude.com/claude-code)