### PR TITLE
feat(recall): informative recall_quick misses (recall#837)

### DIFF
--- a/src/synapt/recall/core.py
+++ b/src/synapt/recall/core.py
@@ -213,6 +213,14 @@ class TranscriptChunk:
 
 
 @dataclass
+class NearMiss:
+    """A sub-threshold candidate surfaced by recall#837 informative misses."""
+
+    topic: str
+    score: float
+
+
+@dataclass
 class SearchDiagnostics:
     """Diagnostic info collected when a search returns no results."""
 
@@ -224,6 +232,15 @@ class SearchDiagnostics:
     date_filter_active: bool = False
     embeddings_available: bool = True  # False when search ran without embeddings
     reason: str = ""                 # empty_index, empty_query, no_matches
+    # recall#837 informative-miss coverage. Consumed by recall_quick via
+    # _format_informative_miss (which maps empty_index -> empty_corpus and
+    # no_matches -> below_threshold). recall_search keeps using format_message,
+    # so these fields are additive and do not change recall_search behavior.
+    chunks_scanned: int = 0
+    best_score: float | None = None
+    threshold: float = 0.0
+    oldest_session_started_at: str | None = None
+    near_misses: list = field(default_factory=list)
 
     def format_message(self) -> str:
         """Format diagnostic information as a user-facing message."""
@@ -1680,6 +1697,11 @@ class TranscriptIndex:
         freshness = math.exp(-decay_rate * age_days)
         return 1.0 + (1.5 * freshness)
 
+    def _oldest_indexed_date(self) -> str | None:
+        """recall#837: oldest indexed chunk date (YYYY-MM-DD) for miss coverage."""
+        stamps = [c.timestamp for c in self.chunks if c.timestamp]
+        return min(stamps)[:10] if stamps else None
+
     def _apply_threshold_with_diagnostics(
         self,
         candidates: list[tuple[int, float]],
@@ -1705,9 +1727,15 @@ class TranscriptIndex:
                 candidates_found=0,
                 search_mode=search_mode,
                 date_filter_active=date_filter_active,
-                sessions_searched=sessions_searched,
+                sessions_searched=sessions_searched or len(self.sessions),
                 embeddings_available=embeddings_available,
                 reason="no_matches",
+                # recall#837: coverage stats so recall_quick can render a
+                # confident verified-absence instead of an empty result.
+                chunks_scanned=len(self.chunks),
+                best_score=0.0,
+                threshold=threshold_ratio,
+                oldest_session_started_at=self._oldest_indexed_date(),
             )
             return []
 
@@ -1795,7 +1823,12 @@ class TranscriptIndex:
         # (cold-start: recall_save was called but no conversations ingested)
         has_knowledge = self._db and self._db.knowledge_count() > 0
         if not self.chunks and not has_knowledge:
-            self._last_diagnostics = SearchDiagnostics(reason="empty_index")
+            self._last_diagnostics = SearchDiagnostics(
+                reason="empty_index",
+                chunks_scanned=0,
+                best_score=0.0,
+                threshold=threshold_ratio,
+            )
             return ""
 
         # Check query cache — skip if max_tokens=0 (diagnostics-only mode)
@@ -1997,7 +2030,7 @@ class TranscriptIndex:
         if depth == "concise":
             return self._concise_lookup(
                 query, max_chunks, max_tokens, knowledge_results,
-                include_archived,
+                include_archived, threshold_ratio=threshold_ratio,
             )
 
         fts_results = self._db.fts_search(query, limit=max_chunks * 10)
@@ -2257,6 +2290,7 @@ class TranscriptIndex:
         max_tokens: int,
         knowledge_results: list[dict] | None = None,
         include_archived: bool = False,
+        threshold_ratio: float = 0.2,
     ) -> str:
         """Search clusters directly and return only summaries.
 
@@ -2273,6 +2307,21 @@ class TranscriptIndex:
                 query, limit=max_chunks * 3, include_archived=include_archived,
             )
         if not cluster_hits and not knowledge_results:
+            # recall#837: concise mode mirrors the full/summary no_matches path
+            # so recall_quick can render an informative verified-absence instead
+            # of an empty result.
+            self._last_diagnostics = SearchDiagnostics(
+                total_chunks=len(self.chunks),
+                total_sessions=len(self.sessions),
+                candidates_found=0,
+                search_mode="concise",
+                sessions_searched=len(self.sessions),
+                reason="no_matches",
+                chunks_scanned=len(self.chunks),
+                best_score=0.0,
+                threshold=threshold_ratio,
+                oldest_session_started_at=self._oldest_indexed_date(),
+            )
             return ""
 
         wm = self._working_memory
@@ -2372,9 +2421,12 @@ class TranscriptIndex:
         agent_id: str | None = None,
     ) -> str:
         """Global lookup using in-memory BM25 (legacy fallback)."""
-        # BM25 path has no cluster FTS — concise mode requires FTS5
+        # BM25 path has no cluster FTS, so concise mode (cluster summaries) is
+        # unsupported. Fall back to summary depth rather than returning ""
+        # silently, so recall#837 informative misses still fire on a no-match
+        # (the no_matches diagnostics get set via _apply_threshold_with_diagnostics).
         if depth == "concise":
-            return ""
+            depth = "summary"
 
         scores = self._bm25.score(query_tokens)
 

--- a/src/synapt/recall/server.py
+++ b/src/synapt/recall/server.py
@@ -369,6 +369,69 @@ def recall_search(
         return f"Search failed: {exc}"
 
 
+def _top_near_misses(diag, limit: int = 2) -> list:
+    """recall#837: the highest-scored candidates strictly below threshold, capped.
+
+    recall_quick owns this ordering rather than trusting producer input order:
+    keep scores strictly below threshold, sort by score descending, cap at limit.
+    """
+    near = getattr(diag, "near_misses", None) or []
+    threshold = getattr(diag, "threshold", 0.0)
+    below = [nm for nm in near if nm.score < threshold]
+    below.sort(key=lambda nm: nm.score, reverse=True)
+    return below[:limit]
+
+
+def _format_informative_miss(query: str, diag) -> str:
+    """recall#837: render a recall_quick miss as a confident, coverage-stated
+    negative instead of an empty result, so a verified absence reads as a real
+    answer rather than tool failure. Reason-keyed. The exact strings are the
+    contract (tests/recall/test_quick_informative_misses.py).
+    """
+    reason = getattr(diag, "reason", "")
+    # Map legacy producer reasons (emitted by the real index.lookup path) onto
+    # the recall#837 informative-miss vocabulary used by the recall#843 spec
+    # stubs, so real misses render the same output as the mocked tests.
+    reason = {
+        "empty_index": "empty_corpus",
+        "no_matches": "below_threshold",
+    }.get(reason, reason)
+
+    if reason == "empty_corpus":
+        # Nothing was indexed, so an absence cannot be verified.
+        return (
+            f"No indexed recall corpus available for '{query}' "
+            f"({diag.sessions_searched} sessions, {diag.chunks_scanned} chunks scanned). "
+            f"Verified absence unavailable. The index is empty."
+        )
+
+    if reason == "threshold_boundary":
+        # Best match sits at the threshold: a borderline hit, not an absence.
+        # Defer to the hit path rather than claim a verified absence.
+        return (
+            f"Borderline match for '{query}' at the score threshold. "
+            f"Not a verified absence. Try recall_search for the full result."
+        )
+
+    if reason == "below_threshold":
+        lines = [
+            f"No prior discussion found for '{query}' "
+            f"(searched {diag.sessions_searched} sessions back to "
+            f"{diag.oldest_session_started_at}, {diag.chunks_scanned} chunks scanned, "
+            f"best score {diag.best_score:.2f} below threshold {diag.threshold:.2f})."
+        ]
+        near = _top_near_misses(diag)
+        if near:
+            lines.append("Closest near misses:")
+            for near_miss in near:
+                lines.append(f'- "{near_miss.topic}" at {near_miss.score:.2f}')
+        lines.append("Proceeding fresh is safe.")
+        return "\n".join(lines)
+
+    # Unknown or legacy reason: safe, non-absence fallback.
+    return "No results found."
+
+
 def recall_quick(query: str) -> str:
     """Quick, low-cost memory check. Use this speculatively — when you're
     not sure if past context exists but want to check.
@@ -416,8 +479,8 @@ def recall_quick(query: str) -> str:
         if result:
             return result
         diag = index._last_diagnostics
-        if diag:
-            return diag.format_message()
+        if diag is not None:
+            return _format_informative_miss(query, diag)
         return "No results found."
     except Exception as exc:
         return f"Search failed: {exc}"

--- a/tests/recall/test_informative_misses_producer.py
+++ b/tests/recall/test_informative_misses_producer.py
@@ -1,0 +1,83 @@
+"""Producer-side coverage for recall#837.
+
+test_quick_informative_misses.py pins the consumer (recall_quick) against a
+mocked _get_index. These tests close the producer/consumer gap: the REAL
+index.lookup() must populate SearchDiagnostics with coverage so recall_quick
+renders informative misses for real searches, not only under the mock.
+
+The producer keeps emitting its legacy reasons (empty_index / no_matches) so
+recall_search's format_message path is unchanged; recall_quick maps those onto
+the informative-miss vocabulary (empty_corpus / below_threshold).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from synapt.recall.core import TranscriptChunk, TranscriptIndex
+from synapt.recall.storage import RecallDB
+
+
+def _index_with_one_chunk(tmp_path) -> TranscriptIndex:
+    db = RecallDB(tmp_path / "recall.db")
+    chunk = TranscriptChunk(
+        id="sess1:t0",
+        session_id="sess1",
+        timestamp="2026-05-01T09:00:00+00:00",
+        turn_index=0,
+        user_text="we discussed kubernetes deployment manifests at length",
+        assistant_text="here is the helm chart for the kubernetes cluster",
+    )
+    return TranscriptIndex([chunk], use_embeddings=False, cache_dir=tmp_path, db=db)
+
+
+def test_real_lookup_no_match_populates_below_threshold_coverage(tmp_path) -> None:
+    index = _index_with_one_chunk(tmp_path)
+    # Tokens that cannot match the single kubernetes chunk.
+    result = index.lookup("xylophone marsupial zzzznonexistent", threshold_ratio=0.2)
+    assert result == ""
+    diag = index._last_diagnostics
+    assert diag is not None
+    assert diag.reason == "no_matches"  # recall_quick maps this to below_threshold
+    assert diag.chunks_scanned == 1
+    assert diag.best_score == 0.0
+    assert diag.threshold == 0.2
+    assert diag.oldest_session_started_at == "2026-05-01"
+
+
+def test_real_lookup_drives_recall_quick_verified_absence(tmp_path) -> None:
+    index = _index_with_one_chunk(tmp_path)
+    with patch("synapt.recall.server._get_index", return_value=index):
+        from synapt.recall.server import recall_quick
+
+        out = recall_quick("xylophone marsupial zzzznonexistent")
+    assert "No prior discussion found for 'xylophone marsupial zzzznonexistent'" in out
+    assert "1 chunks scanned" in out
+    assert "best score 0.00 below threshold 0.20" in out
+    assert "back to 2026-05-01" in out
+    assert "Proceeding fresh is safe." in out
+    assert "No results found." not in out
+
+
+def test_real_empty_index_drives_empty_corpus(tmp_path) -> None:
+    db = RecallDB(tmp_path / "recall.db")
+    index = TranscriptIndex([], use_embeddings=False, cache_dir=tmp_path, db=db)
+    with patch("synapt.recall.server._get_index", return_value=index):
+        from synapt.recall.server import recall_quick
+
+        out = recall_quick("anything at all")
+    assert "No indexed recall corpus available for 'anything at all'" in out
+    assert "Verified absence unavailable" in out
+    assert "Proceeding fresh is safe." not in out
+
+
+def test_empty_index_reason_unchanged_for_format_message(tmp_path) -> None:
+    # recall_search still relies on SearchDiagnostics.format_message with the
+    # legacy reasons; the producer must not have changed that contract.
+    db = RecallDB(tmp_path / "recall.db")
+    index = TranscriptIndex([], use_embeddings=False, cache_dir=tmp_path, db=db)
+    index.lookup("anything", threshold_ratio=0.2)
+    diag = index._last_diagnostics
+    assert diag is not None
+    assert diag.reason == "empty_index"
+    assert "index is empty" in diag.format_message().lower()


### PR DESCRIPTION
## recall#837: informative recall_quick misses

Turns a `recall_quick` miss into a confident, coverage-stated negative instead of an empty result, so a verified absence reads as a real answer rather than tool failure (the trust-asymmetry that drives agents to grep).

**Premium boundary:** OSS (recall retrieval diagnostics; no identity/org semantics).

`Ref #837` — see "Scope" below for why this is `Ref` not `Closes`.

### Contract
Implements the recall#843 TDD spec (merged at 86f7be0). Contract-read + Sentinel's ruling: https://github.com/synapt-dev/recall/pull/843

### Consumer (`server.py`)
`recall_quick` renders reason-keyed informative misses via `_format_informative_miss`, reading structured `SearchDiagnostics` fields. Maps the producer's legacy reasons (`empty_index` -> `empty_corpus`, `no_matches` -> `below_threshold`) so real misses render the same output as the spec stubs. `recall_quick` owns the near-miss ordering (strict below threshold, descending, max two) per the pin.

### Producer (`core.py`)
`SearchDiagnostics` gains coverage fields (`chunks_scanned`, `best_score`, `threshold`, `oldest_session_started_at`, `near_misses`) plus a `NearMiss` type, populated at the `empty_index`, `no_matches` (full/summary), and concise miss sites so the **real** `index.lookup()` drives informative misses, not only the mocked `_get_index`. This closes the producer/consumer gap I raised in the contract-read.

- `recall_search`'s `format_message` path is **unchanged** — legacy reasons preserved, new fields additive.
- bm25 concise falls back to `summary` (it has no cluster FTS) so `recall_quick` gets diagnostics on in-memory indexes too, rather than silently returning "".

### Tests
- 5 consumer spec tests (recall#843) green.
- 4 producer-side coverage tests (`test_informative_misses_producer.py`): real `lookup()` no-match populates `below_threshold` coverage; real lookup drives recall_quick verified-absence; empty index drives `empty_corpus`; `format_message` unchanged for recall_search.
- Full recall suite: **1956 passed**. The 4 `test_attribution` failures are a local `SYNAPT_AGENT_ID` env artifact (green with `env -u SYNAPT_AGENT_ID`), not a regression. CI has no such var.

### Scope (please confirm, @Sentinel)
This PR ships the **verified-absence + coverage** (the issue's core "confident no-prior-discussion-found"). The optional **near-miss suggestion** (the issue's "Optionally suggest 1-2 near-miss topics") is **deferred**: the producer populates `near_misses=[]` for now. Capturing real near-misses needs an absolute quick-floor over the current **relative** threshold (`cutoff = max(score) * ratio`, where the top candidate always survives), which touches the score scale and warrants its own eval-checked PR. The consumer already renders `near_misses` when present (recall#843 test 2 proves it under the mock).

Hence `Ref #837` not `Closes`: your call whether to close #837 as core-done with a new issue tracking near-miss capture, or keep it open for that follow-on.

### Reviewers
Two-distinct-display-name gate. Sentinel (spec author): confirm the near-miss deferral + the legacy-reason-mapping approach (vs emitting new vocabulary at the producer). Second reviewer for correctness + boundary.
