### PR TITLE
feat: per-fixture user_history and Conversa format support

### DIFF
--- a/evaluation/recall-validation/harness.py
+++ b/evaluation/recall-validation/harness.py
@@ -44,6 +44,14 @@ FIXTURES_DIR = HARNESS_DIR / "fixtures"
 RESULTS_DIR = HARNESS_DIR / "results"
 
 
+def _load_fixture_file(path: Path) -> list[dict]:
+    """Load fixtures from JSON array or JSONL file."""
+    text = path.read_text().strip()
+    if path.suffix == ".jsonl":
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+    return json.loads(text)
+
+
 def load_suite(suite_name: str) -> tuple[dict, list[Prayer], list[Fixture]]:
     suite_dir = FIXTURES_DIR / suite_name
     if not suite_dir.is_dir():
@@ -57,8 +65,11 @@ def load_suite(suite_name: str) -> tuple[dict, list[Prayer], list[Fixture]]:
 
     suite_meta = json.loads(suite_meta_path.read_text())
 
-    prayer_history_path = suite_dir / suite_meta["shared_prayer_history"]
-    prayer_history = [Prayer(**p) for p in json.loads(prayer_history_path.read_text())]
+    shared_history_file = suite_meta.get("shared_prayer_history")
+    prayer_history: list[Prayer] = []
+    if shared_history_file:
+        prayer_history_path = suite_dir / shared_history_file
+        prayer_history = [Prayer(**p) for p in json.loads(prayer_history_path.read_text())]
 
     fixtures: list[Fixture] = []
     for category, filename in suite_meta["fixture_files"].items():
@@ -66,9 +77,11 @@ def load_suite(suite_name: str) -> tuple[dict, list[Prayer], list[Fixture]]:
         if not fixture_path.exists():
             print(f"WARNING: fixture file missing: {fixture_path}", file=sys.stderr)
             continue
-        raw_fixtures = json.loads(fixture_path.read_text())
+        raw_fixtures = _load_fixture_file(fixture_path)
         for raw in raw_fixtures:
-            raw["prayer_history"] = [vars(p) for p in prayer_history]
+            has_own_history = "user_history" in raw or "prayer_history" in raw
+            if not has_own_history and prayer_history:
+                raw["prayer_history"] = [vars(p) for p in prayer_history]
             fixtures.append(fixture_from_dict(raw))
 
     return suite_meta, prayer_history, fixtures

--- a/evaluation/recall-validation/models.py
+++ b/evaluation/recall-validation/models.py
@@ -127,32 +127,88 @@ class SuiteResult:
     overall_scores: dict[str, float] = field(default_factory=dict)
 
 
-def fixture_from_dict(d: dict) -> Fixture:
-    """Deserialize a fixture from a JSON-compatible dict."""
-    prayers = [Prayer(**p) for p in d["prayer_history"]]
+def _prayer_from_dict(d: dict) -> Prayer:
+    """Deserialize a Prayer, handling both harness-native and Conversa field names."""
+    return Prayer(
+        id=d["id"],
+        date=d.get("date") or d.get("synthetic_date", ""),
+        text=d["text"],
+        themes=d.get("themes", []),
+        entities=d.get("entities", []),
+        summary=d.get("summary", ""),
+    )
 
-    matches = [ExpectedMatch(**m) for m in d["expected"].get("matches", [])]
-    routing_data = d["expected"].get("response_routing")
+
+def _parse_expected(d: dict) -> Expected:
+    """Parse expected block from harness-native format."""
+    matches = [ExpectedMatch(**m) for m in d.get("matches", [])]
+    routing_data = d.get("response_routing")
     routing = None
     if routing_data:
         routing = ResponseRouting(
             classification=RoutingClassification(routing_data["classification"]),
             safety_critical=routing_data.get("safety_critical", False),
         )
-    expected = Expected(
+    return Expected(
         matches=matches,
         response_routing=routing,
-        expect_empty=d["expected"].get("expect_empty", False),
-        min_precision_at_5=d["expected"].get("min_precision_at_5"),
-        min_recall_at_10=d["expected"].get("min_recall_at_10"),
+        expect_empty=d.get("expect_empty", False),
+        min_precision_at_5=d.get("min_precision_at_5"),
+        min_recall_at_10=d.get("min_recall_at_10"),
     )
+
+
+def _parse_expected_matches(d: dict) -> Expected:
+    """Parse expected block from Conversa fixture format (expected_matches)."""
+    ranked = d.get("ranked", [])
+    matches = [
+        ExpectedMatch(prayer_id=pid, rank=i + 1, relevance="high")
+        for i, pid in enumerate(ranked)
+    ]
+    expect_empty = d.get("max_results") == 0 and not ranked
+    return Expected(
+        matches=matches,
+        expect_empty=expect_empty,
+        min_precision_at_5=d.get("min_precision_at_5"),
+        min_recall_at_10=d.get("min_recall_at_10"),
+    )
+
+
+CATEGORY_ALIASES: dict[str, str] = {
+    "direct": Category.DIRECT_LOOKUP,
+    "thematic": Category.THEMATIC_RECALL,
+    "negative": Category.NEGATIVE_CASE,
+    "temporal": Category.TEMPORAL_QUERIES,
+    "pattern": Category.PATTERN_RECOGNITION,
+    "action_followup": Category.ACTION_FOLLOWUP,
+}
+
+
+def fixture_from_dict(d: dict) -> Fixture:
+    """Deserialize a fixture from a JSON-compatible dict.
+
+    Supports both harness-native format (prayer_history, expected) and
+    Conversa fixture format (user_history, expected_matches).
+    """
+    history_raw = d.get("prayer_history") or d.get("user_history", [])
+    prayers = [_prayer_from_dict(p) for p in history_raw]
+
+    if "expected" in d:
+        expected = _parse_expected(d["expected"])
+    elif "expected_matches" in d:
+        expected = _parse_expected_matches(d["expected_matches"])
+    else:
+        expected = Expected()
+
+    cat_raw = d["category"]
+    category = Category(CATEGORY_ALIASES.get(cat_raw, cat_raw))
 
     return Fixture(
         id=d["id"],
-        category=Category(d["category"]),
-        description=d["description"],
+        category=category,
+        description=d.get("description") or d.get("notes", ""),
         prayer_history=prayers,
         query=d["query"],
-        query_date=d["query_date"],
+        query_date=d.get("query_date", ""),
         expected=expected,
     )

--- a/evaluation/recall-validation/test_fixture_loading.py
+++ b/evaluation/recall-validation/test_fixture_loading.py
@@ -1,0 +1,363 @@
+"""Tests for per-fixture user_history and Conversa format compatibility."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import importlib
+
+rv = importlib.import_module("recall-validation.models")
+rv_harness = importlib.import_module("recall-validation.harness")
+
+Category = rv.Category
+Expected = rv.Expected
+Fixture = rv.Fixture
+Prayer = rv.Prayer
+fixture_from_dict = rv.fixture_from_dict
+_prayer_from_dict = rv._prayer_from_dict
+_parse_expected_matches = rv._parse_expected_matches
+CATEGORY_ALIASES = rv.CATEGORY_ALIASES
+
+load_suite = rv_harness.load_suite
+_load_fixture_file = rv_harness._load_fixture_file
+
+
+class TestPrayerFromDict:
+    def test_harness_native_format(self):
+        d = {
+            "id": "prayer-1",
+            "date": "2023-01-15",
+            "text": "A prayer about hope.",
+            "themes": ["hope"],
+            "entities": ["God"],
+            "summary": "Hope prayer",
+        }
+        p = _prayer_from_dict(d)
+        assert p.id == "prayer-1"
+        assert p.date == "2023-01-15"
+        assert p.text == "A prayer about hope."
+        assert p.themes == ["hope"]
+        assert p.entities == ["God"]
+        assert p.summary == "Hope prayer"
+
+    def test_conversa_format_uses_synthetic_date(self):
+        d = {
+            "id": "Calvin:conv-50:session_1:event_summary:Calvin:1:1",
+            "text": "A prayer text.",
+            "synthetic_date": "2023-03-23",
+            "categories": ["transition", "work"],
+            "emotional_register": "thanksgiving",
+            "themes": ["thanksgiving", "transition"],
+            "source_situation_id": "conv-50:session_1:event_summary:Calvin:1",
+        }
+        p = _prayer_from_dict(d)
+        assert p.id == "Calvin:conv-50:session_1:event_summary:Calvin:1:1"
+        assert p.date == "2023-03-23"
+        assert p.themes == ["thanksgiving", "transition"]
+        assert p.entities == []
+        assert p.summary == ""
+
+    def test_missing_optional_fields_default(self):
+        d = {"id": "p-1", "text": "Minimal prayer."}
+        p = _prayer_from_dict(d)
+        assert p.date == ""
+        assert p.themes == []
+        assert p.entities == []
+        assert p.summary == ""
+
+    def test_date_takes_precedence_over_synthetic_date(self):
+        d = {
+            "id": "p-1",
+            "text": "Text.",
+            "date": "2023-01-01",
+            "synthetic_date": "2023-06-01",
+        }
+        p = _prayer_from_dict(d)
+        assert p.date == "2023-01-01"
+
+
+class TestParseExpectedMatches:
+    def test_ranked_list_becomes_expected_matches(self):
+        d = {
+            "ranked": ["prayer-a", "prayer-b", "prayer-c"],
+            "min_precision_at_5": 0.6,
+            "min_recall_at_10": 1.0,
+        }
+        expected = _parse_expected_matches(d)
+        assert len(expected.matches) == 3
+        assert expected.matches[0].prayer_id == "prayer-a"
+        assert expected.matches[0].rank == 1
+        assert expected.matches[1].rank == 2
+        assert expected.matches[2].rank == 3
+        assert all(m.relevance == "high" for m in expected.matches)
+        assert expected.min_precision_at_5 == 0.6
+        assert expected.min_recall_at_10 == 1.0
+        assert expected.expect_empty is False
+
+    def test_empty_ranked_with_max_results_zero_is_negative(self):
+        d = {
+            "ranked": [],
+            "min_precision_at_5": 1,
+            "min_recall_at_10": 1,
+            "max_results": 0,
+        }
+        expected = _parse_expected_matches(d)
+        assert expected.expect_empty is True
+        assert len(expected.matches) == 0
+
+    def test_empty_ranked_without_max_results_not_negative(self):
+        d = {"ranked": []}
+        expected = _parse_expected_matches(d)
+        assert expected.expect_empty is False
+
+
+class TestCategoryAliases:
+    def test_all_conversa_short_names_resolve(self):
+        assert CATEGORY_ALIASES["direct"] == Category.DIRECT_LOOKUP
+        assert CATEGORY_ALIASES["thematic"] == Category.THEMATIC_RECALL
+        assert CATEGORY_ALIASES["negative"] == Category.NEGATIVE_CASE
+        assert CATEGORY_ALIASES["temporal"] == Category.TEMPORAL_QUERIES
+        assert CATEGORY_ALIASES["pattern"] == Category.PATTERN_RECOGNITION
+        assert CATEGORY_ALIASES["action_followup"] == Category.ACTION_FOLLOWUP
+
+
+class TestFixtureFromDict:
+    def test_conversa_format(self):
+        d = {
+            "id": "direct:Calvin:01",
+            "category": "direct",
+            "persona_id": "Calvin",
+            "query": "What about my mansion?",
+            "user_history": [
+                {
+                    "id": "Calvin:p1",
+                    "text": "A prayer about my mansion.",
+                    "synthetic_date": "2023-03-23",
+                    "themes": ["transition"],
+                },
+                {
+                    "id": "Calvin:p2",
+                    "text": "Another prayer.",
+                    "synthetic_date": "2023-04-01",
+                    "themes": ["gratitude"],
+                },
+            ],
+            "expected_matches": {
+                "ranked": ["Calvin:p1"],
+                "min_precision_at_5": 0.8,
+                "min_recall_at_10": 1.0,
+            },
+            "expected_routing": None,
+            "notes": "Direct lookup for mansion purchase.",
+        }
+        f = fixture_from_dict(d)
+        assert f.id == "direct:Calvin:01"
+        assert f.category == Category.DIRECT_LOOKUP
+        assert len(f.prayer_history) == 2
+        assert f.prayer_history[0].date == "2023-03-23"
+        assert f.expected.matches[0].prayer_id == "Calvin:p1"
+        assert f.expected.min_precision_at_5 == 0.8
+        assert f.description == "Direct lookup for mansion purchase."
+        assert f.query_date == ""
+
+    def test_harness_native_format(self):
+        d = {
+            "id": "test-1",
+            "category": "direct_lookup",
+            "description": "Test fixture",
+            "prayer_history": [
+                {
+                    "id": "p-1",
+                    "date": "2023-01-01",
+                    "text": "A prayer.",
+                    "themes": [],
+                    "entities": [],
+                    "summary": "",
+                },
+            ],
+            "query": "Test query",
+            "query_date": "2023-06-01",
+            "expected": {
+                "matches": [
+                    {"prayer_id": "p-1", "rank": 1, "relevance": "high"},
+                ],
+            },
+        }
+        f = fixture_from_dict(d)
+        assert f.id == "test-1"
+        assert f.category == Category.DIRECT_LOOKUP
+        assert f.prayer_history[0].date == "2023-01-01"
+        assert f.expected.matches[0].prayer_id == "p-1"
+        assert f.description == "Test fixture"
+        assert f.query_date == "2023-06-01"
+
+    def test_negative_case_conversa_format(self):
+        d = {
+            "id": "negative:Calvin:01",
+            "category": "negative",
+            "persona_id": "Calvin",
+            "query": "What about the Mars rover?",
+            "user_history": [
+                {"id": "Calvin:p1", "text": "A prayer.", "synthetic_date": "2023-01-01"},
+            ],
+            "expected_matches": {
+                "ranked": [],
+                "min_precision_at_5": 1,
+                "min_recall_at_10": 1,
+                "max_results": 0,
+            },
+            "expected_routing": None,
+            "notes": "Unrelated query.",
+        }
+        f = fixture_from_dict(d)
+        assert f.expected.expect_empty is True
+        assert len(f.expected.matches) == 0
+
+
+class TestLoadFixtureFile:
+    def test_json_array(self, tmp_path):
+        data = [{"id": "t-1", "query": "q1"}, {"id": "t-2", "query": "q2"}]
+        p = tmp_path / "fixtures.json"
+        p.write_text(json.dumps(data))
+        result = _load_fixture_file(p)
+        assert len(result) == 2
+        assert result[0]["id"] == "t-1"
+
+    def test_jsonl(self, tmp_path):
+        lines = [
+            json.dumps({"id": "t-1", "query": "q1"}),
+            json.dumps({"id": "t-2", "query": "q2"}),
+        ]
+        p = tmp_path / "fixtures.jsonl"
+        p.write_text("\n".join(lines))
+        result = _load_fixture_file(p)
+        assert len(result) == 2
+        assert result[1]["id"] == "t-2"
+
+    def test_jsonl_with_blank_lines(self, tmp_path):
+        lines = [
+            json.dumps({"id": "t-1"}),
+            "",
+            json.dumps({"id": "t-2"}),
+            "",
+        ]
+        p = tmp_path / "data.jsonl"
+        p.write_text("\n".join(lines))
+        result = _load_fixture_file(p)
+        assert len(result) == 2
+
+
+class TestLoadSuitePerFixtureHistory:
+    def _create_suite(self, tmp_path, *, shared_history=True, fixture_has_history=False):
+        suite_dir = tmp_path / "test-suite"
+        suite_dir.mkdir()
+
+        suite_meta = {
+            "name": "test-suite",
+            "version": "0.1.0",
+            "description": "Test suite",
+            "methodology_version": "0.2",
+            "categories": ["direct_lookup"],
+            "fixture_files": {"direct_lookup": "direct.json"},
+        }
+
+        shared_prayers = [
+            {"id": "shared-p1", "date": "2023-01-01", "text": "Shared prayer one.",
+             "themes": [], "entities": [], "summary": ""},
+            {"id": "shared-p2", "date": "2023-02-01", "text": "Shared prayer two.",
+             "themes": [], "entities": [], "summary": ""},
+        ]
+
+        if shared_history:
+            suite_meta["shared_prayer_history"] = "prayer_history.json"
+            (suite_dir / "prayer_history.json").write_text(json.dumps(shared_prayers))
+
+        fixture = {
+            "id": "test-1",
+            "category": "direct_lookup",
+            "description": "Test",
+            "query": "What about prayer one?",
+            "query_date": "2023-06-01",
+            "expected": {
+                "matches": [{"prayer_id": "shared-p1", "rank": 1, "relevance": "high"}],
+            },
+        }
+        if fixture_has_history:
+            fixture["user_history"] = [
+                {"id": "own-p1", "text": "Own prayer.", "synthetic_date": "2023-05-01"},
+            ]
+
+        (suite_dir / "direct.json").write_text(json.dumps([fixture]))
+        (suite_dir / "suite.json").write_text(json.dumps(suite_meta))
+        return suite_dir
+
+    def test_shared_history_injected_when_fixture_lacks_own(self, tmp_path, monkeypatch):
+        self._create_suite(tmp_path, shared_history=True, fixture_has_history=False)
+        monkeypatch.setattr(rv_harness, "FIXTURES_DIR", tmp_path)
+        _, prayer_history, fixtures = load_suite("test-suite")
+        assert len(prayer_history) == 2
+        assert len(fixtures) == 1
+        assert len(fixtures[0].prayer_history) == 2
+        assert fixtures[0].prayer_history[0].id == "shared-p1"
+
+    def test_per_fixture_history_used_when_present(self, tmp_path, monkeypatch):
+        self._create_suite(tmp_path, shared_history=True, fixture_has_history=True)
+        monkeypatch.setattr(rv_harness, "FIXTURES_DIR", tmp_path)
+        _, prayer_history, fixtures = load_suite("test-suite")
+        assert len(prayer_history) == 2
+        assert len(fixtures[0].prayer_history) == 1
+        assert fixtures[0].prayer_history[0].id == "own-p1"
+
+    def test_no_shared_history_with_per_fixture(self, tmp_path, monkeypatch):
+        self._create_suite(tmp_path, shared_history=False, fixture_has_history=True)
+        monkeypatch.setattr(rv_harness, "FIXTURES_DIR", tmp_path)
+        _, prayer_history, fixtures = load_suite("test-suite")
+        assert len(prayer_history) == 0
+        assert len(fixtures[0].prayer_history) == 1
+        assert fixtures[0].prayer_history[0].id == "own-p1"
+
+    def test_jsonl_fixture_loading(self, tmp_path, monkeypatch):
+        suite_dir = tmp_path / "jsonl-suite"
+        suite_dir.mkdir()
+        suite_meta = {
+            "name": "jsonl-suite",
+            "version": "0.1.0",
+            "description": "JSONL test",
+            "methodology_version": "0.2",
+            "categories": ["direct_lookup"],
+            "fixture_files": {"direct_lookup": "direct.jsonl"},
+        }
+        (suite_dir / "suite.json").write_text(json.dumps(suite_meta))
+
+        fixtures_jsonl = "\n".join([
+            json.dumps({
+                "id": "direct:Test:01",
+                "category": "direct",
+                "query": "Test query",
+                "user_history": [
+                    {"id": "p-1", "text": "Prayer text.", "synthetic_date": "2023-01-01"},
+                ],
+                "expected_matches": {
+                    "ranked": ["p-1"],
+                    "min_precision_at_5": 0.8,
+                    "min_recall_at_10": 1.0,
+                },
+                "expected_routing": None,
+                "notes": "Test fixture.",
+            }),
+        ])
+        (suite_dir / "direct.jsonl").write_text(fixtures_jsonl)
+
+        monkeypatch.setattr(rv_harness, "FIXTURES_DIR", tmp_path)
+        _, _, fixtures = load_suite("jsonl-suite")
+        assert len(fixtures) == 1
+        assert fixtures[0].id == "direct:Test:01"
+        assert fixtures[0].category == Category.DIRECT_LOOKUP
+        assert fixtures[0].prayer_history[0].date == "2023-01-01"
+        assert fixtures[0].expected.matches[0].prayer_id == "p-1"


### PR DESCRIPTION
## Summary

- Conversa fixtures embed per-fixture `user_history` (16-20 prayers each) rather than using a shared prayer pool. The harness previously required `shared_prayer_history` and always injected it into every fixture.
- Now fixtures can carry their own `user_history` or `prayer_history`, and shared history is optional fallback only used when a fixture lacks its own.
- Adds Conversa format compatibility: `expected_matches` (ranked list), category aliases (`direct` -> `direct_lookup`), `synthetic_date` -> `date`, `notes` -> `description`, JSONL fixture files.

### What changed

| File | Change |
|------|--------|
| `models.py` | `_prayer_from_dict` handles both field name sets; `_parse_expected_matches` handles Conversa expected format; `CATEGORY_ALIASES` maps short names; `fixture_from_dict` auto-detects format |
| `harness.py` | `shared_prayer_history` optional in `suite.json`; `_load_fixture_file` supports JSON and JSONL; per-fixture history takes precedence over shared pool |
| `test_fixture_loading.py` | 18 new tests covering Prayer deserialization, expected_matches parsing, category aliases, fixture format detection, JSONL loading, and suite-level history precedence |

Premium boundary: core OSS (eval harness primitive, no identity/org touch).

## Test plan

- [x] 18 new tests in `test_fixture_loading.py` all pass
- [x] 15 existing tests in `test_thresholds.py` all pass (no regressions)
- [x] End-to-end verification: real Conversa JSONL fixtures from v0 tarball parse correctly through `fixture_from_dict`
- [x] Backward compatible: existing v0-skeleton suite with shared prayer_history loads identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)