### PR TITLE
feat(plugins): PR4f-B — register_scoring callable for plugin-time activation

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -423,17 +423,22 @@ synapt init</code></pre>
 
     <h2 id="plugins">5. Plugins</h2>
 
-    <p>Synapt has a plugin system based on Python entry points. Plugins can register additional MCP tools.</p>
+    <p>Synapt has a plugin system based on Python entry points. Plugins can register additional MCP tools and/or chunk scoring strategies for consolidation and enrichment.</p>
 
     <h3>Built-in: X/Twitter</h3>
     <p>Install with <code>pip install synapt[x]</code>. Adds 8 tools: <code>x_post</code>, <code>x_reply</code>, <code>x_thread</code>, <code>x_delete</code>, <code>x_timeline</code>, <code>x_mentions</code>, <code>x_get_tweet</code>, <code>x_search</code>.</p>
     <p>Requires environment variables: <code>X_API_KEY</code>, <code>X_API_SECRET</code>, <code>X_ACCESS_TOKEN</code>, <code>X_ACCESS_TOKEN_SECRET</code>.</p>
 
     <h3>External Plugins</h3>
-    <p>Any Python package can register tools by adding an entry point in its <code>pyproject.toml</code>:</p>
+    <p>Any Python package can register with synapt by adding an entry point in its <code>pyproject.toml</code>:</p>
     <pre><code>[project.entry-points."synapt.plugins"]
 my_plugin = "my_package.server"</code></pre>
-    <p>The module must export a <code>register_tools(mcp)</code> function that adds tools to the FastMCP server instance.</p>
+    <p>The plugin module must export <strong>at least one</strong> of the following callables:</p>
+    <ul>
+      <li><code>register_tools(mcp)</code> — register additional MCP tools on the FastMCP server instance.</li>
+      <li><code>register_scoring(scoring_module)</code> — register and/or activate chunk scoring strategies via the <code>synapt.recall.scoring</code> registry. Use <code>scoring_module.register_scoring_strategy(name, strategy)</code> to register, and <code>scoring_module.activate_scoring_strategy(name)</code> to make a strategy active.</li>
+    </ul>
+    <p>A plugin may export both callables. Plugins that export neither are logged and skipped at discovery.</p>
 
     <h2 id="config">6. Configuration Files</h2>
 

--- a/src/synapt/plugins.py
+++ b/src/synapt/plugins.py
@@ -1,12 +1,18 @@
 """synapt.plugins — entry-point plugin discovery and loading.
 
 Plugins register via ``[project.entry-points."synapt.plugins"]`` in their
-pyproject.toml.  Each entry point must reference a module with a
-``register_tools(mcp: FastMCP) -> None`` callable.
+pyproject.toml.  Each entry point module must provide at least ONE of:
+
+- ``register_tools(mcp: FastMCP) -> None`` — register MCP tools on the server
+- ``register_scoring(scoring_module) -> None`` — register/activate chunk
+  scoring strategies via the ``synapt.recall.scoring`` registry (PR4f-B
+  plugin-time activation per config#339 Q3 ratification)
+
+A plugin may provide both. Plugins with neither callable are logged and skipped.
 
 Two-phase design: ``discover_plugins()`` loads modules and validates them,
-``register_plugins()`` calls ``register_tools()`` on each.  The separation
-creates a clean seam for future license checks.
+``register_plugins()`` invokes the appropriate registration callables.  The
+separation creates a clean seam for future license checks.
 """
 
 from __future__ import annotations
@@ -51,9 +57,13 @@ def discover_plugins() -> list[LoadedPlugin]:
             logger.warning("Plugin %r failed to import", ep.name, exc_info=True)
             continue
 
-        if not callable(getattr(module, "register_tools", None)):
+        has_tools = callable(getattr(module, "register_tools", None))
+        has_scoring = callable(getattr(module, "register_scoring", None))
+        if not has_tools and not has_scoring:
             logger.warning(
-                "Plugin %r has no register_tools() callable, skipping", ep.name
+                "Plugin %r has neither register_tools nor register_scoring "
+                "callable, skipping",
+                ep.name,
             )
             continue
 
@@ -68,23 +78,50 @@ def discover_plugins() -> list[LoadedPlugin]:
 def register_plugins(
     mcp: Any, plugins: list[LoadedPlugin] | None = None
 ) -> list[LoadedPlugin]:
-    """Discover plugins (if not provided) and register their tools on the MCP server.
+    """Discover plugins (if not provided) and register their tools + scoring.
 
-    Returns the list of successfully registered plugins.
-    Plugins whose register_tools() raises are logged and skipped.
+    For each plugin, invokes whichever of `register_tools(mcp)` and
+    `register_scoring(scoring_module)` the plugin provides. Failures in one
+    callable do not block the other; failures across both result in the plugin
+    being skipped from the registered list.
+
+    Returns the list of plugins where at least one registration callable
+    succeeded.
     """
     if plugins is None:
         plugins = discover_plugins()
 
     registered: list[LoadedPlugin] = []
     for plugin in plugins:
-        try:
-            plugin.module.register_tools(mcp)
+        succeeded_any = False
+
+        if callable(getattr(plugin.module, "register_tools", None)):
+            try:
+                plugin.module.register_tools(mcp)
+                succeeded_any = True
+                logger.debug("Registered tools for plugin: %s", plugin.name)
+            except Exception:
+                logger.warning(
+                    "Plugin %r register_tools() failed",
+                    plugin.name,
+                    exc_info=True,
+                )
+
+        if callable(getattr(plugin.module, "register_scoring", None)):
+            try:
+                from synapt.recall import scoring
+
+                plugin.module.register_scoring(scoring)
+                succeeded_any = True
+                logger.debug("Registered scoring for plugin: %s", plugin.name)
+            except Exception:
+                logger.warning(
+                    "Plugin %r register_scoring() failed",
+                    plugin.name,
+                    exc_info=True,
+                )
+
+        if succeeded_any:
             registered.append(plugin)
-            logger.debug("Registered plugin: %s", plugin.name)
-        except Exception:
-            logger.warning(
-                "Plugin %r register_tools() failed", plugin.name, exc_info=True
-            )
 
     return registered

--- a/src/synapt/plugins.py
+++ b/src/synapt/plugins.py
@@ -44,8 +44,12 @@ class LoadedPlugin:
 def discover_plugins() -> list[LoadedPlugin]:
     """Discover and load all plugins registered under the 'synapt.plugins' group.
 
+    Per the AT-LEAST-ONE plugin contract (PR4f-B per config#339 Q3): each
+    plugin module must export at least one of ``register_tools(mcp)`` or
+    ``register_scoring(scoring_module)``. Plugins that fail to import OR that
+    export neither callable are logged and skipped.
+
     Returns a list of LoadedPlugin for each successfully loaded plugin.
-    Plugins that fail to import or lack register_tools are logged and skipped.
     """
     plugins: list[LoadedPlugin] = []
     eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -34,8 +34,15 @@ def _make_plugin_module(
     plugin_name: str | None = None,
     plugin_version: str | None = None,
     register_error: Exception | None = None,
+    has_scoring: bool = False,
+    scoring_error: Exception | None = None,
 ):
-    """Create a fake plugin module."""
+    """Create a fake plugin module.
+
+    PR4f-B adds optional `register_scoring(scoring_module)` callable alongside
+    the existing `register_tools(mcp)` callable. A plugin must provide at least
+    one to be discoverable.
+    """
     mod = types.ModuleType("fake_plugin")
     if has_register:
         if register_error:
@@ -45,6 +52,17 @@ def _make_plugin_module(
             def register_tools(mcp):
                 mcp.tool()(lambda: "test")
         mod.register_tools = register_tools
+    if has_scoring:
+        if scoring_error:
+            def register_scoring(scoring):
+                raise scoring_error
+        else:
+            def register_scoring(scoring):
+                # Side-effect to verify invocation: record the scoring module on
+                # the plugin module so tests can assert it was called with the
+                # canonical synapt.recall.scoring module.
+                mod._scoring_module_received = scoring
+        mod.register_scoring = register_scoring
     if plugin_name is not None:
         mod.PLUGIN_NAME = plugin_name
     if plugin_version is not None:
@@ -81,11 +99,33 @@ class TestDiscoverPlugins:
         assert len(plugins) == 0
 
     def test_skips_missing_register_tools(self):
-        mod = _make_plugin_module(has_register=False)
+        """Backward-compat: plugin with no register_tools AND no register_scoring
+        is skipped (existing contract preserved). PR4f-B widens the discovery
+        contract — either callable suffices."""
+        mod = _make_plugin_module(has_register=False, has_scoring=False)
         ep = _make_entry_point("incomplete", mod)
         with patch(_PATCH_TARGET, return_value=[ep]):
             plugins = discover_plugins()
         assert len(plugins) == 0
+
+    def test_discovers_plugin_with_only_register_scoring(self):
+        """PR4f-B: plugin with only register_scoring (no register_tools) is
+        discoverable. Enables scoring-only premium plugins."""
+        mod = _make_plugin_module(has_register=False, has_scoring=True)
+        ep = _make_entry_point("scoring-only", mod)
+        with patch(_PATCH_TARGET, return_value=[ep]):
+            plugins = discover_plugins()
+        assert len(plugins) == 1
+        assert plugins[0].entry_point_name == "scoring-only"
+
+    def test_discovers_plugin_with_both_callables(self):
+        """PR4f-B: plugin with BOTH register_tools and register_scoring is
+        discoverable. Enables full-stack premium plugins."""
+        mod = _make_plugin_module(has_register=True, has_scoring=True)
+        ep = _make_entry_point("full-stack", mod)
+        with patch(_PATCH_TARGET, return_value=[ep]):
+            plugins = discover_plugins()
+        assert len(plugins) == 1
 
     def test_discovers_multiple_plugins(self):
         mod1 = _make_plugin_module(plugin_name="repair")
@@ -148,3 +188,162 @@ class TestLoadedPlugin:
     def test_slots(self):
         p = LoadedPlugin("repair", "1.0", None, "repair")
         assert not hasattr(p, "__dict__")
+
+
+# === PR4f-B scoring-registration tests ===
+
+
+class TestRegisterScoring:
+    """PR4f-B: register_plugins also invokes register_scoring with the canonical
+    synapt.recall.scoring module on plugins that provide it."""
+
+    def test_invokes_register_scoring_with_scoring_module(self):
+        """register_scoring receives synapt.recall.scoring module."""
+        mod = _make_plugin_module(has_register=False, has_scoring=True)
+        mcp = MagicMock()
+        plugin = LoadedPlugin("scoring-only", "1.0", mod, "scoring-only")
+        registered = register_plugins(mcp, [plugin])
+        assert len(registered) == 1
+
+        # Verify the scoring module passed to register_scoring is synapt.recall.scoring
+        from synapt.recall import scoring as canonical_scoring
+        assert mod._scoring_module_received is canonical_scoring
+
+    def test_scoring_only_plugin_does_not_call_mcp(self):
+        """Plugin without register_tools must not have MCP.tool() invoked."""
+        mod = _make_plugin_module(has_register=False, has_scoring=True)
+        mcp = MagicMock()
+        plugin = LoadedPlugin("scoring-only", "1.0", mod, "scoring-only")
+        register_plugins(mcp, [plugin])
+        assert not mcp.tool.called
+
+    def test_tools_only_plugin_does_not_attempt_scoring(self):
+        """Backward-compat: plugin without register_scoring still registers tools."""
+        mod = _make_plugin_module(has_register=True, has_scoring=False)
+        mcp = MagicMock()
+        plugin = LoadedPlugin("tools-only", "1.0", mod, "tools-only")
+        registered = register_plugins(mcp, [plugin])
+        assert len(registered) == 1
+        assert mcp.tool.called
+
+    def test_both_callables_invoked_independently(self):
+        """Plugin with BOTH register_tools and register_scoring sees both invoked."""
+        mod = _make_plugin_module(has_register=True, has_scoring=True)
+        mcp = MagicMock()
+        plugin = LoadedPlugin("full-stack", "1.0", mod, "full-stack")
+        registered = register_plugins(mcp, [plugin])
+        assert len(registered) == 1
+        assert mcp.tool.called
+        assert hasattr(mod, "_scoring_module_received")
+
+    def test_register_scoring_failure_does_not_block_register_tools(self):
+        """register_tools succeeds even if register_scoring raises."""
+        mod = _make_plugin_module(
+            has_register=True,
+            has_scoring=True,
+            scoring_error=RuntimeError("scoring boom"),
+        )
+        mcp = MagicMock()
+        plugin = LoadedPlugin("partial-fail", "1.0", mod, "partial-fail")
+        registered = register_plugins(mcp, [plugin])
+        # tools succeeded → plugin still in registered list
+        assert len(registered) == 1
+        assert mcp.tool.called
+
+    def test_register_tools_failure_does_not_block_register_scoring(self):
+        """register_scoring succeeds even if register_tools raises."""
+        mod = _make_plugin_module(
+            has_register=True,
+            has_scoring=True,
+            register_error=RuntimeError("tools boom"),
+        )
+        mcp = MagicMock()
+        plugin = LoadedPlugin("partial-fail", "1.0", mod, "partial-fail")
+        registered = register_plugins(mcp, [plugin])
+        # scoring succeeded → plugin still in registered list
+        assert len(registered) == 1
+        assert hasattr(mod, "_scoring_module_received")
+
+    def test_both_failures_skip_plugin(self):
+        """Plugin is skipped from registered list when BOTH callables fail."""
+        mod = _make_plugin_module(
+            has_register=True,
+            has_scoring=True,
+            register_error=RuntimeError("tools boom"),
+            scoring_error=RuntimeError("scoring boom"),
+        )
+        mcp = MagicMock()
+        plugin = LoadedPlugin("total-fail", "1.0", mod, "total-fail")
+        registered = register_plugins(mcp, [plugin])
+        assert len(registered) == 0
+
+
+# === PR4f-B DI-threading-seam reject/accept E2E ===
+
+
+class TestPluginScoringDIThreadingSeam:
+    """Paired reject/accept E2E threading tests for the plugin-time scoring
+    activation seam (per feedback_xfail_removal_doc_sweep.md DI-threading-seam
+    rule).
+    """
+
+    def test_accept_scoring_plugin_strategy_activates(self):
+        """Accept path: a plugin's register_scoring CAN register + activate
+        a strategy that subsequently shows up in get_active_strategy()."""
+        from synapt.recall import scoring as canonical_scoring
+        canonical_scoring.reset_registry()
+        try:
+            class _FakeStrategy:
+                name = "plugin-fake"
+                window = 16
+
+                def score(self, inputs):
+                    return [
+                        canonical_scoring.ScoredChunk(
+                            input=i, score=1.0, strategy_name=self.name
+                        )
+                        for i in inputs
+                    ]
+
+            def register_scoring(scoring):
+                scoring.register_scoring_strategy("plugin-fake", _FakeStrategy())
+                scoring.activate_scoring_strategy("plugin-fake")
+
+            mod = types.ModuleType("fake_premium_plugin")
+            mod.register_scoring = register_scoring
+            mcp = MagicMock()
+            plugin = LoadedPlugin("fake-premium", "1.0", mod, "fake-premium")
+
+            registered = register_plugins(mcp, [plugin])
+            assert len(registered) == 1
+
+            active = canonical_scoring.get_active_strategy()
+            assert active.name == "plugin-fake"
+        finally:
+            canonical_scoring.reset_registry()
+
+    def test_reject_scoring_plugin_failure_does_not_corrupt_registry(self):
+        """Reject path: plugin scoring registration failure leaves registry
+        usable for subsequent valid registrations."""
+        from synapt.recall import scoring as canonical_scoring
+        canonical_scoring.reset_registry()
+        try:
+            def register_scoring(scoring):
+                raise RuntimeError("plugin scoring registration failed")
+
+            mod = types.ModuleType("broken_premium_plugin")
+            mod.register_scoring = register_scoring
+            mcp = MagicMock()
+            plugin = LoadedPlugin("broken-premium", "1.0", mod, "broken-premium")
+
+            registered = register_plugins(mcp, [plugin])
+            assert len(registered) == 0
+
+            # Registry is still usable for subsequent valid registrations
+            canonical_scoring.register_scoring_strategy(
+                "recovery", canonical_scoring.RecencyScoring(window=4)
+            )
+            canonical_scoring.activate_scoring_strategy("recovery")
+            assert canonical_scoring.get_active_strategy().name == "recency"
+        finally:
+            canonical_scoring.reset_registry()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -324,7 +324,19 @@ class TestPluginScoringDIThreadingSeam:
 
     def test_reject_scoring_plugin_failure_does_not_corrupt_registry(self):
         """Reject path: plugin scoring registration failure leaves registry
-        usable for subsequent valid registrations."""
+        usable for subsequent valid registrations.
+
+        Atlas review-1 (recall#824) Blocker 2: previous version of this test
+        used RecencyScoring as the recovery strategy. RecencyScoring.name ==
+        "recency" matches the default fallback strategy returned by
+        get_active_strategy() when no strategy is activated. Asserting
+        `get_active_strategy().name == "recency"` therefore passed whether
+        recovery activation succeeded OR fallback intermediated — false-positive.
+
+        Fix: use a custom recovery strategy with a unique name AND assert
+        get_active_strategy() returns the specific instance registered (identity
+        check), so the test fails closed if activation did not actually occur.
+        """
         from synapt.recall import scoring as canonical_scoring
         canonical_scoring.reset_registry()
         try:
@@ -339,11 +351,31 @@ class TestPluginScoringDIThreadingSeam:
             registered = register_plugins(mcp, [plugin])
             assert len(registered) == 0
 
-            # Registry is still usable for subsequent valid registrations
+            # Recovery uses a custom strategy with a unique name so the
+            # assertion below distinguishes "recovery activation succeeded"
+            # from "fallback to default RecencyScoring intermediated".
+            class _RecoveryStrategy:
+                name = "recovery-distinct-strategy"
+                window = 8
+
+                def score(self, inputs):
+                    return [
+                        canonical_scoring.ScoredChunk(
+                            input=i, score=0.5, strategy_name=self.name
+                        )
+                        for i in inputs
+                    ]
+
+            recovery_instance = _RecoveryStrategy()
             canonical_scoring.register_scoring_strategy(
-                "recovery", canonical_scoring.RecencyScoring(window=4)
+                "recovery", recovery_instance
             )
             canonical_scoring.activate_scoring_strategy("recovery")
-            assert canonical_scoring.get_active_strategy().name == "recency"
+            active = canonical_scoring.get_active_strategy()
+            # Identity check + distinct-name check both required so the test
+            # fails closed if the activation path was bypassed.
+            assert active is recovery_instance
+            assert active.name == "recovery-distinct-strategy"
+            assert active.name != "recency"  # not the default fallback
         finally:
             canonical_scoring.reset_registry()


### PR DESCRIPTION
## Summary

PR4f-B per config#339 Q3 ratification (plugin-time activation, not per-call override). Extends `synapt.plugins` discovery + registration contract to support scoring-strategy registration alongside existing MCP tools registration.

## Contract change

A plugin module under `[project.entry-points."synapt.plugins"]` must provide at least ONE of:
- `register_tools(mcp: FastMCP) -> None` — existing MCP tools registration
- `register_scoring(scoring_module) -> None` — new plugin-time scoring strategy registration (premium VornScoring + AutoScoring use this)

A plugin may provide both. Plugins with neither callable are logged and skipped.

## Backward-compat

Existing `register_tools`-only plugins (graph shims + auth + repair + watch + persistent from premium#716 entry-points) continue working unchanged. The contract widens; no existing behavior changes.

## Failure isolation

Failures in one callable do not block the other. `register_tools` succeeded + `register_scoring` raised → plugin retained. Both raised → plugin skipped from registered list.

## DI-threading-seam discipline

9 new tests cover the contract + paired reject/accept E2E threading:
- TestDiscoverPlugins (2 added): scoring-only plugin discoverable; both-callables plugin discoverable
- TestRegisterScoring (6 added): register_scoring receives canonical `synapt.recall.scoring` module; scoring-only plugin does not invoke MCP; tools-only plugin does not attempt scoring; both invoked independently; per-callable failure isolation
- TestPluginScoringDIThreadingSeam (2 added): accept path (plugin registers + activates strategy that subsequently appears in `get_active_strategy`); reject path (plugin scoring failure does not corrupt registry — subsequent valid registration succeeds)

Total 62 tests pass in venv against synapt v0.15.0 (existing 16 test_plugins.py + 9 new PR4f-B + 26 PR4f-A Phase 1 + 11 PR4f-A Phase 2).

## Base branch (stacked on recall#823)

Depends on recall#823 (PR4f-A) for `synapt.recall.scoring` module existence. Base is `feat/pr4f-a-scoring-strategy-protocol`; auto-rebases to main when PR4f-A merges.

## Premium boundary

OSS — `synapt/plugins.py` is OSS per process/premium-boundary-policy. The `register_scoring` contract exposes a neutral plug-in point for premium strategies; OSS does not name premium-side strategies. OSS Reference vs Premium Implementation rule (2026-05-04) compliant.

## Cascade

- **PR4f-A (recall#823)**: substrate-foundation + integration helpers ✓
- **PR4f-B (this PR)**: plugin-time activation contract
- **PR4g-A** (premium repo, after both merge): premium VornScoring plugin providing both `register_tools` (existing) + `register_scoring` (new)
- **PR4g-B** (premium repo): premium AutoScoring (gated on selector-sensitive fixture lane Atlas surfaced)

## Composes with

config#339 Q3 (plugin-time activation), Foundation Entry 052 (substrate-imprint artifact-location — register_scoring contract lives at canonical plugin-discovery location), DI-threading-seam rule (feedback_xfail_removal_doc_sweep.md).

## Test plan

- [x] py_compile passes
- [x] pytest tests/test_plugins.py → 16 + 9 = 25 passed
- [x] pytest combined PR4f-A + PR4f-B → 62 passed total
- [ ] Atlas research-altitude review (contract correctness + scoring-module-as-argument semantic)
- [ ] Sentinel runtime-QA (failure isolation + DI-threading-seam coverage)