### PR TITLE
fix: negative-case P@5 score-threshold gate for dense retrievers

### DIFF
--- a/evaluation/recall-validation/scoring.py
+++ b/evaluation/recall-validation/scoring.py
@@ -98,7 +98,8 @@ def score_fixture(
 
     if expected.expect_empty:
         result.negative_correct = negative_case_correct(retrieved)
-        result.precision_at_5 = 1.0 if not retrieved else 0.0
+        confident = [r for r in retrieved if r.score >= 0.5]
+        result.precision_at_5 = 1.0 if not confident else 0.0
         result.recall_at_10 = 1.0
         result.passed = result.negative_correct
         return result

--- a/evaluation/recall-validation/test_thresholds.py
+++ b/evaluation/recall-validation/test_thresholds.py
@@ -136,6 +136,28 @@ class TestScoreFixturePassField:
         )
         assert result.passed is True
 
+    def test_score_fixture_negative_case_low_scores_p5_correct(self):
+        expected = Expected(expect_empty=True)
+        low_score_results = _make_retrieved(["x", "y", "z"], base_score=0.3)
+        result = score_fixture(
+            retrieved=low_score_results, routing=None,
+            expected=expected, fixture_id="t-1",
+            category=Category.NEGATIVE_CASE,
+        )
+        assert result.precision_at_5 == 1.0
+        assert result.negative_correct is True
+
+    def test_score_fixture_negative_case_high_scores_p5_zero(self):
+        expected = Expected(expect_empty=True)
+        high_score_results = _make_retrieved(["x", "y", "z"], base_score=0.9)
+        result = score_fixture(
+            retrieved=high_score_results, routing=None,
+            expected=expected, fixture_id="t-1",
+            category=Category.NEGATIVE_CASE,
+        )
+        assert result.precision_at_5 == 0.0
+        assert result.negative_correct is False
+
 
 class TestAggregatePassFail:
     def test_category_scores_include_pass_fail_counts(self):


### PR DESCRIPTION
## Summary

- Filter negative-case retrieved results by 0.5 score threshold before computing P@5
- Dense retrievers (cosine, embedding-based) always return k results, making P@5=0.0 for all negative cases regardless of result quality
- Only confident results (score >= 0.5) now count as false positives in P@5
- `negative_case_correct` already uses the same 0.5 threshold; P@5 now aligns with it
- 2 new tests covering low-score (P@5=1.0) and high-score (P@5=0.0) scenarios

Found during v0.5 eval delta run: cosine retrieval scored P@5=0.000 on all negative cases (vs keyword's 0.625) because cosine always returns 10 results. With this fix, low-confidence results are filtered before P@5 computation.

Premium boundary: core OSS (recall-validation harness scoring infrastructure).

## Test plan

- [x] `test_score_fixture_negative_case_low_scores_p5_correct` — low-score results filtered, P@5=1.0
- [x] `test_score_fixture_negative_case_high_scores_p5_zero` — high-score results kept, P@5=0.0
- [x] All 17 threshold tests pass
- [ ] Re-run v0.5 cosine eval with patched harness to verify negative case P@5 lifts from 0.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)