### PR TITLE
feat: threshold-aware reporting (research/ship-gate modes)

### DIFF
--- a/evaluation/recall-validation/harness.py
+++ b/evaluation/recall-validation/harness.py
@@ -23,6 +23,7 @@ from .models import (
     CATEGORY_LABELS,
     Fixture,
     FixtureResult,
+    Mode,
     Prayer,
     RetrievalResult,
     Surface,
@@ -194,9 +195,31 @@ def print_summary(suite_result: SuiteResult, report_path: Path) -> None:
             extra += f"  safety={scores['safety_accuracy']:.3f}"
         if "negative_precision" in scores:
             extra += f"  neg_prec={scores['negative_precision']:.3f}"
+        if "passed_count" in scores:
+            pc = int(scores["passed_count"])
+            fc = int(scores["failed_count"])
+            extra += f"  pass={pc}/{pc + fc}"
         print(f"  {label} (n={n}): P@5={p5:.3f}  R@10={r10:.3f}{extra}")
 
     print(f"\nReport written to: {report_path}")
+
+
+def check_ship_gate(
+    suite_result: SuiteResult,
+    ship_gate_categories: set[str],
+) -> list[str]:
+    """Return list of failure reasons if any ship-gating category is sub-threshold."""
+    failures = []
+    for cat_key, scores in suite_result.category_scores.items():
+        if cat_key not in ship_gate_categories:
+            continue
+        fc = int(scores.get("failed_count", 0))
+        if fc > 0:
+            label = CATEGORY_LABELS.get(cat_key, cat_key)
+            failures.append(
+                f"{label}: {fc} fixture(s) below threshold"
+            )
+    return failures
 
 
 def main() -> None:
@@ -214,23 +237,51 @@ def main() -> None:
         help="Validation surface: recall-with-oracle, routing-with-oracle, or end-to-end (default)",
     )
     parser.add_argument(
+        "--mode",
+        choices=[m.value for m in Mode],
+        default=Mode.RESEARCH.value,
+        help="research (report only, exit 0) or ship-gate (exit non-zero on threshold failure)",
+    )
+    parser.add_argument(
+        "--ship-gate-categories",
+        default=None,
+        help="Comma-separated category names that trigger non-zero exit in ship-gate mode",
+    )
+    parser.add_argument(
         "--baseline", default=None,
         help="Path to a baseline JSON report for three-way diff comparison",
     )
     args = parser.parse_args()
 
     surface = Surface(args.surface)
+    mode = Mode(args.mode)
 
     print(f"Loading suite: {args.suite}")
     suite_meta, prayer_history, fixtures = load_suite(args.suite)
     print(f"Loaded {len(fixtures)} fixtures across {len(suite_meta['categories'])} categories")
     print(f"Prayer history: {len(prayer_history)} prayers")
     print(f"Surface: {surface.value}")
+    print(f"Mode: {mode.value}")
 
     baseline_path = Path(args.baseline) if args.baseline else None
 
     suite_result, report_path = run_suite(args.suite, fixtures, surface, baseline_path)
     print_summary(suite_result, report_path)
+
+    if mode == Mode.SHIP_GATE:
+        if args.ship_gate_categories:
+            gate_cats = {c.strip() for c in args.ship_gate_categories.split(",")}
+        else:
+            gate_cats = set(suite_result.category_scores.keys())
+
+        failures = check_ship_gate(suite_result, gate_cats)
+        if failures:
+            print("\nSHIP-GATE FAILED:")
+            for f in failures:
+                print(f"  - {f}")
+            sys.exit(1)
+        else:
+            print("\nSHIP-GATE PASSED: all gated categories within threshold")
 
 
 if __name__ == "__main__":

--- a/evaluation/recall-validation/models.py
+++ b/evaluation/recall-validation/models.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 
+class Mode(str, Enum):
+    RESEARCH = "research"
+    SHIP_GATE = "ship-gate"
+
+
 class Surface(str, Enum):
     RECALL_WITH_ORACLE = "recall-with-oracle"
     ROUTING_WITH_ORACLE = "routing-with-oracle"
@@ -72,6 +77,8 @@ class Expected:
     matches: list[ExpectedMatch] = field(default_factory=list)
     response_routing: ResponseRouting | None = None
     expect_empty: bool = False
+    min_precision_at_5: float | None = None
+    min_recall_at_10: float | None = None
 
 
 @dataclass
@@ -108,6 +115,7 @@ class FixtureResult:
     safety_correct: bool | None = None
     negative_correct: bool | None = None
     rank_correlation: float | None = None
+    passed: bool | None = None
 
 
 @dataclass
@@ -135,6 +143,8 @@ def fixture_from_dict(d: dict) -> Fixture:
         matches=matches,
         response_routing=routing,
         expect_empty=d["expected"].get("expect_empty", False),
+        min_precision_at_5=d["expected"].get("min_precision_at_5"),
+        min_recall_at_10=d["expected"].get("min_recall_at_10"),
     )
 
     return Fixture(

--- a/evaluation/recall-validation/reporting.py
+++ b/evaluation/recall-validation/reporting.py
@@ -96,6 +96,8 @@ def render_fixture_diff(
         lines.append(f"Safety classification: {'CORRECT' if result.safety_correct else 'WRONG'}")
     if result.negative_correct is not None:
         lines.append(f"Negative case: {'CORRECT' if result.negative_correct else 'FALSE POSITIVE'}")
+    if result.passed is not None:
+        lines.append(f"Threshold: {'PASS' if result.passed else 'FAIL'}")
     lines.append("")
 
     lines.append("--- DIFF ---")
@@ -187,6 +189,7 @@ def write_report(
                 "rank_correlation": r.rank_correlation,
                 "safety_correct": r.safety_correct,
                 "negative_correct": r.negative_correct,
+                "passed": r.passed,
                 "retrieved": [
                     {"prayer_id": ret.prayer_id, "score": ret.score}
                     for ret in r.retrieved

--- a/evaluation/recall-validation/scoring.py
+++ b/evaluation/recall-validation/scoring.py
@@ -167,9 +167,8 @@ def aggregate_category_scores(results: list[FixtureResult]) -> dict[str, dict[st
             scores["mean_rank_correlation"] = sum(rank_vals) / len(rank_vals)
 
         passed_vals = [r.passed for r in cat_results if r.passed is not None]
-        if passed_vals:
-            scores["passed_count"] = sum(passed_vals)
-            scores["failed_count"] = len(passed_vals) - sum(passed_vals)
+        scores["passed_count"] = sum(passed_vals) if passed_vals else 0
+        scores["failed_count"] = (len(passed_vals) - sum(passed_vals)) if passed_vals else 0
 
         category_scores[cat] = scores
 

--- a/evaluation/recall-validation/scoring.py
+++ b/evaluation/recall-validation/scoring.py
@@ -100,6 +100,7 @@ def score_fixture(
         result.negative_correct = negative_case_correct(retrieved)
         result.precision_at_5 = 1.0 if not retrieved else 0.0
         result.recall_at_10 = 1.0
+        result.passed = result.negative_correct
         return result
 
     result.precision_at_5 = precision_at_k(retrieved, expected_ids, 5)
@@ -111,7 +112,26 @@ def score_fixture(
             routing, expected.response_routing.classification
         )
 
+    result.passed = evaluate_thresholds(result, expected)
     return result
+
+
+def evaluate_thresholds(result: FixtureResult, expected: Expected) -> bool | None:
+    """Check if fixture result meets its min thresholds. None if no thresholds set."""
+    if expected.expect_empty:
+        return result.negative_correct
+
+    has_threshold = False
+    if expected.min_precision_at_5 is not None:
+        has_threshold = True
+        if result.precision_at_5 < expected.min_precision_at_5:
+            return False
+    if expected.min_recall_at_10 is not None:
+        has_threshold = True
+        if result.recall_at_10 < expected.min_recall_at_10:
+            return False
+
+    return True if has_threshold else None
 
 
 def aggregate_category_scores(results: list[FixtureResult]) -> dict[str, dict[str, float]]:
@@ -145,6 +165,11 @@ def aggregate_category_scores(results: list[FixtureResult]) -> dict[str, dict[st
         rank_vals = [r.rank_correlation for r in cat_results if r.rank_correlation is not None]
         if rank_vals:
             scores["mean_rank_correlation"] = sum(rank_vals) / len(rank_vals)
+
+        passed_vals = [r.passed for r in cat_results if r.passed is not None]
+        if passed_vals:
+            scores["passed_count"] = sum(passed_vals)
+            scores["failed_count"] = len(passed_vals) - sum(passed_vals)
 
         category_scores[cat] = scores
 

--- a/evaluation/recall-validation/test_thresholds.py
+++ b/evaluation/recall-validation/test_thresholds.py
@@ -157,7 +157,7 @@ class TestAggregatePassFail:
         assert scores["direct_lookup"]["passed_count"] == 2
         assert scores["direct_lookup"]["failed_count"] == 1
 
-    def test_no_passed_field_when_no_thresholds(self):
+    def test_zero_counts_when_no_thresholds(self):
         results = [
             FixtureResult(
                 fixture_id="t-1", category=Category.DIRECT_LOOKUP,
@@ -165,7 +165,8 @@ class TestAggregatePassFail:
             ),
         ]
         scores = aggregate_category_scores(results)
-        assert "passed_count" not in scores["direct_lookup"]
+        assert scores["direct_lookup"]["passed_count"] == 0
+        assert scores["direct_lookup"]["failed_count"] == 0
 
 
 class TestShipGate:

--- a/evaluation/recall-validation/test_thresholds.py
+++ b/evaluation/recall-validation/test_thresholds.py
@@ -1,0 +1,207 @@
+"""Tests for threshold-aware reporting in recall-validation harness."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import importlib
+
+rv = importlib.import_module("recall-validation.models")
+rv_scoring = importlib.import_module("recall-validation.scoring")
+rv_harness = importlib.import_module("recall-validation.harness")
+
+Category = rv.Category
+Expected = rv.Expected
+ExpectedMatch = rv.ExpectedMatch
+FixtureResult = rv.FixtureResult
+Mode = rv.Mode
+RetrievalResult = rv.RetrievalResult
+SuiteResult = rv.SuiteResult
+
+evaluate_thresholds = rv_scoring.evaluate_thresholds
+score_fixture = rv_scoring.score_fixture
+aggregate_category_scores = rv_scoring.aggregate_category_scores
+
+check_ship_gate = rv_harness.check_ship_gate
+
+
+def _make_expected(
+    match_ids: list[str],
+    min_p5: float | None = None,
+    min_r10: float | None = None,
+    expect_empty: bool = False,
+) -> Expected:
+    matches = [
+        ExpectedMatch(prayer_id=pid, rank=i + 1, relevance="high")
+        for i, pid in enumerate(match_ids)
+    ]
+    return Expected(
+        matches=matches,
+        expect_empty=expect_empty,
+        min_precision_at_5=min_p5,
+        min_recall_at_10=min_r10,
+    )
+
+
+def _make_retrieved(ids: list[str], base_score: float = 0.9) -> list[RetrievalResult]:
+    return [
+        RetrievalResult(prayer_id=pid, score=base_score - i * 0.1)
+        for i, pid in enumerate(ids)
+    ]
+
+
+class TestEvaluateThresholds:
+    def test_no_thresholds_returns_none(self):
+        expected = _make_expected(["a", "b"])
+        result = FixtureResult(
+            fixture_id="test-1", category=Category.DIRECT_LOOKUP,
+            precision_at_5=0.4, recall_at_10=0.5,
+        )
+        assert evaluate_thresholds(result, expected) is None
+
+    def test_passes_when_above_thresholds(self):
+        expected = _make_expected(["a", "b"], min_p5=0.3, min_r10=0.5)
+        result = FixtureResult(
+            fixture_id="test-1", category=Category.DIRECT_LOOKUP,
+            precision_at_5=0.4, recall_at_10=1.0,
+        )
+        assert evaluate_thresholds(result, expected) is True
+
+    def test_fails_on_precision_below_threshold(self):
+        expected = _make_expected(["a", "b"], min_p5=0.8, min_r10=0.5)
+        result = FixtureResult(
+            fixture_id="test-1", category=Category.DIRECT_LOOKUP,
+            precision_at_5=0.4, recall_at_10=1.0,
+        )
+        assert evaluate_thresholds(result, expected) is False
+
+    def test_fails_on_recall_below_threshold(self):
+        expected = _make_expected(["a", "b"], min_p5=0.3, min_r10=0.9)
+        result = FixtureResult(
+            fixture_id="test-1", category=Category.DIRECT_LOOKUP,
+            precision_at_5=0.4, recall_at_10=0.5,
+        )
+        assert evaluate_thresholds(result, expected) is False
+
+    def test_negative_case_passes_when_correct(self):
+        expected = _make_expected([], expect_empty=True)
+        result = FixtureResult(
+            fixture_id="test-1", category=Category.NEGATIVE_CASE,
+            negative_correct=True,
+        )
+        assert evaluate_thresholds(result, expected) is True
+
+    def test_negative_case_fails_when_false_positive(self):
+        expected = _make_expected([], expect_empty=True)
+        result = FixtureResult(
+            fixture_id="test-1", category=Category.NEGATIVE_CASE,
+            negative_correct=False,
+        )
+        assert evaluate_thresholds(result, expected) is False
+
+
+class TestScoreFixturePassField:
+    def test_score_fixture_sets_passed_with_thresholds(self):
+        expected = _make_expected(["a", "b"], min_p5=0.3, min_r10=0.5)
+        retrieved = _make_retrieved(["a", "b", "c", "d", "e"])
+        result = score_fixture(
+            retrieved=retrieved, routing=None,
+            expected=expected, fixture_id="t-1",
+            category=Category.DIRECT_LOOKUP,
+        )
+        assert result.passed is True
+        assert result.precision_at_5 == 0.4
+
+    def test_score_fixture_no_thresholds_passed_is_none(self):
+        expected = _make_expected(["a", "b"])
+        retrieved = _make_retrieved(["a", "b", "c"])
+        result = score_fixture(
+            retrieved=retrieved, routing=None,
+            expected=expected, fixture_id="t-1",
+            category=Category.DIRECT_LOOKUP,
+        )
+        assert result.passed is None
+
+    def test_score_fixture_negative_case_sets_passed(self):
+        expected = Expected(expect_empty=True)
+        result = score_fixture(
+            retrieved=[], routing=None,
+            expected=expected, fixture_id="t-1",
+            category=Category.NEGATIVE_CASE,
+        )
+        assert result.passed is True
+
+
+class TestAggregatePassFail:
+    def test_category_scores_include_pass_fail_counts(self):
+        results = [
+            FixtureResult(
+                fixture_id="t-1", category=Category.DIRECT_LOOKUP,
+                precision_at_5=0.8, recall_at_10=1.0, passed=True,
+            ),
+            FixtureResult(
+                fixture_id="t-2", category=Category.DIRECT_LOOKUP,
+                precision_at_5=0.2, recall_at_10=0.5, passed=False,
+            ),
+            FixtureResult(
+                fixture_id="t-3", category=Category.DIRECT_LOOKUP,
+                precision_at_5=0.6, recall_at_10=0.8, passed=True,
+            ),
+        ]
+        scores = aggregate_category_scores(results)
+        assert scores["direct_lookup"]["passed_count"] == 2
+        assert scores["direct_lookup"]["failed_count"] == 1
+
+    def test_no_passed_field_when_no_thresholds(self):
+        results = [
+            FixtureResult(
+                fixture_id="t-1", category=Category.DIRECT_LOOKUP,
+                precision_at_5=0.8, recall_at_10=1.0, passed=None,
+            ),
+        ]
+        scores = aggregate_category_scores(results)
+        assert "passed_count" not in scores["direct_lookup"]
+
+
+class TestShipGate:
+    def _make_suite(self, category_scores: dict) -> SuiteResult:
+        return SuiteResult(
+            suite_name="test",
+            timestamp="2026-01-01",
+            category_scores=category_scores,
+        )
+
+    def test_ship_gate_passes_when_no_failures(self):
+        suite = self._make_suite({
+            "direct_lookup": {"count": 10, "mean_p_at_5": 0.8, "mean_r_at_10": 0.9, "passed_count": 10, "failed_count": 0},
+            "negative_case": {"count": 8, "mean_p_at_5": 1.0, "mean_r_at_10": 1.0, "passed_count": 8, "failed_count": 0},
+        })
+        failures = check_ship_gate(suite, {"direct_lookup", "negative_case"})
+        assert failures == []
+
+    def test_ship_gate_fails_when_gated_category_has_failures(self):
+        suite = self._make_suite({
+            "direct_lookup": {"count": 10, "mean_p_at_5": 0.3, "mean_r_at_10": 0.5, "passed_count": 3, "failed_count": 7},
+            "negative_case": {"count": 8, "mean_p_at_5": 1.0, "mean_r_at_10": 1.0, "passed_count": 8, "failed_count": 0},
+        })
+        failures = check_ship_gate(suite, {"direct_lookup", "negative_case"})
+        assert len(failures) == 1
+        assert "Direct Lookup" in failures[0]
+
+    def test_non_gated_categories_dont_trigger_failure(self):
+        suite = self._make_suite({
+            "direct_lookup": {"count": 10, "mean_p_at_5": 0.3, "mean_r_at_10": 0.5, "passed_count": 3, "failed_count": 7},
+            "temporal_queries": {"count": 8, "mean_p_at_5": 0.0, "mean_r_at_10": 0.0, "passed_count": 0, "failed_count": 8},
+        })
+        failures = check_ship_gate(suite, {"direct_lookup"})
+        assert len(failures) == 1
+        assert "Temporal" not in failures[0]
+
+    def test_research_mode_enum_exists(self):
+        assert Mode.RESEARCH.value == "research"
+        assert Mode.SHIP_GATE.value == "ship-gate"


### PR DESCRIPTION
## Summary

- Adds `--mode {research,ship-gate}` CLI flag to recall-validation harness
- Adds `--ship-gate-categories` CLI flag for designating which categories trigger non-zero exit
- Parses `min_precision_at_5` and `min_recall_at_10` thresholds from fixture metadata
- Computes per-fixture `passed` boolean and per-category `passed_count`/`failed_count` in JSON output
- Research mode (default): reports pass/fail, always exits 0
- Ship-gate mode: exits non-zero if any gated category has threshold failures

Implements harness gap #3 from Conversa v0-fixtures eval run (Apollo #dev pinned post, 2026-05-06). Design per Anchor methodology Q4 answer: v0 = research mode, v1+ flips default to ship-gate.

## Files changed

- `evaluation/recall-validation/models.py`: `Mode` enum, threshold fields on `Expected`, `passed` on `FixtureResult`
- `evaluation/recall-validation/scoring.py`: `evaluate_thresholds()`, pass/fail aggregation
- `evaluation/recall-validation/harness.py`: CLI flags, `check_ship_gate()`
- `evaluation/recall-validation/reporting.py`: `passed` in JSON and text output
- `evaluation/recall-validation/test_thresholds.py`: 15 tests

## Test plan

- [x] 15 new threshold tests passing
- [x] Skeleton suite (`v0-skeleton`) runs with `--mode research` (regression check)
- [x] Pass/fail counts appear correctly for negative case category (which has implicit thresholds)
- [ ] Review: verify threshold semantics match Anchor's Q4 methodology answer

Premium boundary: core OSS (eval infrastructure)