### PR TITLE
chore: bump version to 0.15.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.15.0"
+version = "0.15.3"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/src/synapt/__init__.py
+++ b/src/synapt/__init__.py
@@ -1,3 +1,3 @@
 """Synapt: persistent conversational memory for AI coding assistants."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.3"


### PR DESCRIPTION
Version bump to capture three FP-demo-critical fixes merged into sprint-34 today.

## Fixes captured in 0.15.3

- **#826** feat: \`[all]\` aggregate extra + dashboard template.html package-data
- **#828** fix(embeddings): auto-detect torch device; prefer MPS on Apple Silicon (closes #827 SIGBUS)
- **#830** ci: install \`[dashboard]\` extra so dashboard tests can import nh3 (CI substrate-fix)

## Why now

FreedomPay demo Tue/Wed; Layne is operating on synapt-from-source on his FP laptop. Cutting 0.15.3 to PyPI means he can switch back to clean \`pip install --upgrade "synapt[all]"\` for the demo runtime instead of source-build path.

## Sequence after this PR merges

1. PR sprint-34 → main (ceremony-style, captures all three fixes + this bump)
2. \`gh release create v0.15.3\` triggers CI auto-publish to PyPI
3. Layne switches FP laptop to clean PyPI install

## Premium boundary

Chore — no behavior change. Premium boundary declarations live in each underlying PR.

## Test plan

- [ ] CI matches sprint-34 base profile (langchain-synapt subprocess errors are pre-existing per #831; no new failures)
- [ ] Version verification: \`grep __version__ src/synapt/__init__.py\` shows 0.15.3
- [ ] Version verification: \`grep '^version' pyproject.toml\` shows 0.15.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)