### PR TITLE
fix: include nh3 in dev extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4", "nh3>=0.2.14"]
-dev = ["watchfiles>=0.20"]
+dev = ["watchfiles>=0.20", "nh3>=0.2.14"]
 test = [
     "build>=1.0",
     "pytest>=7.0",


### PR DESCRIPTION
Fixes #805.

The dashboard/test extras already include 
h3, but the dev extra still only installs watchfiles. Since dashboard development and upload tests import the sanitizer, this adds 
h3>=0.2.14 to the dev extra as requested by the issue.