### PR TITLE
fix: release recall cache patch

### DIFF
--- a/.github/contributors/cla-signatures.json
+++ b/.github/contributors/cla-signatures.json
@@ -1,3 +1,12 @@
 {
-   "signedContributors": []
+  "signedContributors": [
+    {
+      "name": "laynepenney",
+      "id": 1295823,
+      "comment_id": 4435214408,
+      "created_at": "2026-05-12T22:08:31Z",
+      "repoId": 1177158725,
+      "pullRequestNo": 817
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to synapt are documented here.
 
+## [0.15.1] — 2026-05-12
+
+### Fixed
+- Fixed `recall_search` falsely reporting a missing index after the cached
+  embedding-enabled index was loaded. `_get_index()` now correctly updates the
+  embedding-cache flag instead of swallowing an `UnboundLocalError` and
+  returning `None`.
+- Fixed `recall_reload()` for editable installs so it restarts the MCP server
+  even when the package version string has not changed.
+
 ## [0.11.0] — 2026-04-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.15.0"
+version = "0.15.1"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -109,7 +109,7 @@ def _get_index(use_embeddings: bool = True) -> TranscriptIndex | None:
         use_embeddings: If False, skip embedding model loading for faster
             startup. Use for recall_quick which only needs BM25/knowledge.
     """
-    global _cached_index, _cached_mtime, _cached_dir
+    global _cached_index, _cached_mtime, _cached_dir, _cached_has_embeddings
     index_dir = project_index_dir()
 
     # Prefer recall.db, fall back to legacy chunks.jsonl
@@ -2096,17 +2096,16 @@ def recall_reload() -> str:
 
     Replaces the current process with a fresh one via os.execv().
     The MCP client (Claude Code) will reconnect automatically.
-    Only needed when you see a stale version warning.
     """
     import os
     import sys
 
     stale = _check_version_stale()
-    if not stale:
-        return f"Server is already running the latest version ({_STARTUP_VERSION}). No reload needed."
-
-    # Log the reload to stderr so it's visible
-    logging.getLogger("synapt.recall").info("Reloading MCP server (v%s -> installed)", _STARTUP_VERSION)
+    log = logging.getLogger("synapt.recall")
+    if stale:
+        log.info("Reloading MCP server (v%s -> installed)", _STARTUP_VERSION)
+    else:
+        log.info("Reloading MCP server (v%s)", _STARTUP_VERSION)
 
     # Flush any pending DB writes
     _invalidate_cache()

--- a/tests/recall/test_server_cache.py
+++ b/tests/recall/test_server_cache.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from synapt.recall import server
+
+
+def test_get_index_reuses_embedding_cache_without_false_missing_index(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+    (index_dir / "recall.db").write_bytes(b"placeholder")
+
+    fake_index = SimpleNamespace(chunks=[], _db=None)
+    calls: list[tuple[object, bool]] = []
+
+    def fake_load(directory, use_embeddings=False):
+        calls.append((directory, use_embeddings))
+        return fake_index
+
+    monkeypatch.setattr(server, "_cached_index", None)
+    monkeypatch.setattr(server, "_cached_mtime", 0.0)
+    monkeypatch.setattr(server, "_cached_dir", None)
+    monkeypatch.setattr(server, "_cached_has_embeddings", False)
+    monkeypatch.setattr(server, "project_index_dir", lambda: index_dir)
+    monkeypatch.setattr(server.TranscriptIndex, "load", fake_load)
+
+    first = server._get_index(use_embeddings=True)
+    second = server._get_index(use_embeddings=True)
+
+    assert first is fake_index
+    assert second is fake_index
+    assert calls == [(index_dir, True)]
+    assert server._cached_has_embeddings is True


### PR DESCRIPTION
## Summary
- fix recall MCP index caching so embedding-enabled searches do not falsely report a missing index
- make recall_reload restart editable-install MCP servers even when the package version string is unchanged
- bump synapt to 0.15.1 for patch release

## Verification
- pytest tests/recall/test_server_cache.py tests/recall/test_live.py -q
- python3 -m build --outdir /tmp/synapt-0.15.1-dist
- MCP recall_stats returns 94,379 chunks
- MCP date-filtered recall_search no longer returns the false missing-index error