### PR TITLE
feat: date-aware temporal retrieval

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -1845,7 +1845,7 @@ class TranscriptIndex:
                 and before is None
                 and not _env_flag("SYNAPT_DISABLE_TEMPORAL_EXTRACTION")
             ):
-                extracted_after, extracted_before = extract_temporal_range(query)
+                extracted_after, extracted_before = extract_temporal_range(query, now=now)
                 if extracted_after is not None:
                     after = extracted_after
                     before = extracted_before

--- a/src/synapt/recall/hybrid.py
+++ b/src/synapt/recall/hybrid.py
@@ -756,6 +756,11 @@ _MONTH_DAY_PATTERN = re.compile(
     r"(?:\s*,?\s*(\d{4}))?\b",
     re.I,
 )
+_MONTH_DAY_AND_DAY_PATTERN = re.compile(
+    r"\b(" + "|".join(_MONTH_NAMES.keys()) + r")\s+(\d{1,2})(?:st|nd|rd|th)?"
+    r"\s+and\s+(\d{1,2})(?:st|nd|rd|th)?(?:\s*,?\s*(\d{4}))?\b",
+    re.I,
+)
 _ISO_DATE_PATTERN = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
 _MONTH_ONLY_PATTERN = re.compile(
     r"\b(?:in|during)\s+(" + "|".join(_MONTH_NAMES.keys()) + r")"
@@ -837,6 +842,23 @@ def extract_temporal_range(
         months = int(match.group(1))
         start = _add_months(now, -months)
         return (start.strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d"))
+
+    # Check "Month Day and Day[, Year]" before the single-day pattern so the
+    # trailing year applies to the whole range, not only the second day.
+    match = _MONTH_DAY_AND_DAY_PATTERN.search(query)
+    if match:
+        month_name = match.group(1).lower()
+        start_day = int(match.group(2))
+        end_day = int(match.group(3))
+        year = int(match.group(4)) if match.group(4) else now.year
+        month = _MONTH_NAMES.get(month_name)
+        if month and 1 <= start_day <= 31 and start_day <= end_day <= 31:
+            try:
+                start = datetime(year, month, start_day, tzinfo=timezone.utc)
+                end = datetime(year, month, end_day, tzinfo=timezone.utc) + timedelta(days=1)
+                return (start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
+            except ValueError:
+                pass
 
     # Check "Month Day[, Year]" pattern
     match = _MONTH_DAY_PATTERN.search(query)

--- a/tests/recall/test_date_aware_retrieval_spike.py
+++ b/tests/recall/test_date_aware_retrieval_spike.py
@@ -1,4 +1,8 @@
-"""Spike tests for date-aware retrieval on Conversa-shaped temporal fixtures."""
+"""Date-aware retrieval tests for Conversa-shaped temporal fixtures."""
+
+from datetime import datetime, timezone
+
+import pytest
 
 from synapt.recall.core import TranscriptChunk, TranscriptIndex
 
@@ -14,14 +18,162 @@ def _chunk(chunk_id: str, date: str, text: str) -> TranscriptChunk:
     )
 
 
-def _lookup_text(query: str, chunks: list[TranscriptChunk]) -> str:
+def _lookup_text(
+    query: str,
+    chunks: list[TranscriptChunk],
+    now: datetime | None = None,
+) -> str:
     index = TranscriptIndex(chunks)
     return index.lookup(
         query,
         max_chunks=10,
         max_tokens=4000,
         threshold_ratio=0,
+        now=now,
     )
+
+
+def test_lookup_uses_reference_clock_for_missing_year_temporal_queries():
+    result = _lookup_text(
+        "What did I pray about on May 31?",
+        [
+            _chunk(
+                "Calvin:2023",
+                "2023-05-31",
+                "I prayed with gratitude after the Tokyo concert.",
+            ),
+            _chunk(
+                "Calvin:2026",
+                "2026-05-31",
+                "I prayed about a future album release.",
+            ),
+        ],
+        now=datetime(2023, 6, 2, tzinfo=timezone.utc),
+    )
+
+    assert "Tokyo concert" in result
+    assert "future album release" not in result
+
+
+TEMPORAL_FIXTURE_CASES = [
+    (
+        "temporal:Calvin:01",
+        "What did I pray about on May 31, 2023?",
+        [(
+            "Calvin:conv-50:session_7:event_summary:Calvin:1:1",
+            "2023-05-31",
+            "expected Calvin May 31 Tokyo concert prayer",
+        )],
+    ),
+    (
+        "temporal:Caroline:02",
+        "Can you remind me what I prayed for on May 8 and 9, 2023?",
+        [
+            (
+                "Caroline:conv-26:session_1:event_summary:Caroline:1:1",
+                "2023-05-08",
+                "expected Caroline May 8 courage before entering the first community meeting",
+            ),
+            (
+                "Caroline:conv-26:session_1:event_summary:Caroline:1:2",
+                "2023-05-09",
+                "expected Caroline May 9 clarity after a hard conversation with her brother",
+            ),
+        ],
+    ),
+    (
+        "temporal:Evan:03",
+        "What was my prayer on January 1, 2024?",
+        [(
+            "Evan:conv-49:session_22:event_summary:Evan:2:2",
+            "2024-01-01",
+            "expected Evan January 1 prayer",
+        )],
+    ),
+    (
+        "temporal:Jolene:04",
+        "What did I pray for on March 28 and 29, 2023?",
+        [
+            (
+                "Jolene:conv-48:session_11:event_summary:Jolene:1:1",
+                "2023-03-28",
+                "expected Jolene March 28 courage before the oncology appointment",
+            ),
+            (
+                "Jolene:conv-48:session_11:event_summary:Jolene:1:2",
+                "2023-03-29",
+                "expected Jolene March 29 gratitude after the lab results brought relief",
+            ),
+        ],
+    ),
+    (
+        "temporal:Jon:05",
+        "What was my prayer on August 6, 2023?",
+        [(
+            "Jon:conv-30:session_19:observation:Jon:3:2",
+            "2023-08-06",
+            "expected Jon August 6 prayer",
+        )],
+    ),
+    (
+        "temporal:James:06",
+        "Can you tell me what I prayed about on November 1, 2022?",
+        [(
+            "James:conv-47:session_29:event_summary:James:1:2",
+            "2022-11-01",
+            "expected James November 1 prayer",
+        )],
+    ),
+    (
+        "temporal:Joanna:07",
+        "What did I pray for on April 17, 2022?",
+        [(
+            "Joanna:conv-42:session_8:observation:Joanna:3:1",
+            "2022-04-17",
+            "expected Joanna April 17 prayer",
+        )],
+    ),
+    (
+        "temporal:Andrew:08",
+        "What was my prayer on October 1, 2023?",
+        [(
+            "Andrew:conv-44:session_20:observation:Andrew:6:1",
+            "2023-10-01",
+            "expected Andrew October 1 prayer",
+        )],
+    ),
+]
+
+
+@pytest.mark.parametrize("fixture_id,query,expected_chunks", TEMPORAL_FIXTURE_CASES)
+def test_all_current_temporal_fixture_queries_filter_by_structured_date(
+    fixture_id: str,
+    query: str,
+    expected_chunks: list[tuple[str, str, str]],
+):
+    chunks = [
+        _chunk(chunk_id, date, text)
+        for chunk_id, date, text in expected_chunks
+    ]
+    chunks.extend([
+        _chunk(
+            f"{fixture_id}:noise-before",
+            "2022-01-01",
+            f"noise before {fixture_id}",
+        ),
+        _chunk(
+            f"{fixture_id}:noise-after",
+            "2025-01-01",
+            f"noise after {fixture_id}",
+        ),
+    ])
+
+    result = _lookup_text(query, chunks)
+
+    for _, _, text in expected_chunks:
+        assert text in result
+    assert f"noise before {fixture_id}" not in result
+    assert f"noise after {fixture_id}" not in result
 
 
 def test_exact_date_query_retrieves_calvin_may_31_fixture_shape():

--- a/tests/recall/test_date_aware_retrieval_spike.py
+++ b/tests/recall/test_date_aware_retrieval_spike.py
@@ -1,0 +1,120 @@
+"""Spike tests for date-aware retrieval on Conversa-shaped temporal fixtures."""
+
+from synapt.recall.core import TranscriptChunk, TranscriptIndex
+
+
+def _chunk(chunk_id: str, date: str, text: str) -> TranscriptChunk:
+    return TranscriptChunk(
+        id=chunk_id,
+        session_id=chunk_id.replace(":", "-")[:36].ljust(36, "0"),
+        timestamp=date,
+        turn_index=0,
+        user_text=text,
+        assistant_text="",
+    )
+
+
+def _lookup_text(query: str, chunks: list[TranscriptChunk]) -> str:
+    index = TranscriptIndex(chunks)
+    return index.lookup(
+        query,
+        max_chunks=10,
+        max_tokens=4000,
+        threshold_ratio=0,
+    )
+
+
+def test_exact_date_query_retrieves_calvin_may_31_fixture_shape():
+    result = _lookup_text(
+        "What did I pray about on May 31, 2023?",
+        [
+            _chunk(
+                "Calvin:conv-50:session_7:event_summary:Calvin:1:1",
+                "2023-05-31",
+                "Thank you for the Frank Ocean Tour in Tokyo and the shared moments on stage.",
+            ),
+            _chunk(
+                "Calvin:other",
+                "2023-05-30",
+                "Please help me prepare for tomorrow's performance.",
+            ),
+        ],
+    )
+
+    assert "Frank Ocean Tour in Tokyo" in result
+    assert "tomorrow's performance" not in result
+
+
+def test_exact_date_query_retrieves_james_november_1_fixture_shape():
+    result = _lookup_text(
+        "Can you tell me what I prayed about on November 1, 2022?",
+        [
+            _chunk(
+                "James:conv-47:session_29:event_summary:James:1:2",
+                "2022-11-01",
+                "I asked for steadiness while navigating a fragile family conversation.",
+            ),
+            _chunk(
+                "James:other",
+                "2022-10-31",
+                "I prayed about patience before the holiday gathering.",
+            ),
+        ],
+    )
+
+    assert "fragile family conversation" in result
+    assert "holiday gathering" not in result
+
+
+def test_paired_date_query_retrieves_caroline_may_8_and_9_fixture_shape():
+    result = _lookup_text(
+        "Can you remind me what I prayed for on May 8 and 9, 2023?",
+        [
+            _chunk(
+                "Caroline:conv-26:session_1:event_summary:Caroline:1:1",
+                "2023-05-08",
+                "I prayed for courage before starting the LGBTQ support group.",
+            ),
+            _chunk(
+                "Caroline:conv-26:session_1:event_summary:Caroline:1:2",
+                "2023-05-09",
+                "I prayed for clarity after the first support group conversation.",
+            ),
+            _chunk(
+                "Caroline:other",
+                "2023-05-10",
+                "I prayed about unrelated school scheduling.",
+            ),
+        ],
+    )
+
+    assert "starting the LGBTQ support group" in result
+    assert "first support group conversation" in result
+    assert "unrelated school scheduling" not in result
+
+
+def test_paired_date_query_retrieves_jolene_march_28_and_29_fixture_shape():
+    result = _lookup_text(
+        "What did I pray for on March 28 and 29, 2023?",
+        [
+            _chunk(
+                "Jolene:conv-48:session_11:event_summary:Jolene:1:1",
+                "2023-03-28",
+                "I prayed for peace while preparing for the medical appointment.",
+            ),
+            _chunk(
+                "Jolene:conv-48:session_11:event_summary:Jolene:1:2",
+                "2023-03-29",
+                "I prayed with gratitude after the appointment brought better news.",
+            ),
+            _chunk(
+                "Jolene:other",
+                "2023-03-30",
+                "I prayed about a different work conflict.",
+            ),
+        ],
+    )
+
+    assert "preparing for the medical appointment" in result
+    assert "appointment brought better news" in result
+    assert "different work conflict" not in result

--- a/tests/recall/test_hybrid.py
+++ b/tests/recall/test_hybrid.py
@@ -446,6 +446,22 @@ class TestTemporalExtraction:
         assert after == "2025-02-28"
         assert before == "2025-03-01"
 
+    def test_month_day_and_day_year(self):
+        after, before = extract_temporal_range(
+            "what did I pray for on May 8 and 9, 2023?",
+            now=self.NOW,
+        )
+        assert after == "2023-05-08"
+        assert before == "2023-05-10"
+
+    def test_month_day_and_day_without_year_defaults_current_year(self):
+        after, before = extract_temporal_range(
+            "what happened on March 28 and 29?",
+            now=self.NOW,
+        )
+        assert after == "2026-03-28"
+        assert before == "2026-03-30"
+
     def test_iso_date(self):
         after, before = extract_temporal_range("changes from 2026-03-01", now=self.NOW)
         assert after == "2026-03-01"


### PR DESCRIPTION
Promotes the date-aware temporal retrieval spike into the implementation contract for Conversa v0.5.

Changes:
- Adds same-month paired-date parsing such as `May 8 and 9, 2023` and `March 28 and 29, 2023`.
- Propagates `TranscriptIndex.lookup(now=...)` into temporal extraction so missing-year historical queries use the caller's deterministic reference clock instead of wall-clock year.
- Adds all eight current Conversa Temporal fixture-shaped retrieval tests over structured timestamps.
- Keeps scope narrow: query-side bounded date parsing over structured `TranscriptChunk.timestamp`; no index-side event-date extraction.

Pre-registered measurement:
- Before: keyword baseline Temporal P@5=0.000, R@10=0.000.
- Before: cosine shim Temporal P@5=0.075, R@10=0.375.
- Prediction: near-ceiling once `synthetic_date` maps to structured timestamp because current Temporal fixtures are exact-date bounded queries.

After measurement:
- Date-aware recall over `/tmp/v0-fixtures/docs/eval/v0-fixtures/temporal-queries.jsonl`: P@5=1.000, R@10=1.000 across 8/8 fixtures.
- Measurement setup: each fixture `user_history[].synthetic_date` mapped to `TranscriptChunk.timestamp`; lookup result IDs parsed from inert `PRAYER_ID` markers in assistant text for scoring.

Validation:
- `PYTHONPATH=src python -m pytest tests/recall/test_hybrid.py tests/recall/test_date_aware_retrieval_spike.py -q` -> 90 passed.
- `python -m ruff check src/synapt/recall/core.py src/synapt/recall/hybrid.py tests/recall/test_hybrid.py tests/recall/test_date_aware_retrieval_spike.py` still reports pre-existing lint debt in these files; no new finding was reported for `tests/recall/test_date_aware_retrieval_spike.py`.

Premium boundary: core OSS recall retrieval primitive. No identity/org/premium behavior.
