### PR TITLE
fix(cli): synapt-private → synapt-premium label + bump 0.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.15.1"
+version = "0.15.2"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/cli.py
+++ b/src/synapt/cli.py
@@ -102,7 +102,7 @@ def _print_help(extra_commands: dict | None = None):
     ]
     if extra_commands:
         for name in sorted(extra_commands):
-            lines.append(f"  {name:<9} (from synapt-private)")
+            lines.append(f"  {name:<9} (from synapt-premium)")
     lines.append("")
     lines.append("Run 'synapt <command> --help' for details on each command.")
     lines.append("")

--- a/src/synapt/recall/__init__.py
+++ b/src/synapt/recall/__init__.py
@@ -1,6 +1,6 @@
 """synapt.recall — persistent conversational memory for Claude Code and ChatGPT sessions."""
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"
 
 from synapt.recall.core import (
     TranscriptChunk,


### PR DESCRIPTION
Addresses Atlas's combo re-verify finding on recall#821 + bumps to 0.15.2 for PyPI publish trigger.

## Changes
- `src/synapt/cli.py:105`: "(from synapt-private)" → "(from synapt-premium)" for premium-sourced commands (agent/repair/watch)
- Version bump 0.15.1 → 0.15.2 (v0.15.1 was previously released 2026-05-12; need fresh version for PyPI publish of PEP 420 conversion + label fix)

## Why now
- recall#821 (PEP 420 conversion) merged at 09:05Z
- Atlas's combo re-verify caught the residual label
- premium#716 needs recall 0.15.2 published to declare `synapt>=0.15.2` for clean install

## Premium boundary
OSS recall — display string + version bump only.

## Test plan
- [x] label fix verified locally
- [x] version bump verified (pyproject.toml + recall/__init__.py both 0.15.2)
- [ ] CI green
- [ ] After merge: gh release create v0.15.2 → PyPI publish triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)