### PR TITLE
feat(recall): cross-org direct-message silo fix (recall#820)

### DIFF
--- a/src/synapt/recall/direct.py
+++ b/src/synapt/recall/direct.py
@@ -122,6 +122,45 @@ def _inbox_path(agent_id: str, project_dir: Path | None = None) -> Path:
     return base / f"{agent_id}.jsonl"
 
 
+# recall#820 cross-org silo fix: the gripspace-local stores above (_direct_dir
+# routes through _channels_dir(project_dir)) silo direct messages per-gripspace.
+# A send from gripspace A lands in A's store; a read from gripspace B queries B's
+# store and finds nothing. The canonical cross-org root below is
+# project-INDEPENDENT (org-keyed, project component dropped) so every gripspace
+# in the org agrees on one inbox per recipient. send_message dual-writes here;
+# read_inbox union-reads from here. Design: config#359 Option A (Layne 2026-05-30).
+_DEFAULT_ORG = "synapt-dev"
+
+
+def _cross_org_root(project_dir: Path | None = None) -> Path:
+    """Resolve the project-independent, org-canonical cross-org direct root.
+
+    Resolution:
+    1. SYNAPT_SHARED_CHANNELS_DIR override -> <shared>/_cross-org/direct/.
+       This branch keeps the existing test suite + explicit shared deployments
+       isolated: because send_message now ALWAYS dual-writes here, a raw
+       Path.home() root would write into the real ~/.synapt during tests that
+       only set the shared override. Honoring the override forecloses that.
+    2. Org-canonical under home -> ~/.synapt/channels/<org>/_cross-org/direct/.
+       The org is derived from the gripspace manifest; the <project> component
+       is intentionally dropped so the root is shared across all gripspaces in
+       the org (this is the silo fix).
+    """
+    from synapt.recall.channel import _resolve_org_id, _shared_channels_dir
+
+    shared = _shared_channels_dir()
+    if shared:
+        return shared / "_cross-org" / "direct"
+    org = _resolve_org_id(project_dir) or _DEFAULT_ORG
+    return Path.home() / ".synapt" / "channels" / org / "_cross-org" / "direct"
+
+
+def _cross_org_inbox_path(to_agent: str, project_dir: Path | None = None) -> Path:
+    base = _cross_org_root(project_dir)
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{to_agent}.jsonl"
+
+
 def _db_path(project_dir: Path | None = None) -> Path:
     base = _direct_dir(project_dir)
     base.mkdir(parents=True, exist_ok=True)
@@ -248,10 +287,17 @@ def send_message(
         if deny_reason is not None:
             raise PermissionError(f"send denied: {deny_reason}")
 
-    # Write to recipient's inbox JSONL
+    # Write to recipient's inbox JSONL (gripspace-local; intra-org fast path)
     inbox = _inbox_path(to_agent, project_dir)
+    line = json.dumps(msg.to_dict(), ensure_ascii=False) + "\n"
     with open(inbox, "a", encoding="utf-8") as f:
-        f.write(json.dumps(msg.to_dict(), ensure_ascii=False) + "\n")
+        f.write(line)
+
+    # recall#820: dual-write to the project-independent cross-org canonical
+    # inbox so a recipient in a different gripspace reads it (the silo fix).
+    cross_inbox = _cross_org_inbox_path(to_agent, project_dir)
+    with open(cross_inbox, "a", encoding="utf-8") as f:
+        f.write(line)
 
     # Track in SQLite
     conn = _get_db(project_dir)
@@ -288,30 +334,106 @@ def send_message(
     return msg
 
 
+def _read_cross_org_candidates(
+    agent_id: str,
+    conn: sqlite3.Connection,
+    local_ids: set[str],
+    project_dir: Path | None,
+) -> list[DirectMessage]:
+    """Return cross-org canonical messages for agent_id not already tracked locally.
+
+    recall#820: messages sent from another gripspace have no local SQLite row
+    (their delivery state lives in the SENDER's store). This scans the canonical
+    cross-org inbox and surfaces any message whose message_id is neither in the
+    local delivered set (`local_ids`) nor already present in the local SQLite
+    `messages` table (read/acked on a prior read). Caller marks the returned
+    ones READ; messages beyond the read limit are left untracked so a later
+    read re-surfaces them.
+    """
+    cross_inbox = _cross_org_inbox_path(agent_id, project_dir)
+    if not cross_inbox.exists():
+        return []
+
+    candidates: list[DirectMessage] = []
+    seen: set[str] = set(local_ids)
+    with open(cross_inbox, encoding="utf-8") as f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            msg = DirectMessage.from_dict(data)
+            if msg.to_agent != agent_id or msg.message_id in seen:
+                continue
+            seen.add(msg.message_id)
+            already = conn.execute(
+                "SELECT 1 FROM messages WHERE message_id = ?", (msg.message_id,)
+            ).fetchone()
+            if already is not None:
+                continue
+            candidates.append(msg)
+    return candidates
+
+
+def _track_cross_org_read(
+    conn: sqlite3.Connection, msg: DirectMessage
+) -> None:
+    """Insert a local SQLite tracking row (status=READ) for a cross-org message.
+
+    Gives the cross-org message a local delivery-state row so re-reads dedup it
+    and ack_message can transition it. Idempotent via INSERT OR IGNORE.
+    """
+    now = datetime.now(timezone.utc).timestamp()
+    conn.execute(
+        """INSERT OR IGNORE INTO messages
+           (message_id, from_agent, to_agent, timestamp, body, reply_to,
+            priority, status, created_at, delivered_at, read_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            msg.message_id,
+            msg.from_agent,
+            msg.to_agent,
+            msg.timestamp,
+            msg.body,
+            msg.reply_to,
+            msg.priority,
+            STATUS_READ,
+            now,
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+
+
 def read_inbox(
     *,
     agent_id: str,
     limit: int = 20,
     project_dir: Path | None = None,
 ) -> list[DirectMessage]:
-    """Read unread messages from an agent's inbox.  Marks them as READ."""
+    """Read unread messages from an agent's inbox.  Marks them as READ.
+
+    recall#820: union of the local SQLite delivery store (intra-org fast path)
+    and the project-independent cross-org canonical inbox (cross-gripspace
+    path), deduped by message_id. Urgent messages surface first, then oldest
+    first; only the returned (post-limit) messages are marked READ.
+    """
     conn = _get_db(project_dir)
     try:
-        rows = conn.execute(
+        local_rows = conn.execute(
             """SELECT message_id, from_agent, to_agent, timestamp, body,
                       reply_to, priority
                FROM messages
-               WHERE to_agent = ? AND status = ?
-               ORDER BY
-                   CASE WHEN priority = 'urgent' THEN 0 ELSE 1 END,
-                   created_at ASC
-               LIMIT ?""",
-            (agent_id, STATUS_DELIVERED, limit),
+               WHERE to_agent = ? AND status = ?""",
+            (agent_id, STATUS_DELIVERED),
         ).fetchall()
 
-        messages = []
-        for row in rows:
-            msg = DirectMessage(
+        local_msgs = [
+            DirectMessage(
                 message_id=row["message_id"],
                 from_agent=row["from_agent"],
                 to_agent=row["to_agent"],
@@ -320,10 +442,28 @@ def read_inbox(
                 reply_to=row["reply_to"],
                 priority=row["priority"],
             )
-            messages.append(msg)
-            _transition_status(conn, msg.message_id, STATUS_READ)
+            for row in local_rows
+        ]
+        local_ids = {m.message_id for m in local_msgs}
 
-        return messages
+        cross_msgs = _read_cross_org_candidates(
+            agent_id, conn, local_ids, project_dir
+        )
+        is_cross = {m.message_id for m in cross_msgs}
+
+        combined = local_msgs + cross_msgs
+        combined.sort(
+            key=lambda m: (0 if m.priority == PRIORITY_URGENT else 1, m.timestamp)
+        )
+        returned = combined[:limit]
+
+        for msg in returned:
+            if msg.message_id in is_cross:
+                _track_cross_org_read(conn, msg)
+            else:
+                _transition_status(conn, msg.message_id, STATUS_READ)
+
+        return returned
     finally:
         conn.close()
 

--- a/tests/recall/test_direct_cross_org.py
+++ b/tests/recall/test_direct_cross_org.py
@@ -1,0 +1,191 @@
+"""Cross-org direct-messaging silo fix (recall#820).
+
+The bug: ``speak_to_agent`` reports "Delivered" on a cross-org send but the
+recipient sees nothing on their inbox-read. Root cause: both the JSONL inbox
+and the SQLite delivery-state store live under the gripspace-local
+``_channels_dir(project_dir)``. A send from gripspace A lands in A's store; a
+read from gripspace B queries B's store and finds nothing. Three months of
+cross-org direct messages may be sitting in siloed inboxes the recipient never
+reads.
+
+The fix (Layne-ratified Option A, design doc config#359
+``recall-820-cross-org-silo-fix-2026-06-07.md``): a project-independent,
+org-canonical cross-org root that ``send_message`` dual-writes to and
+``read_inbox`` union-reads from, deduping by ``message_id``.
+
+These tests reproduce the silo by NOT setting ``SYNAPT_SHARED_CHANNELS_DIR``
+(so local stores resolve per-``project_dir`` via the Tier-3 path) and isolating
+the home-anchored cross-org root via ``monkeypatch``. This is the silo the
+existing ``test_direct.py`` suite cannot reproduce: its autouse fixture sets
+``SYNAPT_SHARED_CHANNELS_DIR``, which collapses every ``project_dir`` to one
+shared store.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from synapt.recall.direct import (
+    STATUS_ACKED,
+    _clear_hooks,
+    ack_message,
+    check_status,
+    read_inbox,
+    send_message,
+)
+
+
+@pytest.fixture(autouse=True)
+def _cross_org_isolation(tmp_path, monkeypatch):
+    """Isolate the cross-org root without collapsing per-gripspace local stores.
+
+    No ``SYNAPT_SHARED_CHANNELS_DIR``: local stores resolve per-``project_dir``
+    (Tier 3), which reproduces the cross-gripspace silo. The cross-org root is
+    home-anchored, so redirect ``Path.home`` into tmp to keep the test from
+    touching the real ``~/.synapt``.
+    """
+    monkeypatch.delenv("SYNAPT_SHARED_CHANNELS_DIR", raising=False)
+    monkeypatch.setenv("SYNAPT_DATA_DIR", str(tmp_path))
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    _clear_hooks()
+    yield
+
+
+@pytest.fixture
+def gripspaces(tmp_path):
+    """Two distinct gripspace project dirs -> two distinct local stores."""
+    a = tmp_path / "gripspace_a"
+    b = tmp_path / "gripspace_b"
+    a.mkdir(parents=True, exist_ok=True)
+    b.mkdir(parents=True, exist_ok=True)
+    return a, b
+
+
+class TestCrossOrgPathResolution:
+    def test_inbox_path_is_project_independent(self) -> None:
+        # Lazy import: the symbol does not exist until the fix lands (RED).
+        from synapt.recall.direct import _cross_org_inbox_path
+
+        p_a = _cross_org_inbox_path("opus-001", project_dir=Path("/tmp/gs_a"))
+        p_b = _cross_org_inbox_path("opus-001", project_dir=Path("/tmp/gs_b"))
+        # Same recipient -> same canonical inbox regardless of sender gripspace.
+        assert p_a == p_b
+
+    def test_inbox_path_is_recipient_keyed_under_cross_org_root(self) -> None:
+        from synapt.recall.direct import _cross_org_inbox_path
+
+        p = _cross_org_inbox_path("opus-001")
+        assert p.name == "opus-001.jsonl"
+        assert p.parent.name == "direct"
+        assert p.parent.parent.name == "_cross-org"
+
+
+class TestCrossOrgDelivery:
+    def test_cross_org_roundtrip(self, gripspaces) -> None:
+        """The core silo fix: send from gripspace A, read from gripspace B."""
+        gs_a, gs_b = gripspaces
+        send_message(
+            from_agent="anchor-001",
+            to_agent="opus-001",
+            body="cross-org bubble from conversa",
+            project_dir=gs_a,
+        )
+        inbox = read_inbox(agent_id="opus-001", project_dir=gs_b)
+        assert len(inbox) == 1
+        assert inbox[0].body == "cross-org bubble from conversa"
+        assert inbox[0].from_agent == "anchor-001"
+
+    def test_cross_org_jsonl_written_at_canonical_path(self, gripspaces) -> None:
+        from synapt.recall.direct import _cross_org_inbox_path
+
+        gs_a, _ = gripspaces
+        send_message(
+            from_agent="anchor-001",
+            to_agent="opus-001",
+            body="canonical write",
+            project_dir=gs_a,
+        )
+        canonical = _cross_org_inbox_path("opus-001", project_dir=gs_a)
+        assert canonical.exists()
+        data = json.loads(canonical.read_text().strip().split("\n")[0])
+        assert data["from"] == "anchor-001"
+        assert data["to"] == "opus-001"
+        assert data["body"] == "canonical write"
+
+    def test_cross_org_read_marks_read(self, gripspaces) -> None:
+        """A second cross-org read returns empty (message tracked READ locally)."""
+        gs_a, gs_b = gripspaces
+        send_message(
+            from_agent="anchor-001",
+            to_agent="opus-001",
+            body="read once",
+            project_dir=gs_a,
+        )
+        first = read_inbox(agent_id="opus-001", project_dir=gs_b)
+        assert len(first) == 1
+        second = read_inbox(agent_id="opus-001", project_dir=gs_b)
+        assert len(second) == 0
+
+    def test_cross_org_ack_after_read(self, gripspaces) -> None:
+        """Ack works cross-org once the message has been read (local tracking row)."""
+        gs_a, gs_b = gripspaces
+        msg = send_message(
+            from_agent="anchor-001",
+            to_agent="opus-001",
+            body="ack me",
+            project_dir=gs_a,
+        )
+        read_inbox(agent_id="opus-001", project_dir=gs_b)
+        result = ack_message(
+            message_id=msg.message_id, agent_id="opus-001", project_dir=gs_b
+        )
+        assert "acknowledged" in result
+        status = check_status(message_id=msg.message_id, project_dir=gs_b)
+        assert status is not None
+        assert status["status"] == STATUS_ACKED
+
+    def test_no_duplicate_when_sender_reads_own_gripspace(self, gripspaces) -> None:
+        """Same-gripspace read dedups: the message lives in BOTH the local SQLite
+        row and the cross-org JSONL, but read_inbox returns it exactly once."""
+        gs_a, _ = gripspaces
+        send_message(
+            from_agent="anchor-001",
+            to_agent="opus-001",
+            body="no dupes",
+            project_dir=gs_a,
+        )
+        inbox = read_inbox(agent_id="opus-001", project_dir=gs_a)
+        assert len(inbox) == 1
+
+    def test_cross_org_dedup_across_repeated_reads(self, gripspaces) -> None:
+        """Sending twice yields two messages; reading does not multiply them."""
+        gs_a, gs_b = gripspaces
+        send_message(
+            from_agent="anchor-001", to_agent="opus-001", body="m1", project_dir=gs_a
+        )
+        send_message(
+            from_agent="anchor-001", to_agent="opus-001", body="m2", project_dir=gs_a
+        )
+        inbox = read_inbox(agent_id="opus-001", project_dir=gs_b)
+        bodies = sorted(m.body for m in inbox)
+        assert bodies == ["m1", "m2"]
+
+
+class TestIntraOrgBackwardCompat:
+    def test_intra_org_send_read_unchanged(self, gripspaces) -> None:
+        """Same project_dir send+read still works (no regression from dual-write)."""
+        gs_a, _ = gripspaces
+        send_message(
+            from_agent="apollo-001",
+            to_agent="opus-001",
+            body="intra-org still works",
+            project_dir=gs_a,
+        )
+        inbox = read_inbox(agent_id="opus-001", project_dir=gs_a)
+        assert len(inbox) == 1
+        assert inbox[0].body == "intra-org still works"


### PR DESCRIPTION
## recall#820 — cross-org direct-messaging silo fix

`speak_to_agent` reported "Delivered" on cross-org sends but the recipient saw nothing on inbox-read. Both the JSONL inbox **and** the SQLite delivery-state store resolve through gripspace-local `_channels_dir(project_dir)`, so a send from gripspace A landed in A's store while a read from gripspace B queried B's store and found nothing. Atlas's MCP `#dev` post timed out today; Sentinel hit `recall_channel` failures this morning. Three months of cross-org direct messages were siloed.

### Fix (Layne-ratified Option A, design `config/design/recall-820-cross-org-silo-fix-2026-06-07.md`)

- **`_cross_org_root` / `_cross_org_inbox_path`**: a project-**independent**, org-keyed canonical root — `~/.synapt/channels/<org>/_cross-org/direct/<recipient>.jsonl`. The `<project>` component is dropped so every gripspace in the org agrees on one inbox per recipient. Honors `SYNAPT_SHARED_CHANNELS_DIR` so the now-always-on dual-write stays isolated in tests + explicit shared deployments.
- **`send_message`**: dual-writes the gripspace-local inbox (intra-org fast path) + the cross-org canonical inbox (cross-gripspace delivery).
- **`read_inbox`**: unions the local SQLite delivered set with cross-org canonical messages, dedups by `message_id`, sorts urgent-then-oldest, and marks **only the returned slice** READ. A first-read cross-org message gets a local SQLite tracking row (`status=READ`) so re-reads dedup it and `ack_message` can transition it.

### Design-vs-code adaptation (disclosed — derive-and-disclose, not silent-invent)

The design doc's §4 union-read snippet assumed `read_inbox` reads from JSONL (`_read_inbox_from_path`). The **real** `read_inbox` reads SQLite-only; the JSONL is an append-only open-protocol log. So the literal "union two JSONLs" wouldn't have fixed the silo. This PR realizes the design's *intent* (canonical recipient-keyed cross-org root) against the *actual* SQLite-as-state-authority mechanism: canonical JSONL is the cross-org transport, SQLite stays local for delivery state, and union-read bridges them with a local tracking-row on first read. The observable contract (cross-org send → recipient reads it; dedup; ack roundtrip) is unchanged from the design's Test plan.

This is migration **Phase 1** (single code PR). Phase 2 backfill (one-time migration of existing siloed messages) + Phase 3/4 (migration window → drop dual-write) remain per the design.

### Tests (TDD: RED commit → GREEN commit)

`tests/recall/test_direct_cross_org.py` — 9 assertions: path resolution (project-independent + recipient-keyed), cross-org roundtrip, canonical-path write, read-marks-read, ack-after-read, same-gripspace dedup, repeated-read dedup, intra-org backward-compat.

- 9 new cross-org tests: **green**
- 30 existing `test_direct.py` tests: **green** (no regression)
- Full recall suite: **1951 passed, 17 skipped, 1 xfailed** in CI-equivalent env

### Premium boundary

OSS recall (direct-messaging transport). Recipient-keyed routing to a canonical store is routing, not identity-derivation per the identity test — org is derived via the existing OSS `_resolve_org_id`.

Closes recall#820


---

## Deferral note — sender-visible cross-org status propagation (Sentinel RC2, Opus ruling 2026-06-12)

Sentinel's review flagged that on the cross-org path the sender-side `check_status` stays `"delivered"` after the recipient reads/acks the message — sender-visible status does not propagate back across the org boundary.

**Opus ruled carve-out, not implement.** This PR ships the cross-org canonical direct-message root **without** sender-visible status propagation. That behavior is tracked in **recall#842** (filed + board-added with acceptance criteria) as the follow-on.

Scope of #839 is therefore explicit: cross-org canonical DM transport + union-read + first-read tracking-row. Sender-visible cross-org status propagation is out of scope here and lives in #842.
