### PR TITLE
feat: [all] aggregate extra + fix: include dashboard template.html in package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,4 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "synapt.resources" = ["skills/dev-loop/SKILL.md"]
+"synapt.dashboard" = ["template.html"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,23 @@ onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4", "nh3>=0.2.14"]
+all = [
+    "fastapi>=0.100",
+    "uvicorn[standard]>=0.20",
+    "sse-starlette>=1.0",
+    "markdown>=3.4",
+    "nh3>=0.2.14",
+    "anthropic>=0.77.0",
+    "openai-agents>=0.10.0",
+    "google-adk>=1.0.0",
+    "langchain-core>=0.2",
+    "crewai>=1.4.0",
+    "huggingface_hub>=0.20",
+    "onnxruntime>=1.16",
+    "optimum[onnxruntime]>=1.16",
+    "transformers>=4.30",
+    "peft>=0.7",
+]
 dev = ["watchfiles>=0.20"]
 test = [
     "pytest>=7.0",


### PR DESCRIPTION
Two install-related fixes surfaced during FreedomPay demo install prep 2026-06-08. Both blockers for any operator running \`pip install synapt[...]\` from PyPI.

## Commits

1. **\`feat: add [all] aggregate extra\`** — operators can install all OSS features with \`pip install \"synapt[all]\"\` instead of manually selecting extras.
2. **\`fix: include dashboard template.html in package-data\`** — without this, \`synapt dashboard\` errors at runtime because the wheel build excludes template.html (only \`synapt.resources\` skill assets were declared in package-data).

## What [all] bundles

- \`dashboard\` (fastapi + uvicorn + sse-starlette + markdown + nh3)
- \`all-integrations\` (anthropic + openai + google-adk + langchain + crewai)
- \`hf\` (huggingface_hub)
- \`onnx\` (onnxruntime + optimum)
- \`transformers\` (transformers + peft)

Excludes \`x\` (twitter — requires creds), \`dev\`, \`test\`.

## Package-data fix

\`pyproject.toml\` declared only \`\"synapt.resources\"\` in \`[tool.setuptools.package-data]\`. The dashboard loads template.html via \`Path(__file__).parent / \"template.html\"\` (see dashboard/app.py:431). Wheel build dropped the file, so runtime failed with "missing template.html" even after correctly installing dashboard extras.

## Premium boundary declaration

Premium boundary: \`synapt\` is OSS. \`[all]\` covers all OSS features. Premium (agent, repair, watch) remains in synapt-private. Boundary preserved.

## Why urgent

FreedomPay demo Tue/Wed 2026-06-09 or 06-10 — Layne needs to install synapt fresh on FP machine and run \`synapt dashboard\` for the demo. Without both fixes, neither path works on PyPI.

## Test plan

- [ ] CI green
- [ ] Verify \`pip install synapt[all]\` resolves cleanly in a fresh venv
- [ ] Verify dashboard launches: \`synapt dashboard\` — template.html loads
- [ ] Verify MCP server launches: \`synapt server\`
- [ ] Verify the built wheel contains template.html: \`unzip -l dist/synapt-*.whl | grep template.html\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)