### PR TITLE
ci: install [dashboard] extra so dashboard tests can import nh3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e ".[test]"
+      - run: pip install -e ".[test,dashboard]"
       - run: pytest tests/ -v


### PR DESCRIPTION
## Summary

One-line CI fix: change `pip install -e ".[test]"` to `pip install -e ".[test,dashboard]"` in `.github/workflows/tests.yml`.

## Why

CI unit-tests have been failing on all 9 platform x Python combinations (ubuntu/windows/macos x 3.10/3.11/3.12) with `ModuleNotFoundError: No module named 'nh3'` across dashboard test modules:

- `tests/dashboard/test_api.py`
- `tests/test_dashboard_app.py`
- `tests/test_dashboard_upload.py`

`nh3` is in the `[dashboard]` extra (per pyproject.toml: `dashboard = [..., "nh3>=0.2.14"]`), but the CI install command only included `[test]`, so dashboard tests could not import it.

Surfaced during review of PR #826 + PR #828 — neither PR caused the failures, both inherited them from sprint-34 base. Substrate-check finding bubbled to Opus before merge; merge call authorized per sprint-branch canon (sprint branches allow failing tests, PRs were FP-demo-critical, conservative scope). This PR is the small focused substrate-fix Opus requested as separate scope.

Does NOT address:
- `tests/integrations/test_langchain_synapt_package.py` wheel-build failures (different scope — subprocess `python -m build` failures, unrelated to `[dashboard]` extra)

## Premium boundary

Premium boundary: OSS. `recall` is OSS; CI config is OSS.

## Test plan

- [ ] CI green on dashboard tests (was: 9 modules x 9 platform/python combos failing on nh3)
- [ ] Other test categories unchanged
- [ ] `pip install -e ".[test,dashboard]"` resolves cleanly in CI runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)