### PR TITLE
chore(readme): refresh LOCOMO benchmark table + add 'as of' framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Use synapt as the memory and coordination substrate beneath higher-level agent o
 
 LOCOMO evaluates long conversational memory over 10 conversations and 1540 QA pairs.
 
-*Selected published LOCOMO results as of 2026-05-21. Methodologies vary across systems including judge model, benchmark harness, and conversation count. This table does not present a comparable leaderboard. synapt's 72.4 is the March 2026 audited reproducible run under the gpt-4o-mini judge methodology matching the Mem0 paper. Rows marked `[methodology-caveat]` use different judge models or harnesses and are not directly comparable to synapt's audited run. Rows marked `[historical]` reflect each system's score as published in the source paper noted, which may have been superseded by newer releases.*
+*Selected published LOCOMO results as of 2026-05-21. Methodologies vary across systems including judge model, benchmark harness, and conversation count. This table does not present a comparable leaderboard. synapt's 72.4 is the March 2026 audited reproducible run under the gpt-4o-mini judge methodology matching the Mem0 paper. Rows marked `[methodology-caveat]` use different judge models or harnesses and are not directly comparable to synapt's audited run. Rows marked `[historical: ENGRAM paper]` reflect each system's score as published in the ENGRAM paper Table 1 with the shared gpt-4o-mini backbone, which may have been superseded by newer releases from those systems under different methodologies.*
 
 | System | LOCOMO J-score | Multi-Hop | Temporal | Methodology / Source |
 |--------|---------------:|----------:|---------:|----------------------|

--- a/README.md
+++ b/README.md
@@ -470,30 +470,37 @@ Use synapt as the memory and coordination substrate beneath higher-level agent o
 
 LOCOMO evaluates long conversational memory over 10 conversations and 1540 QA pairs.
 
-*Comparison as of 2026-05-21. All systems use gpt-4o-mini as the shared generation + judge backbone for fair comparison; rows reflect each system's published evaluation under matched methodology, sourced from the [Engram paper](https://arxiv.org/abs/2511.12960) and [Mem0 paper](https://arxiv.org/abs/2504.19413). Newer post-paper releases from some systems use different judge models or prompt configurations that aren't directly comparable; those are noted inline where applicable.*
+*Selected published LOCOMO results as of 2026-05-21. Methodologies vary across systems including judge model, benchmark harness, and conversation count. This table does not present a comparable leaderboard. synapt's 72.4 is the March 2026 audited reproducible run under the gpt-4o-mini judge methodology matching the Mem0 paper. Rows marked `[methodology-caveat]` use different judge models or harnesses and are not directly comparable to synapt's audited run. Rows marked `[historical]` reflect each system's score as published in the source paper noted, which may have been superseded by newer releases.*
 
-| System | **Overall** | Multi-Hop | Temporal | Infra |
-|--------|-------------|-----------|----------|-------|
-| Engram | 77.55 ± 0.13 | — | — | cloud (BM25+ColBERT+KG) |
-| Memobase | 75.78 | 46.88 | **85.05** | cloud |
-| memOS | 72.99 ± 0.14 | — | — | cloud |
-| Full-Context | 72.90 | — | — | upper bound |
-| **synapt (audited)** | **72.4** | **70.92** | 59.19 | Ministral 8B cloud enrich |
-| **synapt local-first** | **72.4** | 67.02 | 61.06 | **local 3B on M2 Air** |
-| Mem0 | 64.73 ± 0.17 | 51.15 | 55.51 | cloud GPT-4 |
-| Zep | 42.29 ± 0.18 | — | — | cloud |
+| System | LOCOMO J-score | Multi-Hop | Temporal | Methodology / Source |
+|--------|---------------:|----------:|---------:|----------------------|
+| EverCore `[methodology-caveat]` | 93.05 | — | — | EverOS repo + EverMemOS paper ([arXiv:2601.02163](https://arxiv.org/abs/2601.02163)); judge/harness pending verification |
+| Hindsight `[methodology-caveat]` | 92.0 (AMB) / 89.61 (paper) | — | — | Hindsight AMB benchmark page + paper ([arXiv:2512.12818](https://arxiv.org/abs/2512.12818)) |
+| MemMachine `[methodology-caveat]` | 91.69 | — | — | [arXiv:2604.04853](https://arxiv.org/abs/2604.04853) + Apache-2.0 repo; gpt-4.1-mini agent mode |
+| Mem0 managed `[methodology-caveat]` | 91.8 / 90.2 | — | — | Mem0 docs May 2026; managed-platform optimizations not in OSS SDK |
+| Engram `[historical: ENGRAM paper]` | 77.55 ± 0.13 | 79.79 | 70.79 | ENGRAM paper Table 1 ([arXiv:2511.12960](https://arxiv.org/abs/2511.12960)); shared gpt-4o-mini backbone |
+| Zep\* (Memobase-team corrected) `[methodology-caveat]` | 75.14 | 66.04 | 79.79 | Memobase LOCOMO docs; supersedes the ENGRAM Zep row |
+| Memobase v0.0.37 `[methodology-caveat]` | 75.78 | 46.88 | **85.05** | Memobase LOCOMO docs; judge may be gpt-4o not gpt-4o-mini |
+| memOS `[historical: ENGRAM paper]` | 72.99 ± 0.14 | 63.70 | 72.68 | ENGRAM paper Table 1 |
+| Full-Context `[historical: ENGRAM paper]` | 72.60 ± 0.07 | — | — | ENGRAM paper Table 1; upper-bound control |
+| **synapt (audited)** | **72.4** | **70.92** | 59.19 | March 2026 audited rerun; gpt-4o-mini judge; Ministral 8B cloud enrich |
+| **synapt local-first** | **72.4** | 67.02 | 61.06 | March 2026 audited rerun; gpt-4o-mini judge; **local 3B on M2 Air** |
+| Mem0 `[historical: ENGRAM paper]` | 64.73 ± 0.17 | 57.85 | 53.34 | ENGRAM paper Table 1; Mem0's newer releases use different methodologies (see Mem0 managed row) |
+| Zep `[historical: ENGRAM paper]` | 42.29 ± 0.18 | 42.10 | 19.47 | ENGRAM paper Table 1; see Zep\* row for the Memobase-team corrected number |
 
 What matters for the pitch:
-- synapt is competitive with the best published systems
-- the local-first path remains strong on commodity hardware
-- the system is explicit about benchmark methodology, retrieval tradeoffs, and judge-model drift
-- the 72.4 LOCOMO score is the audited, reproducible number to cite
+- synapt's 72.4 is reproducible end-to-end against published methodology including the gpt-4o-mini judge, 1540 questions, and 10 conversations from the Mem0 paper
+- the local-first 3B path achieves the same audited overall score on commodity hardware
+- LOCOMO rankings shift with judge model, harness version, and OSS-versus-managed-platform scope. This table does not assert a leaderboard position
 
 Sources:
-- [LOCOMO](https://snap-research.github.io/locomo/)
+- [LOCOMO benchmark](https://snap-research.github.io/locomo/)
 - [Mem0 paper](https://arxiv.org/abs/2504.19413)
-- [Engram paper](https://arxiv.org/abs/2511.12960)
-- [Memobase benchmark](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)
+- [ENGRAM paper](https://arxiv.org/abs/2511.12960)
+- [Hindsight paper](https://arxiv.org/abs/2512.12818)
+- [MemMachine paper](https://arxiv.org/abs/2604.04853)
+- [EverMemOS paper](https://arxiv.org/abs/2601.02163)
+- [Memobase LOCOMO benchmark](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)
 
 ### CodeMemo
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Use synapt as the memory and coordination substrate beneath higher-level agent o
 
 LOCOMO evaluates long conversational memory over 10 conversations and 1540 QA pairs.
 
-All systems use gpt-4o-mini as the shared generation + judge backbone for fair comparison. Competitor data comes from the [Engram paper](https://arxiv.org/abs/2511.12960) and [Mem0 paper](https://arxiv.org/abs/2504.19413).
+*Comparison as of 2026-05-21. All systems use gpt-4o-mini as the shared generation + judge backbone for fair comparison; rows reflect each system's published evaluation under matched methodology, sourced from the [Engram paper](https://arxiv.org/abs/2511.12960) and [Mem0 paper](https://arxiv.org/abs/2504.19413). Newer post-paper releases from some systems use different judge models or prompt configurations that aren't directly comparable; those are noted inline where applicable.*
 
 | System | **Overall** | Multi-Hop | Temporal | Infra |
 |--------|-------------|-----------|----------|-------|
@@ -498,6 +498,8 @@ Sources:
 ### CodeMemo
 
 CodeMemo evaluates coding-memory tasks across factual recall, debugging context, architecture, temporal ordering, conventions, and cross-session continuity.
+
+*Comparison as of 2026-05-21. Single-evaluation snapshot under matched methodology.*
 
 | System | Overall |
 |--------|---------|


### PR DESCRIPTION
## What this changes

README LOCOMO benchmark table refresh per Sentinel's structured competitor-score audit (2026-05-21), driven by pre-public-flip audit findings on the vorn-mat release.

## Why now

Catches found:
- "#1 open-source on LOCOMO" claim on org page was falsified (synapt 72.4 vs MemMachine 91.69) — fixed in synapt-dev/.github#1 (merged)
- "Scores above Mem0 (66.88%) and Zep (65.99%)" claim on synapt.dev homepage was using stale competitor numbers — fixed in synapt-dev/synapt-dev.github.io#107 (open)
- This README benchmark table had the same drift pattern at a deeper exposure surface

Pre-public-flip gate for the vorn-mat paper release. Dr. Lang and other reviewers may click through `paper → vorn-mat repo → synapt org → synapt.dev → recall product README`. Every claim along that path needs to be narrative-accurate to substrate.

## Two commits

**f6e587f — framing**: Added "as of 2026-05-21" date stamp and methodology disclaimer above both benchmark tables (LOCOMO + CodeMemo).

**37831f9 — cell refresh**: Replaced the leaderboard-shaped LOCOMO table with a "selected published results" table that does not assert ranking. Each competitor row carries one of:
- `[historical: ENGRAM paper]` — score as published in ENGRAM Table 1 with shared gpt-4o-mini backbone; some systems (Mem0, Zep) have newer post-paper releases
- `[methodology-caveat]` — score uses a different judge model, harness, or OSS-vs-managed scope than synapt's audited run

## What's new in the table

| Added row | Score | Source | Caveat |
|---|---|---|---|
| EverCore | 93.05 | EverMemOS paper (arXiv:2601.02163) | judge/harness pending verification |
| Hindsight | 92.0 / 89.61 | Hindsight AMB + paper (arXiv:2512.12818) | different benchmark harness |
| MemMachine | 91.69 | arXiv:2604.04853 + Apache-2.0 repo | gpt-4.1-mini agent mode |
| Mem0 managed | 91.8 / 90.2 | Mem0 docs May 2026 | proprietary managed optimizations not in OSS SDK |
| Zep* corrected | 75.14 | Memobase docs | supersedes ENGRAM Zep row |

Historical rows for Mem0 (64.73) and Zep (42.29) are kept with explicit `[historical: ENGRAM paper]` tags rather than dropped — provides audit trail and prevents the impression that these systems were excluded.

## What's NOT in the table (Sentinel flagged but excluded)

| System | Claim | Why excluded |
|---|---|---|
| Synthius-Mem | 94.37 | Reports LOCOMO 1,813 questions / accuracy metric; not comparable to 1,540-question J-score |
| MemPalace | 88.9 | Reports R@10 retrieval metric, not LOCOMO J-score |
| Memvid | 85.7 | Methodology and system category need more verification |

## What's locked

synapt's audited 72.4 row is unchanged. The March 2026 audited rerun under gpt-4o-mini judge methodology (matching the Mem0 paper) is the canonical synapt cite.

## What's NOT in this PR (separate sprint)

- Re-running our eval against MemMachine's or Hindsight's methodology to produce a like-for-like comparison
- Updating `synapt/docs/index.html` (orphaned — synapt.dev/synapt/ returns 404; not actively served)
- Blog post tables (time-stamped historical snapshots; already dated)

## Ratification

Brand voice + competitive framing are sovereign-Layne territory. The framing chosen here is "selected published, methodologies differ, no ranking" — most truth-aligned given current methodology fragmentation. Alternative path would be to keep a narrow ENGRAM-paper-only comparison.

Comment if you want to redirect the framing or any row-level caveat phrasing; I'll amend before merge.

Premium boundary: OSS (recall public README).

Closes #N/A (audit-driven cleanup, not feature ticket).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>