### PR TITLE
test(recall): specify grep-intercept hook

### DIFF
--- a/tests/recall/test_grep_intercept_hook.py
+++ b/tests/recall/test_grep_intercept_hook.py
@@ -51,9 +51,12 @@ def test_annotation_format_for_positive_recall_hit() -> None:
         assert query == "memory leak"
         return "\n".join([
             "Past session context:",
-            "Session: alpha",
-            "Session: beta",
-            "Session: gamma",
+            "--- [cluster: memory leak triage] 2026-06-01, 4 chunks (clust-alpha) ---",
+            "Memory leak investigation context.",
+            "--- [knowledge #42] debugging (high, today) ---",
+            "Memory leak root cause was retained callbacks.",
+            "--- [2026-06-02 session beta1234] assistant turn ---",
+            "Patch landed in src/app.py.",
         ])
 
     annotated = mod.annotate_tool_result(
@@ -67,6 +70,41 @@ def test_annotation_format_for_positive_recall_hit() -> None:
         'recall: 3 related conversations (recall_search "memory leak" for detail)\n'
     )
     assert annotated.endswith(tool_result)
+
+
+def test_hit_discriminator_uses_real_recall_quick_block_shape() -> None:
+    mod = _grep_intercept()
+    recall_hit = "\n".join([
+        "Past session context:",
+        "--- [cluster: memory leak triage] 2026-06-01, 4 chunks (clust-alpha) ---",
+        "Cluster summary.",
+        "--- [knowledge #42] debugging (high, today) ---",
+        "Knowledge content.",
+        "--- [2026-06-02 session beta1234] assistant turn ---",
+        "Raw chunk content.",
+    ])
+
+    assert mod.count_related_conversations(recall_hit) == 3
+
+
+def test_hit_discriminator_treats_informative_absences_as_zero() -> None:
+    mod = _grep_intercept()
+
+    assert (
+        mod.count_related_conversations(
+            "No prior discussion found for 'licenses proceeding'. Proceeding fresh is safe."
+        )
+        == 0
+    )
+    assert (
+        mod.count_related_conversations(
+            "No indexed recall corpus available for 'anything' "
+            "(0 sessions, 0 chunks scanned). Verified absence unavailable. "
+            "The index is empty."
+        )
+        == 0
+    )
+    assert mod.count_related_conversations("No results found.") == 0
 
 
 def test_miss_or_unavailable_recall_is_silent_noop() -> None:
@@ -114,6 +152,27 @@ def test_timeout_never_blocks_the_original_grep_result() -> None:
 
     assert annotated == tool_result
     assert elapsed < 0.150
+
+
+def test_pretooluse_context_is_advisory_and_does_not_require_tool_result() -> None:
+    mod = _grep_intercept()
+    config = mod.GrepInterceptConfig(enabled=True, timeout_ms=150)
+
+    def recall_quick(query: str) -> str:
+        assert query == "memory leak"
+        return "\n".join([
+            "Past session context:",
+            "--- [cluster: memory leak triage] 2026-06-01, 4 chunks (clust-alpha) ---",
+            "Memory leak investigation context.",
+        ])
+
+    context = mod.build_pretooluse_context(
+        _bash('rg "memory leak" src'),
+        config=config,
+        recall_quick=recall_quick,
+    )
+
+    assert context == 'recall: 1 related conversations (recall_search "memory leak" for detail)'
 
 
 def test_opt_in_config_disabled_never_calls_recall_quick() -> None:

--- a/tests/recall/test_grep_intercept_hook.py
+++ b/tests/recall/test_grep_intercept_hook.py
@@ -1,0 +1,150 @@
+"""TDD contract for recall#836 grep-intercept hook."""
+
+from __future__ import annotations
+
+import importlib
+import time
+from typing import Any
+
+
+def _grep_intercept():
+    return importlib.import_module("synapt.integrations.grep_intercept")
+
+
+def _bash(command: str) -> dict[str, Any]:
+    return {"tool_name": "Bash", "input": {"command": command}}
+
+
+def _grep_tool(pattern: str, *, path: str = ".") -> dict[str, Any]:
+    return {"tool_name": "Grep", "input": {"pattern": pattern, "path": path}}
+
+
+def test_extracts_patterns_from_grep_and_rg_shapes() -> None:
+    mod = _grep_intercept()
+
+    cases = [
+        (_bash('rg -n "memory leak" src tests'), "memory leak"),
+        (_bash("rg --fixed-strings 'SYNAPT_SHARED_CHANNELS_DIR' src"), "SYNAPT_SHARED_CHANNELS_DIR"),
+        (_bash("grep -R --line-number 'modal_execution_requested' active-compression"), "modal_execution_requested"),
+        (_bash("grep -- 'literal-leading-dash' README.md"), "literal-leading-dash"),
+        (_grep_tool("recall_quick verified absence", path="src"), "recall_quick verified absence"),
+    ]
+
+    for tool_call, expected in cases:
+        assert mod.extract_grep_pattern(tool_call) == expected
+
+
+def test_non_grep_commands_are_ignored() -> None:
+    mod = _grep_intercept()
+
+    assert mod.extract_grep_pattern(_bash("git status --short")) is None
+    assert mod.extract_grep_pattern(_bash("python -m pytest tests/recall -q")) is None
+    assert mod.extract_grep_pattern({"tool_name": "Read", "input": {"file_path": "README.md"}}) is None
+
+
+def test_annotation_format_for_positive_recall_hit() -> None:
+    mod = _grep_intercept()
+    config = mod.GrepInterceptConfig(enabled=True, timeout_ms=150)
+    tool_result = "src/app.py:10: memory leak fixed here"
+
+    def recall_quick(query: str) -> str:
+        assert query == "memory leak"
+        return "\n".join([
+            "Past session context:",
+            "Session: alpha",
+            "Session: beta",
+            "Session: gamma",
+        ])
+
+    annotated = mod.annotate_tool_result(
+        _bash('rg "memory leak" src'),
+        tool_result,
+        config=config,
+        recall_quick=recall_quick,
+    )
+
+    assert annotated.startswith(
+        'recall: 3 related conversations (recall_search "memory leak" for detail)\n'
+    )
+    assert annotated.endswith(tool_result)
+
+
+def test_miss_or_unavailable_recall_is_silent_noop() -> None:
+    mod = _grep_intercept()
+    config = mod.GrepInterceptConfig(enabled=True, timeout_ms=150)
+    tool_result = "grep output remains untouched"
+
+    miss = mod.annotate_tool_result(
+        _bash('rg "unseen topic" .'),
+        tool_result,
+        config=config,
+        recall_quick=lambda _query: "No prior discussion found for 'unseen topic'. Proceeding fresh is safe.",
+    )
+    assert miss == tool_result
+
+    def unavailable(_query: str) -> str:
+        raise RuntimeError("recall index unavailable")
+
+    failure = mod.annotate_tool_result(
+        _bash('rg "unseen topic" .'),
+        tool_result,
+        config=config,
+        recall_quick=unavailable,
+    )
+    assert failure == tool_result
+
+
+def test_timeout_never_blocks_the_original_grep_result() -> None:
+    mod = _grep_intercept()
+    config = mod.GrepInterceptConfig(enabled=True, timeout_ms=25)
+    tool_result = "src/app.py:10: needle"
+
+    def slow_recall(_query: str) -> str:
+        time.sleep(0.30)
+        return "Past session context:\nSession: too-late"
+
+    started = time.perf_counter()
+    annotated = mod.annotate_tool_result(
+        _bash('rg "needle" src'),
+        tool_result,
+        config=config,
+        recall_quick=slow_recall,
+    )
+    elapsed = time.perf_counter() - started
+
+    assert annotated == tool_result
+    assert elapsed < 0.150
+
+
+def test_opt_in_config_disabled_never_calls_recall_quick() -> None:
+    mod = _grep_intercept()
+    config = mod.GrepInterceptConfig(enabled=False, timeout_ms=150)
+    calls: list[str] = []
+
+    def recall_quick(query: str) -> str:
+        calls.append(query)
+        return "Past session context:\nSession: should-not-run"
+
+    result = mod.annotate_tool_result(
+        _grep_tool("feature flag"),
+        "src/config.py:1: feature flag",
+        config=config,
+        recall_quick=recall_quick,
+    )
+
+    assert result == "src/config.py:1: feature flag"
+    assert calls == []
+
+
+def test_claude_pretooluse_settings_snippet_is_opt_in_and_bounded() -> None:
+    mod = _grep_intercept()
+
+    snippet = mod.claude_pretooluse_settings_snippet(enabled=True, timeout_ms=150)
+
+    assert "hooks" in snippet
+    assert "PreToolUse" in snippet["hooks"]
+    matcher = snippet["hooks"]["PreToolUse"][0]
+    assert matcher["matcher"] == "Bash|Grep"
+    hook = matcher["hooks"][0]
+    assert hook["command"] == "synapt recall grep-intercept"
+    assert hook["timeout"] <= 1


### PR DESCRIPTION
## Summary

Spec-first PR for recall#836. Adds failing tests that define the grep-intercept hook contract:

- pattern extraction from Bash `rg` / `grep` command shapes and Claude-style `Grep` tool input
- non-grep commands ignored
- positive recall hit annotation format:
  - `recall: N related conversations (recall_search "<pattern>" for detail)`
- named hit-discriminator seam: `count_related_conversations(recall_output)` counts real `recall_quick` hit blocks under `Past session context:` and does **not** count `Session:` lines from a mock-only shape
- non-hit set includes #837 informative absence output, empty-corpus / verified-absence-unavailable output, and generic no-result output
- `build_pretooluse_context(...)` pins the runtime hook point as PreToolUse advisory context: it does not require a grep result and returns the one-line recall annotation as context
- `annotate_tool_result(...)` remains the pure/testable post-result formatter for callers that do have a tool result
- silent no-op on recall miss or recall unavailable
- timeout behavior: original grep result must return within the <150ms target even if recall is slow
- opt-in config: disabled config never calls `recall_quick`
- Claude `PreToolUse` settings snippet shape: matcher `Bash|Grep`, command `synapt recall grep-intercept`, bounded timeout

The tests target a new OSS integration seam at `synapt.integrations.grep_intercept` with `GrepInterceptConfig`, `extract_grep_pattern`, `count_related_conversations`, `build_pretooluse_context`, `annotate_tool_result`, and `claude_pretooluse_settings_snippet` as the contract surface. This is tests-only TDD substrate targeting `sprint-34`; failures are expected until implementation lands.

## Apollo contract-read resolution

Apollo correctly found that the original mock hit shape counted `Session:` lines, while real `recall_quick` hit output is `Past session context:` plus formatted blocks such as `--- [cluster: ...]`, `--- [knowledge ...]`, and raw/source chunk blocks. Commit `516bd7b` fixes the spec to ground the discriminator against the real output shape.

Hook-point decision: runtime is PreToolUse/advisory. The CLI command should emit additional context before grep runs. `annotate_tool_result` stays as a pure library helper for post-result callers, but the PreToolUse path is pinned by `build_pretooluse_context(...)`.

## Verification

- `python -m py_compile tests/recall/test_grep_intercept_hook.py` -> pass
- `ruff check tests/recall/test_grep_intercept_hook.py` -> pass
- `git diff --check` -> pass
- `python -m pytest tests/recall/test_grep_intercept_hook.py -q` -> expected RED: 10 failed because `synapt.integrations.grep_intercept` does not exist yet

## Premium Boundary

OSS-only retrieval/integration surface. No identity, org, entitlement, license, or premium behavior is introduced.

Closes recall#836 after implementation satisfies this spec.
