### PR TITLE
fix: separate carried-forward journal next steps

### DIFF
--- a/src/synapt/recall/cli.py
+++ b/src/synapt/recall/cli.py
@@ -1337,6 +1337,7 @@ def cmd_journal(args: argparse.Namespace) -> None:
         auto_extract_entry,
         format_entry_full,
         format_for_session_start,
+        format_write_confirmation,
         latest_transcript_path,
         merge_carried_forward_next_steps,
         read_entries,
@@ -1397,8 +1398,10 @@ def cmd_journal(args: argparse.Namespace) -> None:
         entry.done = [d.strip() for d in args.done.split(";")]
     if args.decisions:
         entry.decisions = [d.strip() for d in args.decisions.split(";")]
+    explicit_next_steps = list(entry.next_steps)
     if args.next:
         entry.next_steps = [n.strip() for n in args.next.split(";")]
+        explicit_next_steps = list(entry.next_steps)
     entry.next_steps = merge_carried_forward_next_steps(
         entry.next_steps,
         entry.done,
@@ -1426,7 +1429,7 @@ def cmd_journal(args: argparse.Namespace) -> None:
 
     path = append_entry(entry)
     print(f"Journal entry written to {path}", file=sys.stderr)
-    print(format_entry_full(entry))
+    print(format_write_confirmation(entry, explicit_next_steps))
 
 
 def cmd_enrich(args: argparse.Namespace) -> None:

--- a/src/synapt/recall/journal.py
+++ b/src/synapt/recall/journal.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, asdict, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -334,6 +334,45 @@ def format_entry_full(entry: JournalEntry) -> str:
         for c in entry.git_log:
             lines.append(f"- {c}")
     return "\n".join(lines)
+
+
+def format_write_confirmation(
+    entry: JournalEntry,
+    explicit_next_steps: list[str] | None = None,
+) -> str:
+    """Format a write response without conflating carried-forward work.
+
+    Journal storage keeps unresolved prior next steps on the new entry so they
+    remain visible next session.  The write response needs a clearer UX: steps
+    supplied by the caller stay under ``Next``; unresolved prior steps are
+    rendered under a separate carry-forward heading.
+    """
+    explicit_steps = [
+        step.strip()
+        for step in (explicit_next_steps or [])
+        if step and step.strip()
+    ]
+    explicit_keys = {_step_key(step) for step in explicit_steps}
+    if not explicit_keys:
+        display_next: list[str] = []
+        carried = [step for step in entry.next_steps if step and step.strip()]
+    else:
+        display_next = []
+        carried = []
+        for step in entry.next_steps:
+            if not step or not step.strip():
+                continue
+            if _step_key(step) in explicit_keys:
+                display_next.append(step)
+            else:
+                carried.append(step)
+
+    text = format_entry_full(replace(entry, next_steps=display_next))
+    if carried:
+        parts = [text, "\n### Carried Forward Next Steps"]
+        parts.extend(f"- {step}" for step in carried)
+        return "\n".join(part for part in parts if part)
+    return text
 
 
 def _step_key(step: str) -> str:

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -1387,6 +1387,7 @@ def recall_journal(
             auto_extract_entry,
             format_entry_full,
             format_for_session_start,
+            format_write_confirmation,
             latest_transcript_path,
             merge_carried_forward_next_steps,
             pending_next_steps,
@@ -1428,8 +1429,10 @@ def recall_journal(
                 entry.done = [d.strip() for d in done.split(";")]
             if decisions:
                 entry.decisions = [d.strip() for d in decisions.split(";")]
+            explicit_next_steps = list(entry.next_steps)
             if next_steps:
                 entry.next_steps = [n.strip() for n in next_steps.split(";")]
+                explicit_next_steps = list(entry.next_steps)
             entry.next_steps = merge_carried_forward_next_steps(
                 entry.next_steps,
                 entry.done,
@@ -1447,7 +1450,10 @@ def recall_journal(
                 return "No content to journal (no files modified, no fields provided)."
 
             append_entry(entry)
-            return f"Journal entry written.\n\n{format_entry_full(entry)}"
+            return (
+                "Journal entry written.\n\n"
+                f"{format_write_confirmation(entry, explicit_next_steps)}"
+            )
 
         return f"Unknown action: {action}. Use 'read', 'write', 'list', or 'pending'."
     except Exception as exc:

--- a/tests/recall/test_journal.py
+++ b/tests/recall/test_journal.py
@@ -475,6 +475,68 @@ class TestNextStepCarryForward(unittest.TestCase):
         self.assertEqual(merged, ["write tests", "close loop", "follow up with team"])
 
 
+class TestJournalWriteResponse(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.path = Path(self.tmpdir) / "journal.jsonl"
+        self.project = Path(self.tmpdir) / "project"
+        self.project.mkdir()
+
+    def test_write_response_separates_explicit_next_steps_from_carried_forward(self):
+        """MCP write response must not present prior pending work as caller-written."""
+        from synapt.recall.server import recall_journal
+
+        append_entry(
+            JournalEntry(
+                timestamp="2026-05-06T10:00:00+00:00",
+                session_id="prior-session",
+                focus="prior work",
+                next_steps=[
+                    "retrieve the missing design docs",
+                    "estimate effort for prompt profiles",
+                ],
+            ),
+            self.path,
+        )
+
+        with patch("synapt.recall.journal._journal_path", return_value=self.path), \
+             patch("synapt.recall.server.Path.cwd", return_value=self.project), \
+             patch("synapt.recall.journal.latest_transcript_path", return_value=None), \
+             patch("synapt.recall.journal.auto_extract_entry", return_value=JournalEntry(
+                 timestamp="2026-05-07T10:00:00+00:00",
+                 session_id="current-session",
+             )):
+            response = recall_journal(
+                action="write",
+                focus="current work",
+                next_steps="write the crisis eval; update the B3 row",
+            )
+
+        next_section = response.split("### Next", 1)[1].split(
+            "### Carried Forward Next Steps",
+            1,
+        )[0]
+        self.assertIn("write the crisis eval", next_section)
+        self.assertIn("update the B3 row", next_section)
+        self.assertNotIn("retrieve the missing design docs", next_section)
+        self.assertNotIn("estimate effort for prompt profiles", next_section)
+        self.assertIn("### Carried Forward Next Steps", response)
+        self.assertIn("retrieve the missing design docs", response)
+        self.assertIn("estimate effort for prompt profiles", response)
+
+        latest = read_latest(self.path)
+        self.assertIsNotNone(latest)
+        self.assertEqual(
+            latest.next_steps,
+            [
+                "write the crisis eval",
+                "update the B3 row",
+                "retrieve the missing design docs",
+                "estimate effort for prompt profiles",
+            ],
+        )
+
+
 class TestPendingNextSteps(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()


### PR DESCRIPTION
## Summary
- keep journal carry-forward storage behavior unchanged
- render write confirmations with caller-supplied next steps under `Next`
- render unresolved prior-session carry-forward items under a separate `Carried Forward Next Steps` heading
- apply the same confirmation formatter to MCP/server and CLI write paths

## Pre-registered measurement
Prediction: `recall_journal(action="write", next_steps="write the crisis eval; update the B3 row")` with prior unresolved next steps should store both current and carried-forward items, but the rendered write response should show only caller-supplied items under `### Next` and prior items under `### Carried Forward Next Steps`.

Observed: targeted regression test passes and storage still contains both explicit + carried-forward next steps.

## Tests
- `source .venv/bin/activate && python -m pytest tests/recall/test_journal.py::TestJournalWriteResponse::test_write_response_separates_explicit_next_steps_from_carried_forward -q`
- `source .venv/bin/activate && python -m pytest tests/recall/test_journal.py -q`
- `source .venv/bin/activate && python -m pytest tests/recall/test_journal.py tests/recall/test_cli.py::test_cmd_journal_write_carries_forward_unresolved_next_steps -q`
- `source .venv/bin/activate && python -m compileall -q src/synapt/recall/journal.py src/synapt/recall/server.py src/synapt/recall/cli.py`
- `grep __version__ src/synapt/__init__.py` -> `0.15.0`

Note: `source .venv/bin/activate && python -m ruff check ...` could not run because `ruff` is not installed in the existing venv.

Premium boundary: OSS recall journal rendering/storage primitive.
