### PR TITLE
docs/test: sync sprint-34 template and package-test fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,8 @@
 ### Boundary Checklist
 
 - [ ] **Boundary declaration** present above (one-line: what repo, OSS or premium, why)
-- [ ] **Identity test**: does this PR answer "who is this agent?" or "what workspace is this?" If yes, it must go in `synapt-private`.
-- [ ] **Plugin seam**: if this extends OSS for a premium feature, is the extension seam built in OSS first, with the implementation in `synapt-private`?
+- [ ] **Identity test**: does this PR answer "who is this agent?" or "what workspace is this?" If yes, it must go in premium (`synapt-dev/premium`; local worktree `synapt-private/`).
+- [ ] **Plugin seam**: if this extends OSS for a premium feature, is the extension seam built in OSS first, with the implementation in premium (`synapt-dev/premium`; local worktree `synapt-private/`)?
 - [ ] **Boundary-adjacent check**: does this PR do any of the following? If yes to any, it requires premium migration or explicit justification.
   - Parse `workspace.toml`, `agent.toml`, or `repo.toml`
   - Derive agent identity from filesystem layout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ all = [
 ]
 dev = ["watchfiles>=0.20"]
 test = [
+    "build>=1.0",
     "pytest>=7.0",
     "numpy",
     "pytest-benchmark>=4.0",

--- a/tests/integrations/test_langchain_synapt_package.py
+++ b/tests/integrations/test_langchain_synapt_package.py
@@ -13,6 +13,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_DIR = REPO_ROOT / "langchain-synapt"
 
 
+def _venv_python(venv_dir: Path) -> Path:
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
 def _run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd,
@@ -53,7 +59,7 @@ def test_langchain_synapt_installs_and_exports_history_class(tmp_path: Path) -> 
 
     venv_dir = tmp_path / "venv"
     venv.create(venv_dir, with_pip=True)
-    python = venv_dir / "bin" / "python"
+    python = _venv_python(venv_dir)
     pip = [str(python), "-m", "pip"]
 
     _run(pip + ["install", "langchain-core>=0.2"])


### PR DESCRIPTION
## Summary
- Cherry-picks the already-merged recall#835 PR-template naming fix onto `sprint-34`.
- Updates `.github/PULL_REQUEST_TEMPLATE.md` so current-policy premium destination wording uses `synapt-dev/premium` plus local worktree `synapt-private/`, instead of bare `synapt-private`.
- Adds the already-upstream `build>=1.0` test extra to sprint-34 so the existing package-wheel integration tests can run under CI.
- Adds the already-upstream portable venv Python helper so the same packaging tests use `Scripts/python.exe` on Windows.

## Why
The post-rename doc audit confirmed recall `main` is fixed, but the active target branch `sprint-34` still carried stale current-policy checklist wording. CI then exposed two more branch-divergent substrate gaps that are already fixed on main: sprint-34 missed the `build>=1.0` test dependency required by `tests/integrations/test_langchain_synapt_package.py`, and it missed the Windows venv path helper required for those tests on Windows.

## Verification
- `git diff --check audit/recall-sprint-34...HEAD`
- Targeted template scan confirms no bare current-canonical ``synapt-private`` token, `synapt-dev/synapt-private`, or `synapt_private` remains in `.github/PULL_REQUEST_TEMPLATE.md`.
- `tomllib` parse/assertion confirms `build>=1.0` is present in `[project.optional-dependencies].test`.
- Static assertion confirms `_venv_python()` handles `sys.platform == "win32"` and the packaging test calls it.
- CI rerun pending on updated head.

## Premium Boundary
Premium boundary: recall is OSS. This PR changes only OSS contributor-template wording and OSS test dependency/test portability metadata; it adds no premium implementation.
