### PR TITLE
fix(speak_to_agent): deliver via tmux paste-buffer to the recipient's pane (recall#852)

### DIFF
--- a/src/synapt/recall/direct.py
+++ b/src/synapt/recall/direct.py
@@ -16,12 +16,15 @@ Hook registration for premium:
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 MAX_BODY_SIZE = 65536  # 64KB default cap
 
@@ -413,6 +416,186 @@ def message_history(
 
 
 # ---------------------------------------------------------------------------
+# tmux delivery (recall#852) -- OSS transport
+#
+# The inbox write is durable but passive: the recipient has to poll it. This
+# layer ALSO delivers the message into the recipient's live tmux pane via
+# load-buffer + paste-buffer + send-keys, the mechanism that actually lands.
+# Boundary: the tmux MECHANICS are OSS transport. The agent->pane map is
+# operator-supplied data read from a neutral env/config seam (SYNAPT_AGENT_PANES),
+# NOT identity topology hardcoded into OSS -- resolving "who is at which pane" is
+# operator config, the same shape as an /etc/hosts routing table.
+# ---------------------------------------------------------------------------
+
+# Pastes at/above this size tend to collapse in the recipient TUI ("paste again
+# to expand"); we send one extra guarded Enter to expand before the submit Enter.
+LARGE_PASTE_THRESHOLD = 1200
+
+# Runtime -> Enter count. Claude needs paste-expand + submit; Codex folds large
+# pastes so it needs an extra fold-expand first.
+_ENTER_COUNT = {"claude": 2, "codex": 3}
+
+_TMUX_BUFFER = "synapt_speak_to_agent"
+
+# A short pause between key sends so the TUI registers each Enter separately
+# rather than coalescing expand and submit into one keystroke.
+_SEND_KEY_PAUSE_SECONDS = 0.15
+
+
+@dataclass(frozen=True)
+class PaneTarget:
+    """Where (and how) to deliver to an agent's live session."""
+
+    target: str
+    runtime: str
+
+
+@dataclass
+class TmuxDelivery:
+    """Result of a best-effort tmux delivery."""
+
+    delivered: bool
+    target: str | None
+    enters: int
+    detail: str
+
+
+def enter_count(runtime: str | None) -> int:
+    """Enter keystrokes needed to submit a paste for this runtime.
+
+    Claude=2 (paste-expand + submit), Codex=3 (fold-expand + paste-expand +
+    submit). Unknown runtimes default to the Claude count.
+    """
+    return _ENTER_COUNT.get((runtime or "").strip().lower(), 2)
+
+
+def load_pane_map() -> dict[str, Any]:
+    """Operator-supplied agent->pane map (neutral routing table, not identity).
+
+    Source order: the ``SYNAPT_AGENT_PANES`` env var as a JSON object, else the
+    JSON file at ``SYNAPT_AGENT_PANES_FILE``. Defaults to an empty map (which
+    makes delivery a no-op so the send falls back to inbox-only). OSS never
+    hardcodes the workspace's agent topology -- that is operator config.
+
+    Format (operator-supplied)::
+
+        {"<agent>": {"target": "<tmux-session>:<window>", "runtime": "claude|codex"}}
+    """
+    raw = os.environ.get("SYNAPT_AGENT_PANES")
+    if raw:
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+    path = os.environ.get("SYNAPT_AGENT_PANES_FILE")
+    if path and Path(path).exists():
+        try:
+            return json.loads(Path(path).read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            return {}
+    return {}
+
+
+def _normalize_agent_key(to_agent: str) -> str:
+    # Recipients may arrive bare ("apollo"), org-prefixed ("synapt:apollo"), or
+    # cased; the pane map is keyed by the bare lower-case agent name.
+    key = to_agent.strip().lower()
+    if ":" in key:
+        key = key.split(":", 1)[1]
+    return key
+
+
+def resolve_pane(to_agent: str, pane_map: dict[str, Any]) -> PaneTarget | None:
+    """Resolve a recipient to its PaneTarget via the operator map, or None."""
+    if not to_agent or not pane_map:
+        return None
+    entry = pane_map.get(to_agent) or pane_map.get(_normalize_agent_key(to_agent))
+    if not isinstance(entry, dict) or not entry.get("target"):
+        return None
+    return PaneTarget(target=str(entry["target"]), runtime=str(entry.get("runtime", "claude")))
+
+
+def build_tmux_commands(
+    target: str,
+    runtime: str | None,
+    body: str,
+    *,
+    buffer_name: str = _TMUX_BUFFER,
+    large_threshold: int = LARGE_PASTE_THRESHOLD,
+) -> tuple[list[list[str]], int]:
+    """Build the tmux command sequence + the Enter count it will send.
+
+    load-buffer (body via stdin, never shell-escaped) -> paste-buffer into the
+    target pane (-d deletes the buffer after) -> N send-keys Enter, where N is the
+    runtime Enter count plus one guarded Enter when the paste is collapse-large.
+    """
+    enters = enter_count(runtime)
+    if len(body) >= large_threshold:
+        enters += 1
+    cmds: list[list[str]] = [
+        ["tmux", "load-buffer", "-b", buffer_name, "-"],
+        ["tmux", "paste-buffer", "-t", target, "-b", buffer_name, "-d"],
+    ]
+    cmds += [["tmux", "send-keys", "-t", target, "Enter"] for _ in range(enters)]
+    return cmds, enters
+
+
+def _run_tmux(cmd: list[str], *, input: str | None = None) -> Any:
+    """Default tmux runner (injectable for tests)."""
+    return subprocess.run(cmd, input=input, capture_output=True, text=True, timeout=10)
+
+
+def deliver_via_tmux(
+    target: str,
+    runtime: str | None,
+    body: str,
+    *,
+    run: Callable[..., Any] | None = None,
+    sleep: Callable[[float], Any] | None = None,
+    buffer_name: str = _TMUX_BUFFER,
+    large_threshold: int = LARGE_PASTE_THRESHOLD,
+) -> TmuxDelivery:
+    """Best-effort delivery into a live tmux pane. Never raises.
+
+    On any failure (missing pane, no tmux binary, error) ``delivered`` is False
+    and ``detail`` carries the reason, so the caller can fall back to the durable
+    inbox without an exception escaping. ``run``/``sleep`` resolve to the module
+    defaults at call time (not bound as parameter defaults) so tests can
+    monkeypatch ``_run_tmux``.
+    """
+    run = run or _run_tmux
+    sleep = sleep or time.sleep
+    cmds, enters = build_tmux_commands(target, runtime, body, buffer_name=buffer_name, large_threshold=large_threshold)
+    try:
+        for cmd in cmds:
+            is_load = cmd[:2] == ["tmux", "load-buffer"]
+            is_send = cmd[:2] == ["tmux", "send-keys"]
+            if is_send:
+                # Pause before each Enter: the first lets the paste register
+                # before expand; later ones keep expand and submit distinct.
+                sleep(_SEND_KEY_PAUSE_SECONDS)
+            result = run(cmd, input=body if is_load else None)
+            returncode = getattr(result, "returncode", 0)
+            if returncode != 0:
+                detail = getattr(result, "stderr", "") or f"tmux exited {returncode}"
+                return TmuxDelivery(delivered=False, target=target, enters=enters, detail=f"{cmd[1]} failed for {target}: {detail}".strip())
+    except FileNotFoundError:
+        return TmuxDelivery(delivered=False, target=target, enters=enters, detail="tmux not available")
+    except Exception as exc:  # never let delivery break the send
+        return TmuxDelivery(delivered=False, target=target, enters=enters, detail=f"tmux delivery error: {exc}")
+    return TmuxDelivery(delivered=True, target=target, enters=enters, detail=f"pasted to {target} ({enters} Enter(s))")
+
+
+def _attempt_tmux_delivery(to_agent: str, body: str) -> TmuxDelivery | None:
+    """Resolve the recipient's pane from the operator map and deliver, or None
+    when no pane is configured (caller then reports inbox-only)."""
+    pane = resolve_pane(to_agent, load_pane_map())
+    if pane is None:
+        return None
+    return deliver_via_tmux(pane.target, pane.runtime, body)
+
+
+# ---------------------------------------------------------------------------
 # MCP tool function
 # ---------------------------------------------------------------------------
 
@@ -465,10 +648,17 @@ def speak_to_agent(
                 reply_to=reply_to,
                 priority=priority,
             )
-            return (
-                f"Sent to {to}: {msg.message_id}\n"
-                f"Status: delivered (written to {to}'s inbox)"
-            )
+            # The inbox write above is the durable record. Now also push the
+            # message into the recipient's live tmux pane so it actually lands
+            # (recall#852) -- best-effort, never breaks the send.
+            delivery = _attempt_tmux_delivery(to, message)
+            if delivery is None:
+                status = f"Status: written to {to}'s inbox (no tmux pane configured; inbox-only)"
+            elif delivery.delivered:
+                status = f"Status: written to {to}'s inbox AND delivered to live pane {delivery.target} via tmux"
+            else:
+                status = f"Status: written to {to}'s inbox; tmux delivery did not land ({delivery.detail})"
+            return f"Sent to {to}: {msg.message_id}\n{status}"
 
         elif action == "read":
             messages = read_inbox(agent_id=agent_id, limit=limit)

--- a/tests/recall/test_speak_to_agent_tmux.py
+++ b/tests/recall/test_speak_to_agent_tmux.py
@@ -1,0 +1,190 @@
+"""Contract for speak_to_agent tmux delivery (recall#852).
+
+speak_to_agent used to write a passive inbox the recipient had to poll. This locks
+the fix: on send it ALSO resolves the recipient to a tmux pane and delivers via
+load-buffer + paste-buffer + send-keys, with a runtime-aware Enter count
+(Claude=2, Codex=3) and an extra guarded Enter for large pastes that collapse.
+
+Boundary discipline (locked here): the tmux MECHANICS are OSS transport; the
+agent->pane map is operator-supplied data read from a neutral env/config seam, NOT
+hardcoded identity topology. resolve_pane on an empty map returns None -> the send
+falls back to inbox-only, never raising.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from synapt.recall.direct import (
+    LARGE_PASTE_THRESHOLD,
+    PaneTarget,
+    TmuxDelivery,
+    build_tmux_commands,
+    deliver_via_tmux,
+    enter_count,
+    load_pane_map,
+    resolve_pane,
+    speak_to_agent,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNAPT_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("SYNAPT_SHARED_CHANNELS_DIR", str(tmp_path / "channels"))
+    (tmp_path / "channels" / "direct").mkdir(parents=True, exist_ok=True)
+    monkeypatch.delenv("SYNAPT_AGENT_PANES", raising=False)
+    monkeypatch.delenv("SYNAPT_AGENT_PANES_FILE", raising=False)
+    yield
+
+
+# ── runtime-aware Enter count ──────────────────────────────────────
+
+
+def test_enter_count_claude_is_two():
+    assert enter_count("claude") == 2
+
+
+def test_enter_count_codex_is_three():
+    assert enter_count("codex") == 3
+
+
+def test_enter_count_unknown_runtime_defaults_to_two():
+    assert enter_count("something-else") == 2
+    assert enter_count(None) == 2
+
+
+# ── pane map (neutral operator-supplied seam) ──────────────────────
+
+
+def test_load_pane_map_from_env_json(monkeypatch):
+    monkeypatch.setenv("SYNAPT_AGENT_PANES", json.dumps({"apollo": {"target": "synapt:3", "runtime": "claude"}}))
+    pane_map = load_pane_map()
+    assert pane_map["apollo"]["target"] == "synapt:3"
+
+
+def test_load_pane_map_defaults_empty_when_unset():
+    assert load_pane_map() == {}
+
+
+def test_resolve_pane_exact_and_normalized():
+    pane_map = {"apollo": {"target": "synapt:3", "runtime": "claude"}, "atlas": {"target": "synapt:4", "runtime": "codex"}}
+    assert resolve_pane("apollo", pane_map) == PaneTarget(target="synapt:3", runtime="claude")
+    # case-insensitive + org-prefixed recipient both normalize to the bare agent key
+    assert resolve_pane("Apollo", pane_map) == PaneTarget(target="synapt:3", runtime="claude")
+    assert resolve_pane("synapt:atlas", pane_map) == PaneTarget(target="synapt:4", runtime="codex")
+
+
+def test_resolve_pane_missing_returns_none():
+    assert resolve_pane("ghost", {"apollo": {"target": "synapt:3", "runtime": "claude"}}) is None
+    assert resolve_pane("apollo", {}) is None
+
+
+# ── tmux command sequence ──────────────────────────────────────────
+
+
+def test_build_tmux_commands_sequence_for_claude():
+    cmds, enters = build_tmux_commands("synapt:3", "claude", "hi", buffer_name="b")
+    assert enters == 2
+    assert cmds[0] == ["tmux", "load-buffer", "-b", "b", "-"]            # body piped via stdin
+    assert cmds[1] == ["tmux", "paste-buffer", "-t", "synapt:3", "-b", "b", "-d"]
+    send_keys = [c for c in cmds if c[:2] == ["tmux", "send-keys"]]
+    assert send_keys == [["tmux", "send-keys", "-t", "synapt:3", "Enter"]] * 2
+
+
+def test_build_tmux_commands_codex_gets_three_enters():
+    cmds, enters = build_tmux_commands("synapt:4", "codex", "hi", buffer_name="b")
+    assert enters == 3
+    assert sum(1 for c in cmds if c[:2] == ["tmux", "send-keys"]) == 3
+
+
+def test_build_tmux_commands_large_paste_adds_one_extra_enter():
+    big = "x" * (LARGE_PASTE_THRESHOLD + 1)
+    _cmds, enters_claude = build_tmux_commands("synapt:3", "claude", big, buffer_name="b")
+    _cmds2, enters_codex = build_tmux_commands("synapt:4", "codex", big, buffer_name="b")
+    assert enters_claude == 3  # 2 + 1 guarded for collapse
+    assert enters_codex == 4   # 3 + 1
+
+
+# ── delivery via injected runner ───────────────────────────────────
+
+
+def _recorder():
+    calls = []
+
+    def run(cmd, *, input=None):
+        calls.append((cmd, input))
+        return SimpleNamespace(returncode=0, stderr="")
+
+    return run, calls
+
+
+def test_deliver_via_tmux_pipes_body_and_runs_full_sequence():
+    run, calls = _recorder()
+    sleeps = []
+    result = deliver_via_tmux("synapt:3", "claude", "hello world", run=run, sleep=sleeps.append, buffer_name="b")
+    assert isinstance(result, TmuxDelivery)
+    assert result.delivered is True
+    assert result.target == "synapt:3"
+    assert result.enters == 2
+    # body is piped to load-buffer's stdin, not shell-escaped into argv
+    load = [c for c in calls if c[0][:2] == ["tmux", "load-buffer"]][0]
+    assert load[1] == "hello world"
+    # paste then the two Enters actually ran
+    assert sum(1 for c, _ in calls if c[:2] == ["tmux", "send-keys"]) == 2
+    assert sleeps  # guarded sleeps between expand/submit
+
+
+def test_deliver_via_tmux_reports_failure_gracefully():
+    def run(cmd, *, input=None):
+        if cmd[:2] == ["tmux", "paste-buffer"]:
+            return SimpleNamespace(returncode=1, stderr="can't find pane: synapt:9")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    result = deliver_via_tmux("synapt:9", "claude", "hi", run=run, sleep=lambda *_: None, buffer_name="b")
+    assert result.delivered is False
+    assert "synapt:9" in result.detail
+
+
+def test_deliver_via_tmux_survives_missing_tmux_binary():
+    def run(cmd, *, input=None):
+        raise FileNotFoundError("tmux")
+
+    result = deliver_via_tmux("synapt:3", "claude", "hi", run=run, sleep=lambda *_: None, buffer_name="b")
+    assert result.delivered is False  # no raise
+
+
+# ── speak_to_agent integration: inbox ALWAYS, tmux when pane resolves ──
+
+
+def test_speak_to_agent_send_delivers_via_tmux_and_keeps_inbox(monkeypatch):
+    monkeypatch.setattr("synapt.recall.channel._agent_id", lambda: "opus", raising=False)
+    monkeypatch.setenv("SYNAPT_AGENT_PANES", json.dumps({"apollo": {"target": "synapt:3", "runtime": "claude"}}))
+    run, calls = _recorder()
+    monkeypatch.setattr("synapt.recall.direct._run_tmux", run)
+
+    out = speak_to_agent(action="send", to="apollo", message="ping")
+
+    # durable inbox write still happened (belt + suspenders)
+    from synapt.recall.direct import read_inbox
+    assert read_inbox(agent_id="apollo")  # apollo has an unread message
+    # AND tmux delivery was attempted to apollo's pane
+    assert any(c[0][:2] == ["tmux", "paste-buffer"] and "synapt:3" in c[0] for c in calls)
+    assert "synapt:3" in out or "tmux" in out.lower()
+
+
+def test_speak_to_agent_send_inbox_only_when_no_pane(monkeypatch):
+    monkeypatch.setattr("synapt.recall.channel._agent_id", lambda: "opus", raising=False)
+    # no SYNAPT_AGENT_PANES -> empty map -> no pane resolves
+    called = []
+    monkeypatch.setattr("synapt.recall.direct._run_tmux", lambda cmd, **k: called.append(cmd))
+
+    out = speak_to_agent(action="send", to="apollo", message="ping")
+
+    from synapt.recall.direct import read_inbox
+    assert read_inbox(agent_id="apollo")  # inbox still written
+    assert called == []  # no tmux attempted
+    assert "inbox" in out.lower()


### PR DESCRIPTION
Closes #852

## Problem
`speak_to_agent` wrote a **passive inbox** the recipient had to poll. The only delivery that reliably lands is tmux `load-buffer` + `paste-buffer` + `send-keys`. Layne (2026-06-14): *"fix speak to agent mcp to use the right tmux, it's annoying me."*

## Fix
On `send`, the tool now resolves the recipient to its tmux pane and **delivers via tmux itself**, while keeping the inbox write as the durable record (belt + suspenders).

- `resolve_pane` — recipient → `PaneTarget(target, runtime)` via an operator-supplied map, normalized lookup (bare / cased / `org:agent` all resolve)
- `deliver_via_tmux` — `load-buffer` (body via **stdin**, never shell-escaped) → `paste-buffer -d` → N×`send-keys Enter`, **runtime-aware** (Claude=2, Codex=3) + **one guarded extra Enter** for collapse-large pastes (≥1200 chars). Best-effort: missing pane / no tmux / error → `delivered=False`, never raises.
- `speak_to_agent(action=send)` — inbox write (durable) **then** tmux delivery; the return reports both; inbox-only fallback when no pane is configured.

## Tests (TDD, 15 — written first, RED→GREEN)
enter-count by runtime · pane resolution (exact/normalized/missing) · command sequence (Claude 2, Codex 3, large +1) · delivery pipes body to stdin / reports failure / survives missing tmux · send integration (inbox **always** written; tmux attempted only when a pane resolves). Full direct suite (30) still green; ruff clean.

## Premium boundary
**OSS — recall messaging transport.** The tmux mechanics are pure transport. The agent→pane map is read from a **neutral operator-supplied seam** (`SYNAPT_AGENT_PANES` env / `SYNAPT_AGENT_PANES_FILE`), **not** hardcoded identity topology — OSS consumes a routing table, it does not derive or persist agent identity. **Sprint-21 identity test passes** (no `workspace.toml`/`agent.toml` parsing, no identity derivation, no premium-prefix IDs). I'd especially welcome Sentinel's boundary read on the routing-table-vs-identity line.

## To make it live (operator config, not OSS)
Set `SYNAPT_AGENT_PANES` (or point `SYNAPT_AGENT_PANES_FILE` at a JSON file) in the gripspace. Canonical synapt map (from the bubble-up-pattern table):
```json
{
  "apollo":   {"target": "synapt:3", "runtime": "claude"},
  "atlas":    {"target": "synapt:4", "runtime": "codex"},
  "sentinel": {"target": "synapt:5", "runtime": "codex"},
  "opus":     {"target": "synapt:1", "runtime": "claude"}
}
```

## Deferred (issue's optional item)
`capture-pane` idle-verify before pasting. The guarded extra Enter is the minimum guard shipped here; the idle-check is a clean follow-up if we see unsubmitted-paste cases.

## Reviewers (assigned up front)
**Opus** (coordinator / claim-boundary) + **Sentinel** (QA / premium-boundary).

Heads-up unrelated to this PR: the full `tests/recall` sweep shows 4 pre-existing failures in `test_attribution.py` (chunk `agent_id` round-trip — a different subsystem, does not import `direct.py`). Flagging, not introduced here.