### PR TITLE
feat: add sleep-cycle dry-run scheduler spike

### DIFF
--- a/src/synapt/recall/sleep_cycle.py
+++ b/src/synapt/recall/sleep_cycle.py
@@ -1,0 +1,305 @@
+"""Sleep-cycle scheduler substrate for recall consolidation.
+
+The sleep cycle is the cold path of recall cognition: it decides when a
+workspace is quiet enough to plan consolidation work.  This module is a
+dry-run-only spike.  It performs no model calls and no destructive writes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+
+TelemetryHook = Callable[[dict], None]
+
+
+@dataclass(frozen=True)
+class SleepCycleConfig:
+    """Scheduler thresholds for automatic sleep-cycle eligibility."""
+
+    idle_after: timedelta = timedelta(minutes=30)
+    quiet_after: timedelta = timedelta(minutes=15)
+    window_start_hour: int = 1
+    window_end_hour: int = 5
+    dry_run: bool = True
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.window_start_hour <= 23:
+            raise ValueError("window_start_hour must be in 0..23")
+        if not 0 <= self.window_end_hour <= 23:
+            raise ValueError("window_end_hour must be in 0..23")
+        if self.idle_after < timedelta(0):
+            raise ValueError("idle_after must be non-negative")
+        if self.quiet_after < timedelta(0):
+            raise ValueError("quiet_after must be non-negative")
+        if not self.dry_run:
+            raise ValueError("sleep-cycle spike only supports dry_run=True")
+
+
+@dataclass(frozen=True)
+class SleepCycleSignals:
+    """Runtime signals used to decide whether a sleep cycle may run."""
+
+    now: datetime
+    last_write_at: datetime | None = None
+    last_channel_activity_at: datetime | None = None
+    pending_transcript_chunks: int = 0
+    pending_knowledge_nodes: int = 0
+    force: bool = False
+
+    def __post_init__(self) -> None:
+        if self.pending_transcript_chunks < 0:
+            raise ValueError("pending_transcript_chunks must be non-negative")
+        if self.pending_knowledge_nodes < 0:
+            raise ValueError("pending_knowledge_nodes must be non-negative")
+
+
+@dataclass(frozen=True)
+class SleepCycleDecision:
+    """Eligibility decision for a candidate sleep cycle."""
+
+    should_run: bool
+    triggered_by: str
+    blocked_by: tuple[str, ...] = ()
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ConsolidationJob:
+    """Dry-run job planned for a future consolidation engine."""
+
+    kind: str
+    input_count: int
+    output_target: str
+    description: str
+
+
+@dataclass(frozen=True)
+class ConsolidationPlan:
+    """Dry-run consolidation plan with candidate counts and job sequence."""
+
+    candidate_counts: dict[str, int]
+    jobs: list[ConsolidationJob] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SleepCycleTelemetry:
+    """Telemetry emitted by a dry-run sleep-cycle attempt."""
+
+    cycle_id: str
+    status: str
+    dry_run: bool
+    started_at: datetime
+    completed_at: datetime | None
+    decision: SleepCycleDecision
+    plan: ConsolidationPlan | None
+    model_calls: int = 0
+    destructive_writes: int = 0
+
+
+def evaluate_sleep_cycle(
+    signals: SleepCycleSignals,
+    config: SleepCycleConfig | None = None,
+) -> SleepCycleDecision:
+    """Return whether the current signals allow a sleep cycle.
+
+    Automatic cycles require four gates: inside the configured time window,
+    recall-write idleness, channel quiescence, and at least one consolidation
+    candidate.  Forced cycles bypass timing gates but still require work.
+    """
+
+    config = config or SleepCycleConfig()
+    now = _normalize_datetime(signals.now)
+    blocked: list[str] = []
+    reasons: list[str] = []
+
+    candidate_count = (
+        signals.pending_transcript_chunks + signals.pending_knowledge_nodes
+    )
+    if candidate_count == 0:
+        blocked.append("no_candidates")
+    else:
+        reasons.append("candidate_backlog")
+
+    if signals.force:
+        reasons.append("forced")
+        return SleepCycleDecision(
+            should_run=not blocked,
+            triggered_by="force",
+            blocked_by=tuple(blocked),
+            reasons=tuple(reasons),
+        )
+
+    if not _inside_window(now, config.window_start_hour, config.window_end_hour):
+        blocked.append("outside_window")
+    else:
+        reasons.append("inside_window")
+
+    if not _elapsed_at_least(now, signals.last_write_at, config.idle_after):
+        blocked.append("write_not_idle")
+    else:
+        reasons.append("write_idle")
+
+    if not _elapsed_at_least(
+        now,
+        signals.last_channel_activity_at,
+        config.quiet_after,
+    ):
+        blocked.append("channel_active")
+    else:
+        reasons.append("channel_quiet")
+
+    return SleepCycleDecision(
+        should_run=not blocked,
+        triggered_by="schedule",
+        blocked_by=tuple(blocked),
+        reasons=tuple(reasons),
+    )
+
+
+def build_dry_run_consolidation_plan(
+    signals: SleepCycleSignals,
+) -> ConsolidationPlan:
+    """Build a deterministic consolidation plan without executing it."""
+
+    jobs: list[ConsolidationJob] = []
+    if signals.pending_transcript_chunks:
+        jobs.append(
+            ConsolidationJob(
+                kind="extract_knowledge_nodes",
+                input_count=signals.pending_transcript_chunks,
+                output_target="knowledge_nodes",
+                description=(
+                    "Plan transcript-chunk replay into candidate knowledge "
+                    "nodes with provenance preserved."
+                ),
+            )
+        )
+    if signals.pending_knowledge_nodes:
+        jobs.append(
+            ConsolidationJob(
+                kind="distill_patterns",
+                input_count=signals.pending_knowledge_nodes,
+                output_target="distilled_patterns",
+                description=(
+                    "Plan knowledge-node clustering, deduplication, and "
+                    "pattern distillation."
+                ),
+            )
+        )
+
+    return ConsolidationPlan(
+        candidate_counts={
+            "transcript_chunks": signals.pending_transcript_chunks,
+            "knowledge_nodes": signals.pending_knowledge_nodes,
+        },
+        jobs=jobs,
+    )
+
+
+def run_sleep_cycle_dry_run(
+    signals: SleepCycleSignals,
+    config: SleepCycleConfig | None = None,
+    telemetry_hook: TelemetryHook | None = None,
+) -> SleepCycleTelemetry:
+    """Evaluate and plan one sleep cycle without mutating recall state."""
+
+    config = config or SleepCycleConfig()
+    now = _normalize_datetime(signals.now)
+    decision = evaluate_sleep_cycle(signals, config)
+    cycle_id = _cycle_id(signals)
+
+    if not decision.should_run:
+        telemetry = SleepCycleTelemetry(
+            cycle_id=cycle_id,
+            status="skipped",
+            dry_run=True,
+            started_at=now,
+            completed_at=now,
+            decision=decision,
+            plan=None,
+        )
+        _emit(telemetry_hook, "sleep_cycle.skipped", telemetry)
+        return telemetry
+
+    _emit(
+        telemetry_hook,
+        "sleep_cycle.started",
+        cycle_id=cycle_id,
+        status="running",
+        dry_run=True,
+        started_at=now.isoformat(),
+        triggered_by=decision.triggered_by,
+    )
+    plan = build_dry_run_consolidation_plan(signals)
+    telemetry = SleepCycleTelemetry(
+        cycle_id=cycle_id,
+        status="completed",
+        dry_run=True,
+        started_at=now,
+        completed_at=now,
+        decision=decision,
+        plan=plan,
+    )
+    _emit(telemetry_hook, "sleep_cycle.completed", telemetry)
+    return telemetry
+
+
+def _inside_window(now: datetime, start_hour: int, end_hour: int) -> bool:
+    if start_hour == end_hour:
+        return True
+    if start_hour < end_hour:
+        return start_hour <= now.hour < end_hour
+    return now.hour >= start_hour or now.hour < end_hour
+
+
+def _elapsed_at_least(
+    now: datetime,
+    last_seen: datetime | None,
+    threshold: timedelta,
+) -> bool:
+    if last_seen is None:
+        return True
+    return now - _normalize_datetime(last_seen) >= threshold
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _cycle_id(signals: SleepCycleSignals) -> str:
+    now = _normalize_datetime(signals.now).isoformat()
+    payload = "|".join(
+        [
+            now,
+            str(signals.pending_transcript_chunks),
+            str(signals.pending_knowledge_nodes),
+            "force" if signals.force else "schedule",
+        ]
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+    return f"sleep-{digest}"
+
+
+def _emit(
+    hook: TelemetryHook | None,
+    event: str,
+    telemetry: SleepCycleTelemetry | None = None,
+    **payload,
+) -> None:
+    if hook is None:
+        return
+    if telemetry is not None:
+        payload = {
+            "cycle_id": telemetry.cycle_id,
+            "status": telemetry.status,
+            "dry_run": telemetry.dry_run,
+            "blocked_by": list(telemetry.decision.blocked_by),
+            **payload,
+        }
+    hook({"event": event, **payload})

--- a/tests/recall/test_sleep_cycle.py
+++ b/tests/recall/test_sleep_cycle.py
@@ -1,0 +1,156 @@
+"""Sleep-cycle scheduler spike tests.
+
+The spike is intentionally dry-run only.  It locks the substrate seam for
+nightly recall consolidation without performing model calls or destructive
+storage operations.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from synapt.recall.sleep_cycle import (
+    SleepCycleConfig,
+    SleepCycleSignals,
+    evaluate_sleep_cycle,
+    run_sleep_cycle_dry_run,
+)
+
+
+NOW = datetime(2026, 5, 7, 8, 30, tzinfo=timezone.utc)
+
+
+def _config() -> SleepCycleConfig:
+    return SleepCycleConfig(
+        idle_after=timedelta(minutes=30),
+        quiet_after=timedelta(minutes=15),
+        window_start_hour=0,
+        window_end_hour=23,
+        dry_run=True,
+    )
+
+
+def _signals(**overrides) -> SleepCycleSignals:
+    values = {
+        "now": NOW,
+        "last_write_at": NOW - timedelta(hours=2),
+        "last_channel_activity_at": NOW - timedelta(hours=1),
+        "pending_transcript_chunks": 3,
+        "pending_knowledge_nodes": 2,
+    }
+    values.update(overrides)
+    return SleepCycleSignals(**values)
+
+
+def test_idle_quiescent_window_triggers_dry_run_plan():
+    events: list[dict] = []
+
+    telemetry = run_sleep_cycle_dry_run(
+        _signals(),
+        _config(),
+        telemetry_hook=events.append,
+    )
+
+    assert telemetry.status == "completed"
+    assert telemetry.dry_run is True
+    assert telemetry.decision.should_run is True
+    assert telemetry.model_calls == 0
+    assert telemetry.destructive_writes == 0
+    assert telemetry.plan is not None
+    assert [job.kind for job in telemetry.plan.jobs] == [
+        "extract_knowledge_nodes",
+        "distill_patterns",
+    ]
+    assert telemetry.plan.candidate_counts == {
+        "transcript_chunks": 3,
+        "knowledge_nodes": 2,
+    }
+    assert [event["event"] for event in events] == [
+        "sleep_cycle.started",
+        "sleep_cycle.completed",
+    ]
+
+
+def test_active_channel_blocks_automatic_cycle():
+    decision = evaluate_sleep_cycle(
+        _signals(last_channel_activity_at=NOW - timedelta(minutes=5)),
+        _config(),
+    )
+
+    assert decision.should_run is False
+    assert "channel_active" in decision.blocked_by
+
+
+def test_outside_window_blocks_automatic_cycle():
+    config = SleepCycleConfig(
+        idle_after=timedelta(minutes=30),
+        quiet_after=timedelta(minutes=15),
+        window_start_hour=1,
+        window_end_hour=5,
+        dry_run=True,
+    )
+
+    telemetry = run_sleep_cycle_dry_run(_signals(), config)
+
+    assert telemetry.status == "skipped"
+    assert telemetry.plan is None
+    assert "outside_window" in telemetry.decision.blocked_by
+    assert telemetry.model_calls == 0
+    assert telemetry.destructive_writes == 0
+
+
+def test_no_candidates_skips_without_mutation():
+    telemetry = run_sleep_cycle_dry_run(
+        _signals(pending_transcript_chunks=0, pending_knowledge_nodes=0),
+        _config(),
+    )
+
+    assert telemetry.status == "skipped"
+    assert telemetry.plan is None
+    assert "no_candidates" in telemetry.decision.blocked_by
+    assert telemetry.model_calls == 0
+    assert telemetry.destructive_writes == 0
+
+
+def test_force_trigger_bypasses_timing_gates_but_stays_dry_run():
+    config = SleepCycleConfig(
+        idle_after=timedelta(hours=4),
+        quiet_after=timedelta(hours=2),
+        window_start_hour=1,
+        window_end_hour=5,
+        dry_run=True,
+    )
+    telemetry = run_sleep_cycle_dry_run(
+        _signals(
+            force=True,
+            last_write_at=NOW - timedelta(minutes=1),
+            last_channel_activity_at=NOW - timedelta(minutes=1),
+        ),
+        config,
+    )
+
+    assert telemetry.status == "completed"
+    assert telemetry.decision.should_run is True
+    assert telemetry.decision.triggered_by == "force"
+    assert telemetry.model_calls == 0
+    assert telemetry.destructive_writes == 0
+
+
+def test_window_that_wraps_midnight_allows_late_night_cycle():
+    late_night = datetime(2026, 5, 7, 2, 15, tzinfo=timezone.utc)
+    config = SleepCycleConfig(
+        idle_after=timedelta(minutes=30),
+        quiet_after=timedelta(minutes=15),
+        window_start_hour=22,
+        window_end_hour=5,
+        dry_run=True,
+    )
+
+    decision = evaluate_sleep_cycle(
+        _signals(
+            now=late_night,
+            last_write_at=late_night - timedelta(hours=2),
+            last_channel_activity_at=late_night - timedelta(hours=1),
+        ),
+        config,
+    )
+
+    assert decision.should_run is True


### PR DESCRIPTION
## Summary
- add a dry-run sleep-cycle scheduler seam for recall cold-path consolidation
- plan transcript-chunk to knowledge-node extraction and knowledge-node pattern distillation without executing either
- emit telemetry for completed and skipped cycles

## Pre-registered measurement
Predicted an idle, quiet, inside-window fixture with 3 pending transcript chunks and 2 pending knowledge nodes would produce exactly one dry-run cycle with two planned jobs, zero model calls, and zero destructive writes.

Observed: focused sleep-cycle contract passes with that telemetry shape.

## Tests
- `source .venv/bin/activate && python -m pytest tests/recall/test_sleep_cycle.py -q`
- `source .venv/bin/activate && python -m pytest tests/recall/test_sleep_cycle.py tests/recall/test_consolidate.py -q`
- `python -m compileall -q src/synapt/recall/sleep_cycle.py`

Note: `python -m ruff check` was not available in the existing venv.

Premium boundary: OSS recall substrate primitive. Scheduler, dry-run planner, and telemetry only; model-backed consolidation, quality scoring, identity/org policy, and entitlements stay premium.
