### PR TITLE
docs: update premium boundary template naming

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,8 @@
 ### Boundary Checklist
 
 - [ ] **Boundary declaration** present above (one-line: what repo, OSS or premium, why)
-- [ ] **Identity test**: does this PR answer "who is this agent?" or "what workspace is this?" If yes, it must go in `synapt-private`.
-- [ ] **Plugin seam**: if this extends OSS for a premium feature, is the extension seam built in OSS first, with the implementation in `synapt-private`?
+- [ ] **Identity test**: does this PR answer "who is this agent?" or "what workspace is this?" If yes, it must go in premium (`synapt-dev/premium`; local worktree `synapt-private/`).
+- [ ] **Plugin seam**: if this extends OSS for a premium feature, is the extension seam built in OSS first, with the implementation in premium (`synapt-dev/premium`; local worktree `synapt-private/`)?
 - [ ] **Boundary-adjacent check**: does this PR do any of the following? If yes to any, it requires premium migration or explicit justification.
   - Parse `workspace.toml`, `agent.toml`, or `repo.toml`
   - Derive agent identity from filesystem layout


### PR DESCRIPTION
## Summary

Updates the live recall PR template after the `synapt-private` -> `synapt.premium` rename cascade. The boundary checklist now points premium implementation work at `synapt-dev/premium` while preserving `synapt-private/` only as the local worktree-dir convention.

## Classification

- Updated: 2 current-canonical PR-template references that used `synapt-private` as repo/package shorthand.
- Left: historical docs/blog references under `docs/blog/**`.
- Left: local worktree-dir references where `synapt-private/` is intentionally the gripspace directory name.

## Verification

- `git diff --check`
- `rg -n "synapt-private|synapt_private" .github/*.md README.md *.md docs -g "*.md" -g "!docs/blog/**"` shows only the two intentional local-worktree clarifications in the updated template.

Premium boundary: docs-only boundary-template naming fix. No runtime behavior change.