### PR TITLE
release: v0.15.3 hotfix (FP-demo install fixes — [all] aggregate + dashboard + MPS embeddings)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e ".[test]"
+      - run: pip install -e ".[test,dashboard]"
       - run: pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,23 @@ onnx = ["onnxruntime>=1.16", "optimum[onnxruntime]>=1.16"]
 transformers = ["transformers>=4.30", "peft>=0.7"]
 x = ["tweepy>=4.14"]
 dashboard = ["fastapi>=0.100", "uvicorn[standard]>=0.20", "sse-starlette>=1.0", "markdown>=3.4", "nh3>=0.2.14"]
+all = [
+    "fastapi>=0.100",
+    "uvicorn[standard]>=0.20",
+    "sse-starlette>=1.0",
+    "markdown>=3.4",
+    "nh3>=0.2.14",
+    "anthropic>=0.77.0",
+    "openai-agents>=0.10.0",
+    "google-adk>=1.0.0",
+    "langchain-core>=0.2",
+    "crewai>=1.4.0",
+    "huggingface_hub>=0.20",
+    "onnxruntime>=1.16",
+    "optimum[onnxruntime]>=1.16",
+    "transformers>=4.30",
+    "peft>=0.7",
+]
 dev = ["watchfiles>=0.20"]
 test = [
     "build>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapt"
-version = "0.15.2"
+version = "0.15.3"
 description = "Persistent conversational memory for AI coding assistants"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,4 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "synapt.resources" = ["skills/dev-loop/SKILL.md"]
+"synapt.dashboard" = ["template.html"]

--- a/src/synapt/recall/__init__.py
+++ b/src/synapt/recall/__init__.py
@@ -1,6 +1,6 @@
 """synapt.recall — persistent conversational memory for Claude Code and ChatGPT sessions."""
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"
 
 from synapt.recall.core import (
     TranscriptChunk,

--- a/src/synapt/recall/embeddings.py
+++ b/src/synapt/recall/embeddings.py
@@ -24,6 +24,30 @@ import urllib.request
 from typing import List, Optional
 
 
+def _detect_device() -> str:
+    """Pick the safest available torch device for embedding inference.
+
+    Apple Silicon CPU path hits a Accelerate BLAS alignment fault (SIGBUS) on
+    sentence-transformers matmul; prefer MPS when available. Linux and other
+    CPU-only environments fall back to "cpu" cleanly.
+
+    Env override: SYNAPT_EMBED_DEVICE=cpu|mps|cuda
+    """
+    import os
+    override = os.environ.get("SYNAPT_EMBED_DEVICE", "").strip().lower()
+    if override in ("cpu", "mps", "cuda"):
+        return override
+    try:
+        import torch
+        if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+            return "mps"
+        if torch.cuda.is_available():
+            return "cuda"
+    except ImportError:
+        pass
+    return "cpu"
+
+
 class EmbeddingProvider:
     """Base class for embedding backends."""
 
@@ -50,9 +74,9 @@ class LocalEmbeddings(EmbeddingProvider):
     """
 
     def __init__(self, model_name: str = "all-MiniLM-L6-v2",
-                 device: str = "cpu"):
+                 device: str | None = None):
         self._model_name = model_name
-        self._device = device
+        self._device = device if device is not None else _detect_device()
         self._model = None
         self._dim_cached: int | None = None
 


### PR DESCRIPTION
Hotfix release directly to main capturing four FP-demo-critical fixes that were merged into sprint-34 earlier today. sprint-34 has structurally diverged from main (PEP 420 namespace conversion + PR4f-A/B work landed on main without going through sprint-34), so the standard sprint-34 → main ceremony shape didn't apply.

Original ceremony PR #833 closed with explanation; cherry-picked the four substantive commits onto a hotfix branch from main directly.

## Closes

- Closes #827 (SIGBUS / EXC_ARM_DA_ALIGN on macOS arm64 during embedding load — fixed by MPS auto-detect commit below)

## What ships in 0.15.3

### Install path fixes (FP-demo critical)

- `feat: add [all] aggregate extra for one-command OSS install` (cherry-pick of recall#826 sub-commit)
  - New: `pip install "synapt[all]"` installs all OSS features in one command (dashboard, all-integrations, hf, onnx, transformers)
- `fix: include dashboard template.html in package-data` (cherry-pick of recall#826 sub-commit)
  - dashboard wheel now ships `template.html` (was excluded from package-data, causing `synapt dashboard` runtime failure)
- `fix(embeddings): auto-detect torch device; prefer MPS on Apple Silicon` (cherry-pick of recall#828)
  - Resolves SIGBUS / Accelerate BLAS alignment fault on Apple Silicon during embedding model load
  - `LocalEmbeddings` now auto-detects: MPS (Apple Silicon) → CUDA (Linux+NVIDIA) → CPU
  - Override via `SYNAPT_EMBED_DEVICE=cpu|mps|cuda`
  - Conservative scope: only changes Apple Silicon default; Linux/Modal CPU path unchanged

### Supporting

- `ci: install [dashboard] extra so dashboard tests can import nh3` (cherry-pick of recall#830)
  - CI substrate-fix: dashboard tests were failing with `ModuleNotFoundError: nh3` because CI install used `[test]` only
  - Now installs `[test,dashboard]` — nh3 reaches dashboard test modules
  - Removed ~15 ImportError failures across the matrix

### Chore

- `chore: bump version to 0.15.3` — synapt/recall/__init__.py + pyproject.toml

## Premium boundary

OSS — recall is OSS. v0.15.3 is the OSS release; premium ships separately per its own cadence.

## Test plan

- [x] All four substantive fixes already reviewed + merged into sprint-34 individually (gates checked at each step)
- [x] CI substrate-fix verified by fruit: ~15 nh3 ImportErrors → 0 after #830 merged (verified on sprint-34)
- [x] Cherry-picks applied cleanly without conflicts onto main's PEP 420 structure
- [x] Version verification: pyproject.toml + src/synapt/recall/__init__.py both show 0.15.3
- [ ] Main CI green (pending this PR's CI run)
- [ ] PyPI publish auto-triggers on merge (publish workflow per CLAUDE.md canon)

## Substrate-debt out of scope

- **#831** langchain-synapt wheel-build subprocess error on CI — pre-existing failure not introduced by this hotfix; carved out separately per Apollo's substrate-check
- **#829** MLX embedding backend — durable architectural follow-up; non-urgent

## Sequence after merge

1. PyPI publish triggers automatically via existing publish workflow (per CLAUDE.md release canon)
2. `gh release create v0.15.3` for the changelog + announcement (release tag does NOT trigger publish; publish already happens on push to main per canon)
3. Layne switches FP laptop from source-install to `pip install --upgrade "synapt[all]"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)